### PR TITLE
#34: Reorganize and fix builtin reducers 

### DIFF
--- a/source/API/core/builtin_reducers.rst
+++ b/source/API/core/builtin_reducers.rst
@@ -1,19 +1,20 @@
-
 Built-in Reducers
 #################
 
 .. toctree::
    :maxdepth: 1
 
+   ./builtinreducers/ReducerConcept
    ./builtinreducers/BAnd
-   ./builtinreducers/Sum
-   ./builtinreducers/Prod
-   ./builtinreducers/MinMaxLoc
-   ./builtinreducers/MinMax
-   ./builtinreducers/MinLoc
-   ./builtinreducers/Min
-   ./builtinreducers/MaxLoc
-   ./builtinreducers/Max
-   ./builtinreducers/LOr
-   ./builtinreducers/LAnd
    ./builtinreducers/BOr
+   ./builtinreducers/LAnd
+   ./builtinreducers/LOr
+   ./builtinreducers/Max
+   ./builtinreducers/MaxLoc
+   ./builtinreducers/Min
+   ./builtinreducers/MinLoc
+   ./builtinreducers/MinMax
+   ./builtinreducers/MinMaxLoc
+   ./builtinreducers/Prod
+   ./builtinreducers/Sum
+   ./builtinreducers/ReductionScalarTypes

--- a/source/API/core/builtinreducers/BAnd.md
+++ b/source/API/core/builtinreducers/BAnd.md
@@ -1,48 +1,46 @@
 # `BAnd`
 
-Specific implementation of [ReducerConcept](Kokkos%3A%3AReducerConcept) performing bitwise `AND` operation
+Specific implementation of [ReducerConcept](ReducerConcept) performing bitwise `AND` operation
 
 Header File: `Kokkos_Core.hpp`
 
 Usage: 
-  ```c++
-  T result;
-  parallel_reduce(N,Functor,BAnd<T,S>(result));
-  ```
-
-. 
+```c++
+T result;
+parallel_reduce(N,Functor,BAnd<T,S>(result));
+```
 
 ## Synopsis 
-  ```c++
-  template<class Scalar, class Space>
-  class BAnd{
-    public:
-      typedef BAnd reducer;
-      typedef typename std::remove_cv<Scalar>::type value_type;
-      typedef Kokkos::View<value_type, Space> result_view_type;
-      
-      KOKKOS_INLINE_FUNCTION
-      void join(value_type& dest, const value_type& src)  const
+```c++
+template<class Scalar, class Space>
+class BAnd{
+ public:
+   typedef BAnd reducer;
+   typedef typename std::remove_cv<Scalar>::type value_type;
+   typedef Kokkos::View<value_type, Space> result_view_type;
+   
+   KOKKOS_INLINE_FUNCTION
+   void join(value_type& dest, const value_type& src)  const
 
-      KOKKOS_INLINE_FUNCTION
-      void join(volatile value_type& dest, const volatile value_type& src) const;
+   KOKKOS_INLINE_FUNCTION
+   void join(volatile value_type& dest, const volatile value_type& src) const;
 
-      KOKKOS_INLINE_FUNCTION
-      void init( value_type& val)  const;
+   KOKKOS_INLINE_FUNCTION
+   void init( value_type& val)  const;
 
-      KOKKOS_INLINE_FUNCTION
-      value_type& reference() const;
+   KOKKOS_INLINE_FUNCTION
+   value_type& reference() const;
 
-      KOKKOS_INLINE_FUNCTION
-      result_view_type view() const;
+   KOKKOS_INLINE_FUNCTION
+   result_view_type view() const;
 
-      KOKKOS_INLINE_FUNCTION
-      BAnd(value_type& value_);
+   KOKKOS_INLINE_FUNCTION
+   BAnd(value_type& value_);
 
-      KOKKOS_INLINE_FUNCTION
-      BAnd(const result_view_type& value_);
-  };
-  ```
+   KOKKOS_INLINE_FUNCTION
+   BAnd(const result_view_type& value_);
+};
+```
 
 ## Public Class Members
 
@@ -60,14 +58,14 @@ Usage:
    Constructs a reducer which references a local variable as its result location.  
  
  * ```c++
-   BAnd(const result_view_type result)`
+   BAnd(const result_view_type result)
    ```
    Constructs a reducer which references a specific view as its result location.
 
 ### Functions
 
  * ```c++
-   void join(value_type& dest, const value_type& src)  const;`
+   void join(value_type& dest, const value_type& src)  const;
    ```
    Store bitwise `and` of `src` and `dest` into `dest`:  `dest = src & dest;`. 
 
@@ -95,4 +93,4 @@ Usage:
    * `BAnd<T,S>::value_type` is non-const `T`
    * `BAnd<T,S>::result_view_type` is `Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>`.  Note that the S (memory space) must be the same as the space where the result resides.
    * Requires: `Scalar` has `operator =` and `operator &` defined. `Kokkos::reduction_identity<Scalar>::band()` is a valid expression. 
-   * In order to use BAnd with a custom type, a template specialization of Kokkos::reduction_identity<CustomType> must be defined.  See [Using Built-in Reducers with Custom Scalar Types](Custom-Reductions%3A-Built-In-Reducers-with-Custom-Scalar-Types) for details
+   * In order to use BAnd with a custom type, a template specialization of `Kokkos::reduction_identity<CustomType>` must be defined. See [Built-In Reducers with Custom Scalar Types](../../../ProgrammingGuide/Custom-Reductions:-Built-In-Reducers-with-Custom-Scalar-Types) for details

--- a/source/API/core/builtinreducers/BOr.md
+++ b/source/API/core/builtinreducers/BOr.md
@@ -1,48 +1,46 @@
 # `BOr`
 
-Specific implementation of [ReducerConcept](Kokkos%3A%3AReducerConcept) performing bitwise `OR` operation
+Specific implementation of [ReducerConcept](ReducerConcept) performing bitwise `OR` operation
 
 Header File: `Kokkos_Core.hpp`
 
 Usage: 
-  ```c++
-  T result;
-  parallel_reduce(N,Functor,BOr<T,S>(result));
-  ```
-
-. 
+```c++
+T result;
+parallel_reduce(N,Functor,BOr<T,S>(result));
+```
 
 ## Synopsis 
-  ```c++
-  template<class Scalar, class Space>
-  class BOr{
-    public:
-      typedef BOr reducer;
-      typedef typename std::remove_cv<Scalar>::type value_type;
-      typedef Kokkos::View<value_type, Space> result_view_type;
-      
-      KOKKOS_INLINE_FUNCTION
-      void join(value_type& dest, const value_type& src)  const
+```c++
+template<class Scalar, class Space>
+class BOr{
+ public:
+   typedef BOr reducer;
+   typedef typename std::remove_cv<Scalar>::type value_type;
+   typedef Kokkos::View<value_type, Space> result_view_type;
+   
+   KOKKOS_INLINE_FUNCTION
+   void join(value_type& dest, const value_type& src)  const
 
-      KOKKOS_INLINE_FUNCTION
-      void join(volatile value_type& dest, const volatile value_type& src) const;
+   KOKKOS_INLINE_FUNCTION
+   void join(volatile value_type& dest, const volatile value_type& src) const;
 
-      KOKKOS_INLINE_FUNCTION
-      void init( value_type& val)  const;
+   KOKKOS_INLINE_FUNCTION
+   void init( value_type& val)  const;
 
-      KOKKOS_INLINE_FUNCTION
-      value_type& reference() const;
+   KOKKOS_INLINE_FUNCTION
+   value_type& reference() const;
 
-      KOKKOS_INLINE_FUNCTION
-      result_view_type view() const;
+   KOKKOS_INLINE_FUNCTION
+   result_view_type view() const;
 
-      KOKKOS_INLINE_FUNCTION
-      BOr(value_type& value_);
+   KOKKOS_INLINE_FUNCTION
+   BOr(value_type& value_);
 
-      KOKKOS_INLINE_FUNCTION
-      BOr(const result_view_type& value_);
-  };
-  ```
+   KOKKOS_INLINE_FUNCTION
+   BOr(const result_view_type& value_);
+};
+```
 
 ## Public Class Members
 
@@ -60,14 +58,14 @@ Usage:
    Constructs a reducer which references a local variable as its result location.  
  
  * ```c++
-   BOr(const result_view_type result)`
+   BOr(const result_view_type result)
    ```
    Constructs a reducer which references a specific view as its result location.
 
 ### Functions
 
  * ```c++
-   void join(value_type& dest, const value_type& src)  const;`
+   void join(value_type& dest, const value_type& src)  const;
    ```
    Store logical `or` of `src` and `dest` into `dest`:  `dest = src | dest;`. 
 
@@ -95,4 +93,4 @@ Usage:
    * `BOr<T,S>::value_type` is non-const `T`
    * `BOr<T,S>::result_view_type` is `Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>`.  Note that the S (memory space) must be the same as the space where the result resides.
    * Requires: `Scalar` has `operator =` and `operator |` defined. `Kokkos::reduction_identity<Scalar>::bor()` is a valid expression. 
-   * In order to use BOr with a custom type, a template specialization of Kokkos::reduction_identity<CustomType> must be defined.  See [Using Built-in Reducers with Custom Scalar Types](Custom-Reductions%3A-Built-In-Reducers-with-Custom-Scalar-Types) for details
+   * In order to use BOr with a custom type, a template specialization of `Kokkos::reduction_identity<CustomType>` must be defined. See [Built-In Reducers with Custom Scalar Types](../../../ProgrammingGuide/Custom-Reductions:-Built-In-Reducers-with-Custom-Scalar-Types) for details

--- a/source/API/core/builtinreducers/LAnd.md
+++ b/source/API/core/builtinreducers/LAnd.md
@@ -1,48 +1,46 @@
 # `LAnd`
 
-Specific implementation of [ReducerConcept](Kokkos%3A%3AReducerConcept) performing logical `AND` operation
+Specific implementation of [ReducerConcept](ReducerConcept) performing logical `AND` operation
 
 Header File: `Kokkos_Core.hpp`
 
 Usage: 
-  ```c++
-  T result;
-  parallel_reduce(N,Functor,LAnd<T,S>(result));
-  ```
-
-. 
+```c++
+T result;
+parallel_reduce(N,Functor,LAnd<T,S>(result));
+```
 
 ## Synopsis 
-  ```c++
-  template<class Scalar, class Space>
-  class LAnd{
-    public:
-      typedef LAnd reducer;
-      typedef typename std::remove_cv<Scalar>::type value_type;
-      typedef Kokkos::View<value_type, Space> result_view_type;
-      
-      KOKKOS_INLINE_FUNCTION
-      void join(value_type& dest, const value_type& src)  const
+```c++
+template<class Scalar, class Space>
+class LAnd{
+ public:
+   typedef LAnd reducer;
+   typedef typename std::remove_cv<Scalar>::type value_type;
+   typedef Kokkos::View<value_type, Space> result_view_type;
+   
+   KOKKOS_INLINE_FUNCTION
+   void join(value_type& dest, const value_type& src)  const
 
-      KOKKOS_INLINE_FUNCTION
-      void join(volatile value_type& dest, const volatile value_type& src) const;
+   KOKKOS_INLINE_FUNCTION
+   void join(volatile value_type& dest, const volatile value_type& src) const;
 
-      KOKKOS_INLINE_FUNCTION
-      void init( value_type& val)  const;
+   KOKKOS_INLINE_FUNCTION
+   void init( value_type& val)  const;
 
-      KOKKOS_INLINE_FUNCTION
-      value_type& reference() const;
+   KOKKOS_INLINE_FUNCTION
+   value_type& reference() const;
 
-      KOKKOS_INLINE_FUNCTION
-      result_view_type view() const;
+   KOKKOS_INLINE_FUNCTION
+   result_view_type view() const;
 
-      KOKKOS_INLINE_FUNCTION
-      LAnd(value_type& value_);
+   KOKKOS_INLINE_FUNCTION
+   LAnd(value_type& value_);
 
-      KOKKOS_INLINE_FUNCTION
-      LAnd(const result_view_type& value_);
-  };
-  ```
+   KOKKOS_INLINE_FUNCTION
+   LAnd(const result_view_type& value_);
+};
+```
 
 ## Public Class Members
 
@@ -60,14 +58,14 @@ Usage:
    Constructs a reducer which references a local variable as its result location.  
  
  * ```c++
-   LAnd(const result_view_type result)`
+   LAnd(const result_view_type result)
    ```
    Constructs a reducer which references a specific view as its result location.
 
 ### Functions
 
  * ```c++
-   void join(value_type& dest, const value_type& src)  const;`
+   void join(value_type& dest, const value_type& src)  const;
    ```
    Store logical `and` of `src` and `dest` into `dest`:  `dest = src && dest;`. 
 
@@ -95,4 +93,4 @@ Usage:
    * `LAnd<T,S>::value_type` is non-const `T`
    * `LAnd<T,S>::result_view_type` is `Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>`.  Note that the S (memory space) must be the same as the space where the result resides.
    * Requires: `Scalar` has `operator =` and `operator &&` defined. `Kokkos::reduction_identity<Scalar>::land()` is a valid expression. 
-   * In order to use LAnd with a custom type, a template specialization of Kokkos::reduction_identity<CustomType> must be defined.  See [Using Built-in Reducers with Custom Scalar Types](Custom-Reductions%3A-Built-In-Reducers-with-Custom-Scalar-Types) for details
+   * In order to use LAnd with a custom type, a template specialization of `Kokkos::reduction_identity<CustomType>` must be defined.  See [Built-In Reducers with Custom Scalar Types](../../../ProgrammingGuide/Custom-Reductions:-Built-In-Reducers-with-Custom-Scalar-Types) for details

--- a/source/API/core/builtinreducers/LOr.md
+++ b/source/API/core/builtinreducers/LOr.md
@@ -1,48 +1,46 @@
 # `LOr`
 
-Specific implementation of [ReducerConcept](Kokkos%3A%3AReducerConcept) performing logical `OR` operation
+Specific implementation of [ReducerConcept](ReducerConcept) performing logical `OR` operation
 
 Header File: `Kokkos_Core.hpp`
 
 Usage: 
-  ```c++
-  T result;
-  parallel_reduce(N,Functor,LOr<T,S>(result));
-  ```
-
-. 
+```c++
+T result;
+parallel_reduce(N,Functor,LOr<T,S>(result));
+```
 
 ## Synopsis 
-  ```c++
-  template<class Scalar, class Space>
-  class LOr{
-    public:
-      typedef LOr reducer;
-      typedef typename std::remove_cv<Scalar>::type value_type;
-      typedef Kokkos::View<value_type, Space> result_view_type;
-      
-      KOKKOS_INLINE_FUNCTION
-      void join(value_type& dest, const value_type& src)  const
+```c++
+template<class Scalar, class Space>
+class LOr{
+ public:
+   typedef LOr reducer;
+   typedef typename std::remove_cv<Scalar>::type value_type;
+   typedef Kokkos::View<value_type, Space> result_view_type;
+   
+   KOKKOS_INLINE_FUNCTION
+   void join(value_type& dest, const value_type& src)  const
 
-      KOKKOS_INLINE_FUNCTION
-      void join(volatile value_type& dest, const volatile value_type& src) const;
+   KOKKOS_INLINE_FUNCTION
+   void join(volatile value_type& dest, const volatile value_type& src) const;
 
-      KOKKOS_INLINE_FUNCTION
-      void init( value_type& val)  const;
+   KOKKOS_INLINE_FUNCTION
+   void init( value_type& val)  const;
 
-      KOKKOS_INLINE_FUNCTION
-      value_type& reference() const;
+   KOKKOS_INLINE_FUNCTION
+   value_type& reference() const;
 
-      KOKKOS_INLINE_FUNCTION
-      result_view_type view() const;
+   KOKKOS_INLINE_FUNCTION
+   result_view_type view() const;
 
-      KOKKOS_INLINE_FUNCTION
-      LOr(value_type& value_);
+   KOKKOS_INLINE_FUNCTION
+   LOr(value_type& value_);
 
-      KOKKOS_INLINE_FUNCTION
-      LOr(const result_view_type& value_);
-  };
-  ```
+   KOKKOS_INLINE_FUNCTION
+   LOr(const result_view_type& value_);
+};
+```
 
 ## Public Class Members
 
@@ -60,14 +58,14 @@ Usage:
    Constructs a reducer which references a local variable as its result location.  
  
  * ```c++
-   LOr(const result_view_type result)`
+   LOr(const result_view_type result)
    ```
    Constructs a reducer which references a specific view as its result location.
 
 ### Functions
 
  * ```c++
-   void join(value_type& dest, const value_type& src)  const;`
+   void join(value_type& dest, const value_type& src)  const;
    ```
    Store logical `or` of `src` and `dest` into `dest`:  `dest = src || dest;`. 
 
@@ -95,4 +93,4 @@ Usage:
    * `LOr<T,S>::value_type` is non-const `T`
    * `LOr<T,S>::result_view_type` is `Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>`.  Note that the S (memory space) must be the same as the space where the result resides.
    * Requires: `Scalar` has `operator =` and `operator ||` defined. `Kokkos::reduction_identity<Scalar>::lor()` is a valid expression. 
-   * In order to use LOr with a custom type, a template specialization of Kokkos::reduction_identity<CustomType> must be defined.  See [Using Built-in Reducers with Custom Scalar Types](Custom-Reductions%3A-Built-In-Reducers-with-Custom-Scalar-Types) for details
+   * In order to use LOr with a custom type, a template specialization of `Kokkos::reduction_identity<CustomType>` must be defined.  See [Built-In Reducers with Custom Scalar Types](../../../ProgrammingGuide/Custom-Reductions:-Built-In-Reducers-with-Custom-Scalar-Types) for details

--- a/source/API/core/builtinreducers/Max.md
+++ b/source/API/core/builtinreducers/Max.md
@@ -1,48 +1,46 @@
 # `Max`
 
-Specific implementation of [ReducerConcept](Kokkos%3A%3AReducerConcept) storing the maximum value
+Specific implementation of [ReducerConcept](ReducerConcept) storing the maximum value
 
 Header File: `Kokkos_Core.hpp`
 
 Usage: 
-  ```c++
-  T result;
-  parallel_reduce(N,Functor,Max<T,S>(result));
-  ```
-
-. 
+```c++
+T result;
+parallel_reduce(N,Functor,Max<T,S>(result));
+```
 
 ## Synopsis 
-  ```c++
-  template<class Scalar, class Space>
-  class Max{
-    public:
-      typedef Max reducer;
-      typedef typename std::remove_cv<Scalar>::type value_type;
-      typedef Kokkos::View<value_type, Space> result_view_type;
-      
-      KOKKOS_INLINE_FUNCTION
-      void join(value_type& dest, const value_type& src)  const
+```c++
+template<class Scalar, class Space>
+class Max{
+ public:
+   typedef Max reducer;
+   typedef typename std::remove_cv<Scalar>::type value_type;
+   typedef Kokkos::View<value_type, Space> result_view_type;
+   
+   KOKKOS_INLINE_FUNCTION
+   void join(value_type& dest, const value_type& src)  const
 
-      KOKKOS_INLINE_FUNCTION
-      void join(volatile value_type& dest, const volatile value_type& src) const;
+   KOKKOS_INLINE_FUNCTION
+   void join(volatile value_type& dest, const volatile value_type& src) const;
 
-      KOKKOS_INLINE_FUNCTION
-      void init( value_type& val)  const;
+   KOKKOS_INLINE_FUNCTION
+   void init( value_type& val)  const;
 
-      KOKKOS_INLINE_FUNCTION
-      value_type& reference() const;
+   KOKKOS_INLINE_FUNCTION
+   value_type& reference() const;
 
-      KOKKOS_INLINE_FUNCTION
-      result_view_type view() const;
+   KOKKOS_INLINE_FUNCTION
+   result_view_type view() const;
 
-      KOKKOS_INLINE_FUNCTION
-      Max(value_type& value_);
+   KOKKOS_INLINE_FUNCTION
+   Max(value_type& value_);
 
-      KOKKOS_INLINE_FUNCTION
-      Max(const result_view_type& value_);
-  };
-  ```
+   KOKKOS_INLINE_FUNCTION
+   Max(const result_view_type& value_);
+};
+```
 
 ## Public Class Members
 
@@ -60,14 +58,14 @@ Usage:
    Constructs a reducer which references a local variable as its result location.  
  
  * ```c++
-   Max(const result_view_type result)`
+   Max(const result_view_type result)
    ```
    Constructs a reducer which references a specific view as its result location.
 
 ### Functions
 
  * ```c++
-   void join(value_type& dest, const value_type& src)  const;`
+   void join(value_type& dest, const value_type& src)  const;
    ```
    Store maximum of `src` and `dest` into `dest`:  `dest = (src > dest) ? src : dest;`. 
 
@@ -95,4 +93,4 @@ Usage:
    * `Max<T,S>::value_type` is non-const `T`
    * `Max<T,S>::result_view_type` is `Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>`.  Note that the S (memory space) must be the same as the space where the result resides.
    * Requires: `Scalar` has `operator =` and `operator >` defined. `Kokkos::reduction_identity<Scalar>::max()` is a valid expression. 
-   * In order to use Max with a custom type, a template specialization of Kokkos::reduction_identity<CustomType> must be defined.  See [Using Built-in Reducers with Custom Scalar Types](Custom-Reductions%3A-Built-In-Reducers-with-Custom-Scalar-Types) for details
+   * In order to use Max with a custom type, a template specialization of `Kokkos::reduction_identity<CustomType>` must be defined.  See [Built-In Reducers with Custom Scalar Types](../../../ProgrammingGuide/Custom-Reductions:-Built-In-Reducers-with-Custom-Scalar-Types) for details

--- a/source/API/core/builtinreducers/MaxLoc.md
+++ b/source/API/core/builtinreducers/MaxLoc.md
@@ -1,49 +1,47 @@
 # `MaxLoc`
 
-Specific implementation of [ReducerConcept](Kokkos%3A%3AReducerConcept) storing the maximum value
+Specific implementation of [ReducerConcept](ReducerConcept) storing the maximum value
 
 Header File: `Kokkos_Core.hpp`
 
 Usage: 
-  ```c++
-  MaxLoc<T,I,S>::value_type result;
-  parallel_reduce(N,Functor,MaxLoc<T,I,S>(result));
-  ```
-
-. 
+```c++
+MaxLoc<T,I,S>::value_type result;
+parallel_reduce(N,Functor,MaxLoc<T,I,S>(result));
+```
 
 ## Synopsis 
-  ```c++
-  template<class Scalar, class Index, class Space>
-  class MaxLoc{
-    public:
-      typedef MaxLoc reducer;
-      typedef ValLocScalar<typename std::remove_cv<Scalar>::type,
-                           typename std::remove_cv<Index>::type > value_type;
-      typedef Kokkos::View<value_type, Space> result_view_type;
-      
-      KOKKOS_INLINE_FUNCTION
-      void join(value_type& dest, const value_type& src)  const
+```c++
+template<class Scalar, class Index, class Space>
+class MaxLoc{
+ public:
+   typedef MaxLoc reducer;
+   typedef ValLocScalar<typename std::remove_cv<Scalar>::type,
+                        typename std::remove_cv<Index>::type > value_type;
+   typedef Kokkos::View<value_type, Space> result_view_type;
+   
+   KOKKOS_INLINE_FUNCTION
+   void join(value_type& dest, const value_type& src)  const
 
-      KOKKOS_INLINE_FUNCTION
-      void join(volatile value_type& dest, const volatile value_type& src) const;
+   KOKKOS_INLINE_FUNCTION
+   void join(volatile value_type& dest, const volatile value_type& src) const;
 
-      KOKKOS_INLINE_FUNCTION
-      void init( value_type& val)  const;
+   KOKKOS_INLINE_FUNCTION
+   void init( value_type& val)  const;
 
-      KOKKOS_INLINE_FUNCTION
-      value_type& reference() const;
+   KOKKOS_INLINE_FUNCTION
+   value_type& reference() const;
 
-      KOKKOS_INLINE_FUNCTION
-      result_view_type view() const;
+   KOKKOS_INLINE_FUNCTION
+   result_view_type view() const;
 
-      KOKKOS_INLINE_FUNCTION
-      MaxLoc(value_type& value_);
+   KOKKOS_INLINE_FUNCTION
+   MaxLoc(value_type& value_);
 
-      KOKKOS_INLINE_FUNCTION
-      MaxLoc(const result_view_type& value_);
-  };
-  ```
+   KOKKOS_INLINE_FUNCTION
+   MaxLoc(const result_view_type& value_);
+};
+```
 
 ## Public Class Members
 
@@ -61,14 +59,14 @@ Usage:
    Constructs a reducer which references a local variable as its result location.  
  
  * ```c++
-   MaxLoc(const result_view_type result)`
+   MaxLoc(const result_view_type result)
    ```
    Constructs a reducer which references a specific view as its result location.
 
 ### Functions
 
  * ```c++
-   void join(value_type& dest, const value_type& src)  const;`
+   void join(value_type& dest, const value_type& src)  const;
    ```
    Store maximum with index of `src` and `dest` into `dest`:  `dest = (src.val > dest.val) ? src : dest;`. 
 
@@ -99,4 +97,4 @@ Usage:
    * `MaxLoc<T,I,S>::result_view_type` is `Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>`.  Note that the S (memory space) must be the same as the space where the result resides.
    * Requires: `Scalar` has `operator =` and `operator >` defined. `Kokkos::reduction_identity<Scalar>::max()` is a valid expression. 
    * Requires: `Index` has `operator =` defined. `Kokkos::reduction_identity<Index>::min()` is a valid expression. 
-   * In order to use MaxLoc with a custom type of either `Scalar` or `Index`, a template specialization of Kokkos::reduction_identity<CustomType> must be defined.  See [Using Built-in Reducers with Custom Scalar Types](Custom-Reductions%3A-Built-In-Reducers-with-Custom-Scalar-Types) for details
+   * In order to use MaxLoc with a custom type of either `Scalar` or `Index`, a template specialization of `Kokkos::reduction_identity<CustomType>` must be defined.  See [Built-In Reducers with Custom Scalar Types](../../../ProgrammingGuide/Custom-Reductions:-Built-In-Reducers-with-Custom-Scalar-Types) for details

--- a/source/API/core/builtinreducers/Min.md
+++ b/source/API/core/builtinreducers/Min.md
@@ -1,48 +1,46 @@
 # `Min`
 
-Specific implementation of [ReducerConcept](Kokkos%3A%3AReducerConcept) storing the minimum value
+Specific implementation of [ReducerConcept](ReducerConcept) storing the minimum value
 
 Header File: `Kokkos_Core.hpp`
 
 Usage: 
-  ```c++
-  T result;
-  parallel_reduce(N,Functor,Min<T,S>(result));
-  ```
-
-. 
+```c++
+T result;
+parallel_reduce(N,Functor,Min<T,S>(result));
+```
 
 ## Synopsis 
-  ```c++
-  template<class Scalar, class Space>
-  class Min{
-    public:
-      typedef Min reducer;
-      typedef typename std::remove_cv<Scalar>::type value_type;
-      typedef Kokkos::View<value_type, Space> result_view_type;
-      
-      KOKKOS_INLINE_FUNCTION
-      void join(value_type& dest, const value_type& src)  const
+```c++
+template<class Scalar, class Space>
+class Min{
+ public:
+   typedef Min reducer;
+   typedef typename std::remove_cv<Scalar>::type value_type;
+   typedef Kokkos::View<value_type, Space> result_view_type;
+   
+   KOKKOS_INLINE_FUNCTION
+   void join(value_type& dest, const value_type& src)  const
 
-      KOKKOS_INLINE_FUNCTION
-      void join(volatile value_type& dest, const volatile value_type& src) const;
+   KOKKOS_INLINE_FUNCTION
+   void join(volatile value_type& dest, const volatile value_type& src) const;
 
-      KOKKOS_INLINE_FUNCTION
-      void init( value_type& val)  const;
+   KOKKOS_INLINE_FUNCTION
+   void init( value_type& val)  const;
 
-      KOKKOS_INLINE_FUNCTION
-      value_type& reference() const;
+   KOKKOS_INLINE_FUNCTION
+   value_type& reference() const;
 
-      KOKKOS_INLINE_FUNCTION
-      result_view_type view() const;
+   KOKKOS_INLINE_FUNCTION
+   result_view_type view() const;
 
-      KOKKOS_INLINE_FUNCTION
-      Min(value_type& value_);
+   KOKKOS_INLINE_FUNCTION
+   Min(value_type& value_);
 
-      KOKKOS_INLINE_FUNCTION
-      Min(const result_view_type& value_);
-  };
-  ```
+   KOKKOS_INLINE_FUNCTION
+   Min(const result_view_type& value_);
+};
+```
 
 ## Public Class Members
 
@@ -60,14 +58,14 @@ Usage:
    Constructs a reducer which references a local variable as its result location.  
  
  * ```c++
-   Min(const result_view_type result)`
+   Min(const result_view_type result)
    ```
    Constructs a reducer which references a specific view as its result location.
 
 ### Functions
 
  * ```c++
-   void join(value_type& dest, const value_type& src)  const;`
+   void join(value_type& dest, const value_type& src)  const;
    ```
    Store minimum of `src` and `dest` into `dest`:  `dest = (src < dest) ? src : dest;`. 
 
@@ -95,4 +93,4 @@ Usage:
    * `Min<T,S>::value_type` is non-const `T`
    * `Min<T,S>::result_view_type` is `Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>`.  Note that the S (memory space) must be the same as the space where the result resides.
    * Requires: `Scalar` has `operator =` and `operator <` defined. `Kokkos::reduction_identity<Scalar>::min()` is a valid expression. 
-   * In order to use Min with a custom type, a template specialization of Kokkos::reduction_identity<CustomType> must be defined.  See [Using Built-in Reducers with Custom Scalar Types](Custom-Reductions%3A-Built-In-Reducers-with-Custom-Scalar-Types) for details
+   * In order to use Min with a custom type, a template specialization of `Kokkos::reduction_identity<CustomType>` must be defined.  See [Built-In Reducers with Custom Scalar Types](../../../ProgrammingGuide/Custom-Reductions:-Built-In-Reducers-with-Custom-Scalar-Types) for details

--- a/source/API/core/builtinreducers/MinLoc.md
+++ b/source/API/core/builtinreducers/MinLoc.md
@@ -1,49 +1,47 @@
 # `MinLoc`
 
-Specific implementation of [ReducerConcept](Kokkos%3A%3AReducerConcept) storing the minimum value with an index
+Specific implementation of [ReducerConcept](ReducerConcept) storing the minimum value with an index
 
 Header File: `Kokkos_Core.hpp`
 
 Usage: 
-  ```c++
-  MinLoc<T,I,S>::value_type result;
-  parallel_reduce(N,Functor,MinLoc<T,I,S>(result));
-  ```
-
-. 
+```c++
+MinLoc<T,I,S>::value_type result;
+parallel_reduce(N,Functor,MinLoc<T,I,S>(result));
+```
 
 ## Synopsis 
-  ```c++
-  template<class Scalar, class Index, class Space>
-  class MinLoc{
-    public:
-      typedef MinLoc reducer;
-      typedef ValLocScalar<typename std::remove_cv<Scalar>::type,
-                           typename std::remove_cv<Index>::type > value_type;
-      typedef Kokkos::View<value_type, Space> result_view_type;
-      
-      KOKKOS_INLINE_FUNCTION
-      void join(value_type& dest, const value_type& src)  const
+```c++
+template<class Scalar, class Index, class Space>
+class MinLoc{
+ public:
+   typedef MinLoc reducer;
+   typedef ValLocScalar<typename std::remove_cv<Scalar>::type,
+                        typename std::remove_cv<Index>::type > value_type;
+   typedef Kokkos::View<value_type, Space> result_view_type;
+   
+   KOKKOS_INLINE_FUNCTION
+   void join(value_type& dest, const value_type& src)  const
 
-      KOKKOS_INLINE_FUNCTION
-      void join(volatile value_type& dest, const volatile value_type& src) const;
+   KOKKOS_INLINE_FUNCTION
+   void join(volatile value_type& dest, const volatile value_type& src) const;
 
-      KOKKOS_INLINE_FUNCTION
-      void init( value_type& val)  const;
+   KOKKOS_INLINE_FUNCTION
+   void init( value_type& val)  const;
 
-      KOKKOS_INLINE_FUNCTION
-      value_type& reference() const;
+   KOKKOS_INLINE_FUNCTION
+   value_type& reference() const;
 
-      KOKKOS_INLINE_FUNCTION
-      result_view_type view() const;
+   KOKKOS_INLINE_FUNCTION
+   result_view_type view() const;
 
-      KOKKOS_INLINE_FUNCTION
-      MinLoc(value_type& value_);
+   KOKKOS_INLINE_FUNCTION
+   MinLoc(value_type& value_);
 
-      KOKKOS_INLINE_FUNCTION
-      MinLoc(const result_view_type& value_);
-  };
-  ```
+   KOKKOS_INLINE_FUNCTION
+   MinLoc(const result_view_type& value_);
+};
+```
 
 ## Public Class Members
 
@@ -61,14 +59,14 @@ Usage:
    Constructs a reducer which references a local variable as its result location.  
  
  * ```c++
-   MinLoc(const result_view_type result)`
+   MinLoc(const result_view_type result)
    ```
    Constructs a reducer which references a specific view as its result location.
 
 ### Functions
 
  * ```c++
-   void join(value_type& dest, const value_type& src)  const;`
+   void join(value_type& dest, const value_type& src)  const;
    ```
    Store minimum with index of `src` and `dest` into `dest`:  `dest = (src.val < dest.val) ? src : dest;`. 
 
@@ -99,4 +97,4 @@ Usage:
    * `MinLoc<T,I,S>::result_view_type` is `Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>`.  Note that the S (memory space) must be the same as the space where the result resides.
    * Requires: `Scalar` has `operator =` and `operator <` defined. `Kokkos::reduction_identity<Scalar>::min()` is a valid expression. 
    * Requires: `Index` has `operator =` defined. `Kokkos::reduction_identity<Index>::min()` is a valid expression. 
-   * In order to use MinLoc with a custom type of either `Scalar` or `Index`, a template specialization of Kokkos::reduction_identity<CustomType> must be defined.  See [Using Built-in Reducers with Custom Scalar Types](Custom-Reductions%3A-Built-In-Reducers-with-Custom-Scalar-Types) for details
+   * In order to use MinLoc with a custom type of either `Scalar` or `Index`, a template specialization of `Kokkos::reduction_identity<CustomType>` must be defined.  See [Built-In Reducers with Custom Scalar Types](../../../ProgrammingGuide/Custom-Reductions:-Built-In-Reducers-with-Custom-Scalar-Types) for details

--- a/source/API/core/builtinreducers/MinMax.md
+++ b/source/API/core/builtinreducers/MinMax.md
@@ -1,48 +1,46 @@
 # `MinMax`
 
-Specific implementation of [ReducerConcept](Kokkos%3A%3AReducerConcept) storing both the minimum and maximum values
+Specific implementation of [ReducerConcept](ReducerConcept) storing both the minimum and maximum values
 
 Header File: `Kokkos_Core.hpp`
 
 Usage: 
-  ```c++
-  MinMax<T,S>::value_type result;
-  parallel_reduce(N,Functor,MinMax<T,S>(result));
-  ```
-
-. 
+```c++
+MinMax<T,S>::value_type result;
+parallel_reduce(N,Functor,MinMax<T,S>(result));
+```
 
 ## Synopsis 
-  ```c++
-  template<class Scalar, class Space>
-  class MinMax{
-    public:
-      typedef MinMax reducer;
-      typedef MinMaxScalar<typename std::remove_cv<Scalar>::type> value_type;
-      typedef Kokkos::View<value_type, Space> result_view_type;
-      
-      KOKKOS_INLINE_FUNCTION
-      void join(value_type& dest, const value_type& src)  const
+```c++
+template<class Scalar, class Space>
+class MinMax{
+ public:
+   typedef MinMax reducer;
+   typedef MinMaxScalar<typename std::remove_cv<Scalar>::type> value_type;
+   typedef Kokkos::View<value_type, Space> result_view_type;
+   
+   KOKKOS_INLINE_FUNCTION
+   void join(value_type& dest, const value_type& src)  const
 
-      KOKKOS_INLINE_FUNCTION
-      void join(volatile value_type& dest, const volatile value_type& src) const;
+   KOKKOS_INLINE_FUNCTION
+   void join(volatile value_type& dest, const volatile value_type& src) const;
 
-      KOKKOS_INLINE_FUNCTION
-      void init( value_type& val)  const;
+   KOKKOS_INLINE_FUNCTION
+   void init( value_type& val)  const;
 
-      KOKKOS_INLINE_FUNCTION
-      value_type& reference() const;
+   KOKKOS_INLINE_FUNCTION
+   value_type& reference() const;
 
-      KOKKOS_INLINE_FUNCTION
-      result_view_type view() const;
+   KOKKOS_INLINE_FUNCTION
+   result_view_type view() const;
 
-      KOKKOS_INLINE_FUNCTION
-      MinMax(value_type& value_);
+   KOKKOS_INLINE_FUNCTION
+   MinMax(value_type& value_);
 
-      KOKKOS_INLINE_FUNCTION
-      MinMax(const result_view_type& value_);
-  };
-  ```
+   KOKKOS_INLINE_FUNCTION
+   MinMax(const result_view_type& value_);
+};
+```
 
 ## Public Class Members
 
@@ -98,4 +96,4 @@ Usage:
    * `MinMax<T,S>::value_type` is Specialization of MinMaxScalar on non-const `T`
    * `MinMax<T,S>::result_view_type` is `Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>`.  Note that the S (memory space) must be the same as the space where the result resides.
    * Requires: `Scalar` has `operator =`, `operator <` and `operator >` defined. `Kokkos::reduction_identity<Scalar>::min()` and `Kokkos::reduction_identity<Scalar>::max()` are a valid expressions. 
-   * In order to use MinMax with a custom type of `Scalar`, a template specialization of Kokkos::reduction_identity<CustomType> must be defined.  See [Using Built-in Reducers with Custom Scalar Types](Custom-Reductions%3A-Built-In-Reducers-with-Custom-Scalar-Types) for details
+   * In order to use MinMax with a custom type of `Scalar`, a template specialization of `Kokkos::reduction_identity<CustomType>` must be defined.  See [Built-In Reducers with Custom Scalar Types](../../../ProgrammingGuide/Custom-Reductions:-Built-In-Reducers-with-Custom-Scalar-Types) for details

--- a/source/API/core/builtinreducers/MinMaxLoc.md
+++ b/source/API/core/builtinreducers/MinMaxLoc.md
@@ -1,49 +1,47 @@
 # `MinMaxLoc`
 
-Specific implementation of [ReducerConcept](Kokkos%3A%3AReducerConcept) storing both the minimum and maximum values with corresponding indicies
+Specific implementation of [ReducerConcept](ReducerConcept) storing both the minimum and maximum values with corresponding indicies
 
 Header File: `Kokkos_Core.hpp`
 
 Usage: 
-  ```c++
-  MinMaxLoc<T,I,S>::value_type result;
-  parallel_reduce(N,Functor,MinMaxLoc<T,I,S>(result));
-  ```
-
-. 
+```c++
+MinMaxLoc<T,I,S>::value_type result;
+parallel_reduce(N,Functor,MinMaxLoc<T,I,S>(result));
+```
 
 ## Synopsis 
-  ```c++
-  template<class Scalar, class Space>
-  class MinMaxLoc{
-    public:
-      typedef MinMaxLoc reducer;
-      typedef MinMaxLocScalar<typename std::remove_cv<Scalar>::type,
-                              typename std::remove_cv<Index>::type> value_type;
-      typedef Kokkos::View<value_type, Space> result_view_type;
-      
-      KOKKOS_INLINE_FUNCTION
-      void join(value_type& dest, const value_type& src)  const
+```c++
+template<class Scalar, class Space>
+class MinMaxLoc{
+ public:
+   typedef MinMaxLoc reducer;
+   typedef MinMaxLocScalar<typename std::remove_cv<Scalar>::type,
+                           typename std::remove_cv<Index>::type> value_type;
+   typedef Kokkos::View<value_type, Space> result_view_type;
+   
+   KOKKOS_INLINE_FUNCTION
+   void join(value_type& dest, const value_type& src)  const
 
-      KOKKOS_INLINE_FUNCTION
-      void join(volatile value_type& dest, const volatile value_type& src) const;
+   KOKKOS_INLINE_FUNCTION
+   void join(volatile value_type& dest, const volatile value_type& src) const;
 
-      KOKKOS_INLINE_FUNCTION
-      void init( value_type& val)  const;
+   KOKKOS_INLINE_FUNCTION
+   void init( value_type& val)  const;
 
-      KOKKOS_INLINE_FUNCTION
-      value_type& reference() const;
+   KOKKOS_INLINE_FUNCTION
+   value_type& reference() const;
 
-      KOKKOS_INLINE_FUNCTION
-      result_view_type view() const;
+   KOKKOS_INLINE_FUNCTION
+   result_view_type view() const;
 
-      KOKKOS_INLINE_FUNCTION
-      MinMaxLoc(value_type& value_);
+   KOKKOS_INLINE_FUNCTION
+   MinMaxLoc(value_type& value_);
 
-      KOKKOS_INLINE_FUNCTION
-      MinMaxLoc(const result_view_type& value_);
-  };
-  ```
+   KOKKOS_INLINE_FUNCTION
+   MinMaxLoc(const result_view_type& value_);
+};
+```
 
 ## Public Class Members
 
@@ -104,4 +102,4 @@ Usage:
    * `MinMaxLoc<T,I,S>::result_view_type` is `Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>`.  Note that the S (memory space) must be the same as the space where the result resides.
    * Requires: `Scalar` has `operator =`, `operator <` and `operator >` defined. `Kokkos::reduction_identity<Scalar>::min()` and `Kokkos::reduction_identity<Scalar>::max()` are a valid expressions. 
    * Requires: `Index` has `operator =` defined. `Kokkos::reduction_identity<Scalar>::min()` is a valid expressions.
-  * In order to use MinMaxLoc with a custom type of either `Scalar` or `Index`, a template specialization of Kokkos::reduction_identity<CustomType> must be defined.  See [Using Built-in Reducers with Custom Scalar Types](Custom-Reductions%3A-Built-In-Reducers-with-Custom-Scalar-Types) for details
+   * In order to use MinMaxLoc with a custom type of either `Scalar` or `Index`, a template specialization of `Kokkos::reduction_identity<CustomType>` must be defined.  See [Built-In Reducers with Custom Scalar Types](../../../ProgrammingGuide/Custom-Reductions:-Built-In-Reducers-with-Custom-Scalar-Types) for details

--- a/source/API/core/builtinreducers/Prod.md
+++ b/source/API/core/builtinreducers/Prod.md
@@ -1,48 +1,46 @@
 # `Prod`
 
-Specific implementation of [ReducerConcept](Kokkos%3A%3AReducerConcept) performing a `multiply` operation
+Specific implementation of [ReducerConcept](ReducerConcept) performing a `multiply` operation
 
 Header File: `Kokkos_Core.hpp`
 
 Usage: 
-  ```c++
-  T result;
-  parallel_reduce(N,Functor,Prod<T,S>(result));
-  ```
-
-. 
+```c++
+T result;
+parallel_reduce(N,Functor,Prod<T,S>(result));
+```
 
 ## Synopsis 
-  ```c++
-  template<class Scalar, class Space>
-  class Prod{
-    public:
-      typedef Prod reducer;
-      typedef typename std::remove_cv<Scalar>::type value_type;
-      typedef Kokkos::View<value_type, Space> result_view_type;
-      
-      KOKKOS_INLINE_FUNCTION
-      void join(value_type& dest, const value_type& src)  const
+```c++
+template<class Scalar, class Space>
+class Prod{
+ public:
+   typedef Prod reducer;
+   typedef typename std::remove_cv<Scalar>::type value_type;
+   typedef Kokkos::View<value_type, Space> result_view_type;
+   
+   KOKKOS_INLINE_FUNCTION
+   void join(value_type& dest, const value_type& src)  const
 
-      KOKKOS_INLINE_FUNCTION
-      void join(volatile value_type& dest, const volatile value_type& src) const;
+   KOKKOS_INLINE_FUNCTION
+   void join(volatile value_type& dest, const volatile value_type& src) const;
 
-      KOKKOS_INLINE_FUNCTION
-      void init( value_type& val)  const;
+   KOKKOS_INLINE_FUNCTION
+   void init( value_type& val)  const;
 
-      KOKKOS_INLINE_FUNCTION
-      value_type& reference() const;
+   KOKKOS_INLINE_FUNCTION
+   value_type& reference() const;
 
-      KOKKOS_INLINE_FUNCTION
-      result_view_type view() const;
+   KOKKOS_INLINE_FUNCTION
+   result_view_type view() const;
 
-      KOKKOS_INLINE_FUNCTION
-      Prod(value_type& value_);
+   KOKKOS_INLINE_FUNCTION
+   Prod(value_type& value_);
 
-      KOKKOS_INLINE_FUNCTION
-      Prod(const result_view_type& value_);
-  };
-  ```
+   KOKKOS_INLINE_FUNCTION
+   Prod(const result_view_type& value_);
+};
+```
 
 ## Public Class Members
 
@@ -60,14 +58,14 @@ Usage:
    Constructs a reducer which references a local variable as its result location.  
  
  * ```c++
-   Prod(const result_view_type result)`
+   Prod(const result_view_type result)
    ```
    Constructs a reducer which references a specific view as its result location.
 
 ### Functions
 
  * ```c++
-   void join(value_type& dest, const value_type& src)  const;`
+   void join(value_type& dest, const value_type& src)  const;
    ```
    Multiply `src` and `dest` and store in `dest`:  `dest*=src;`. 
 
@@ -95,4 +93,4 @@ Usage:
    * `Prod<T,S>::value_type` is non-const `T`
    * `Prod<T,S>::result_view_type` is `Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>`.  Note that the S (memory space) must be the same as the space where the result resides.
    * Requires: `Scalar` has `operator =` and `operator *=` defined. `Kokkos::reduction_identity<Scalar>::prod()` is a valid expression. 
-   * In order to use Prod with a custom type, a template specialization of Kokkos::reduction_identity<CustomType> must be defined.  See [Using Built-in Reducers with Custom Scalar Types](Custom-Reductions%3A-Built-In-Reducers-with-Custom-Scalar-Types) for details
+   * In order to use Prod with a custom type, a template specialization of `Kokkos::reduction_identity<CustomType>` must be defined.  See [Built-In Reducers with Custom Scalar Types](../../../ProgrammingGuide/Custom-Reductions:-Built-In-Reducers-with-Custom-Scalar-Types) for details

--- a/source/API/core/builtinreducers/Sum.md
+++ b/source/API/core/builtinreducers/Sum.md
@@ -1,48 +1,46 @@
 # `Sum`
 
-Specific implementation of [ReducerConcept](Kokkos%3A%3AReducerConcept) performing an `add` operation
+Specific implementation of [ReducerConcept](ReducerConcept) performing an `add` operation
 
 Header File: `Kokkos_Core.hpp`
 
 Usage: 
-  ```c++
-  T result;
-  parallel_reduce(N,Functor,Sum<T,S>(result));
-  ```
-
-. 
+```c++
+T result;
+parallel_reduce(N,Functor,Sum<T,S>(result));
+```
 
 ## Synopsis 
-  ```c++
-  template<class Scalar, class Space>
-  class Sum{
-    public:
-      typedef Sum reducer;
-      typedef typename std::remove_cv<Scalar>::type value_type;
-      typedef Kokkos::View<value_type, Space> result_view_type;
-      
-      KOKKOS_INLINE_FUNCTION
-      void join(value_type& dest, const value_type& src)  const
+```c++
+template<class Scalar, class Space>
+class Sum{
+ public:
+   typedef Sum reducer;
+   typedef typename std::remove_cv<Scalar>::type value_type;
+   typedef Kokkos::View<value_type, Space> result_view_type;
+   
+   KOKKOS_INLINE_FUNCTION
+   void join(value_type& dest, const value_type& src)  const
 
-      KOKKOS_INLINE_FUNCTION
-      void join(volatile value_type& dest, const volatile value_type& src) const;
+   KOKKOS_INLINE_FUNCTION
+   void join(volatile value_type& dest, const volatile value_type& src) const;
 
-      KOKKOS_INLINE_FUNCTION
-      void init( value_type& val)  const;
+   KOKKOS_INLINE_FUNCTION
+   void init( value_type& val)  const;
 
-      KOKKOS_INLINE_FUNCTION
-      value_type& reference() const;
+   KOKKOS_INLINE_FUNCTION
+   value_type& reference() const;
 
-      KOKKOS_INLINE_FUNCTION
-      result_view_type view() const;
+   KOKKOS_INLINE_FUNCTION
+   result_view_type view() const;
 
-      KOKKOS_INLINE_FUNCTION
-      Sum(value_type& value_);
+   KOKKOS_INLINE_FUNCTION
+   Sum(value_type& value_);
 
-      KOKKOS_INLINE_FUNCTION
-      Sum(const result_view_type& value_);
-  };
-  ```
+   KOKKOS_INLINE_FUNCTION
+   Sum(const result_view_type& value_);
+};
+```
 
 ## Public Class Members
 
@@ -60,14 +58,14 @@ Usage:
    Constructs a reducer which references a local variable as its result location.  
  
  * ```c++
-   Sum(const result_view_type result)`
+   Sum(const result_view_type result)
    ```
    Constructs a reducer which references a specific view as its result location.
 
 ### Functions
 
  * ```c++
-   void join(value_type& dest, const value_type& src)  const;`
+   void join(value_type& dest, const value_type& src)  const;
    ```
    Add `src` into `dest`:  `dest+=src;`. 
 
@@ -95,4 +93,4 @@ Usage:
    * `Sum<T,S>::value_type` is non-const `T`
    * `Sum<T,S>::result_view_type` is `Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>`.  Note that the S (memory space) must be the same as the space where the result resides.
    * Requires: `Scalar` has `operator =` and `operator +=` defined. `Kokkos::reduction_identity<Scalar>::sum()` is a valid expression. 
-   * In order to use Sum with a custom type, a template specialization of Kokkos::reduction_identity<CustomType> must be defined.  See [Using Built-in Reducers with Custom Scalar Types](Custom-Reductions%3A-Built-In-Reducers-with-Custom-Scalar-Types) for details
+   * In order to use Sum with a custom type, a template specialization of `Kokkos::reduction_identity<CustomType>` must be defined.  See [Built-In Reducers with Custom Scalar Types](../../../ProgrammingGuide/Custom-Reductions:-Built-In-Reducers-with-Custom-Scalar-Types) for details


### PR DESCRIPTION
### This PR:
- reorganized API/core/builtin_reducers
- fixed links, removed unnecessary indentation, removed char "" in order to render C++ block corectly in API/core/builtinreducers/BAnd`
- fixed links, removed unnecessary indentation, removed char "" in order to render C++ block corectly in API/core/builtinreducers/BOr`
- fixed links, removed unnecessary indentation, removed char "" in order to render C++ block corectly in API/core/builtinreducers/LAnd`
- fixed links, removed unnecessary indentation, removed char "" in order to render C++ block corectly in API/core/builtinreducers/LOr`
- fixed links, removed unnecessary indentation, removed char "" in order to render C++ block corectly in API/core/builtinreducers/Max`
- fixed links, removed unnecessary indentation, removed char "" in order to render C++ block corectly in API/core/builtinreducers/MaxLoc`
- fixed links, removed unnecessary indentation, removed char "" in order to render C++ block corectly in API/core/builtinreducers/Min`
- fixed links, removed unnecessary indentation, removed char "" in order to render C++ block corectly in API/core/builtinreducers/MinLoc`
- fixed links, removed unnecessary indentation, removed char "" in order to render C++ block corectly in API/core/builtinreducers/MinMax`
- fixed links, removed unnecessary indentation, removed char "" in order to render C++ block corectly in API/core/builtinreducers/MinMaxLoc`
- fixed links, removed unnecessary indentation, removed char "" in order to render C++ block corectly in API/core/builtinreducers/Prod`
- fixed links, removed unnecessary indentation, removed char "" in order to render C++ block corectly in API/core/builtinreducers/Sum`