### PR TITLE
Issue/5017

### DIFF
--- a/ProgrammingGuide/Kokkos-and-Virtual-Functions.md
+++ b/ProgrammingGuide/Kokkos-and-Virtual-Functions.md
@@ -109,6 +109,7 @@ Instance* deviceInstance = Kokkos::kokkos_malloc<Kokkos::CudaUVMSpace>(sizeof(In
 Kokkos::parallel_for(... {
   new((Instance*)deviceInstance) Instance(); // initialize an instance, and place the result in the pointer deviceInstance
 });
+Kokkos::fence();
 deviceInstance->setAField(someHostValue); // set some field on the host
 ```
 


### PR DESCRIPTION
This change addresses #5017 by adding `Kokkos::fence()` after the end of the `parallel_for()` bloc in the UVM example in `ProgrammingGuide/Kokkos-and-Virtual-Functions.md.`