### PR TITLE
#34: Fix API-core-atomics

### DIFF
--- a/source/API/core/atomics.rst
+++ b/source/API/core/atomics.rst
@@ -1,15 +1,14 @@
-
 Atomics
 =========
 
 .. toctree::
    :maxdepth: 2
 
-   ./atomics/atomic_compare_exchange_strong
    ./atomics/atomic_compare_exchange
+   ./atomics/atomic_compare_exchange_strong
    ./atomics/atomic_exchange
    ./atomics/atomic_fetch_op
    ./atomics/atomic_load
-   ./atomics/atomic_op_fetch
    ./atomics/atomic_op
+   ./atomics/atomic_op_fetch
    ./atomics/atomic_store

--- a/source/API/core/atomics/atomic_compare_exchange.md
+++ b/source/API/core/atomics/atomic_compare_exchange.md
@@ -3,9 +3,9 @@
 Header File: `Kokkos_Core.hpp`
 
 Usage:
-  ```c++
-  old_val = atomic_compare_exchange(ptr_to_value,comparison_value, new_value);
-  ```
+```c++
+old_val = atomic_compare_exchange(ptr_to_value,comparison_value, new_value);
+```
 
 Atomically sets the value at the address given by `ptr_to_value` to `new_value` if the current value at `ptr_to_value`
 is equal to `comparison_value`, and returns the previously stored value at the address independent on whether 
@@ -14,8 +14,8 @@ the exchange has happened.
 ## Synopsis
 
 ```c++
-  template<class T>
-  T atomic_compare_exchange(T* const ptr_to_value, const T comparison_value, const T new_value);
+template<class T>
+T atomic_compare_exchange(T* const ptr_to_value, const T comparison_value, const T new_value);
 ```
 
 ## Description
@@ -30,5 +30,3 @@ the exchange has happened.
   * `comparison_value`: value to be compared to. 
   * `new_value`: new value.
   * `old_value`: value at address `ptr_to_value` before doing the exchange.
-
-

--- a/source/API/core/atomics/atomic_compare_exchange_strong.md
+++ b/source/API/core/atomics/atomic_compare_exchange_strong.md
@@ -3,9 +3,9 @@
 Header File: `Kokkos_Core.hpp`
 
 Usage:
-  ```c++
-  was_exchanged = atomic_compare_exchange_strong(ptr_to_value,comparison_value, new_value);
-  ```
+```c++
+was_exchanged = atomic_compare_exchange_strong(ptr_to_value,comparison_value, new_value);
+```
 
 Atomically sets the value at the address given by `ptr_to_value` to `new_value` if the current value at `ptr_to_value`
 is equal to `comparison_value`, and returns true if the exchange has happened.
@@ -13,8 +13,8 @@ is equal to `comparison_value`, and returns true if the exchange has happened.
 ## Synopsis
 
 ```c++
-  template<class T>
-  bool atomic_compare_exchange_strong(T* const ptr_to_value, const T comparison_value, const T new_value);
+template<class T>
+bool atomic_compare_exchange_strong(T* const ptr_to_value, const T comparison_value, const T new_value);
 ```
 
 ## Description
@@ -29,5 +29,3 @@ is equal to `comparison_value`, and returns true if the exchange has happened.
   * `comparison_value`: value to be comapred to.
   * `new_value`: new value.
   * `old_value`: value at address `ptr_to_value` before doing the exchange.
-
-

--- a/source/API/core/atomics/atomic_exchange.md
+++ b/source/API/core/atomics/atomic_exchange.md
@@ -3,17 +3,17 @@
 Header File: `Kokkos_Core.hpp`
 
 Usage:
-  ```c++
-  old_val = atomic_exchange(ptr_to_value,new_value);
-  ```
+```c++
+old_val = atomic_exchange(ptr_to_value,new_value);
+```
 
 Atomically sets the value at the address given by `ptr_to_value` to `new_value` and returns the previously stored value at the address.
 
 ## Synopsis
 
 ```c++
-  template<class T>
-  T atomic_exchange(T* const ptr_to_value, const T new_value);
+template<class T>
+T atomic_exchange(T* const ptr_to_value, const T new_value);
 ```
 
 ## Description
@@ -27,5 +27,3 @@ Atomically sets the value at the address given by `ptr_to_value` to `new_value` 
   * `ptr_to_value`: address of the to be updated value.
   * `new_value`: new value.
   * `old_value`: value at address `ptr_to_value` before doing the exchange.
-
-

--- a/source/API/core/atomics/atomic_fetch_op.md
+++ b/source/API/core/atomics/atomic_fetch_op.md
@@ -3,9 +3,9 @@
 Header File: `Kokkos_Core.hpp`
 
 Usage:
-  ```c++
-  old_value =  atomic_fetch_[op](ptr_to_value,update_value);
-  ```
+```c++
+old_value =  atomic_fetch_[op](ptr_to_value,update_value);
+```
 
 Atomically updates the variable at the address given by `ptr_to_value` with `update_value` according to the relevant operation, 
 and returns the previous value found at that address..
@@ -13,41 +13,41 @@ and returns the previous value found at that address..
 ## Synopsis
 
 ```c++
-  template<class T>
-  T atomic_fetch_add(T* const ptr_to_value, const T value);
+template<class T>
+T atomic_fetch_add(T* const ptr_to_value, const T value);
 
-  template<class T>
-  T atomic_fetch_and(T* const ptr_to_value, const T value);
+template<class T>
+T atomic_fetch_and(T* const ptr_to_value, const T value);
 
-  template<class T>
-  T atomic_fetch_div(T* const ptr_to_value, const T value);
+template<class T>
+T atomic_fetch_div(T* const ptr_to_value, const T value);
 
-  template<class T>
-  T atomic_fetch_lshift(T* const ptr_to_value, const unsigned shift);
+template<class T>
+T atomic_fetch_lshift(T* const ptr_to_value, const unsigned shift);
 
-  template <class T>
-  T atomic_fetch_max(T* const ptr_to_value, const T val);
+template <class T>
+T atomic_fetch_max(T* const ptr_to_value, const T val);
 
-  template <class T>
-  T atomic_fetch_min(T* const ptr_to_value, const T val);
+template <class T>
+T atomic_fetch_min(T* const ptr_to_value, const T val);
 
-  template<class T>
-  T atomic_fetch_mod(T* const ptr_to_value, const T value);
+template<class T>
+T atomic_fetch_mod(T* const ptr_to_value, const T value);
 
-  template<class T>
-  T atomic_fetch_mul(T* const ptr_to_value, const T value);
- 
-  template<class T>
-  T atomic_fetch_or(T* const ptr_to_value, const T value);
+template<class T>
+T atomic_fetch_mul(T* const ptr_to_value, const T value);
 
-  template<class T>
-  T atomic_fetch_rshift(T* const ptr_to_value, const unsigned shift);
+template<class T>
+T atomic_fetch_or(T* const ptr_to_value, const T value);
 
-  template<class T>
-  T atomic_fetch_sub(T* const ptr_to_value, const T value);
- 
-  template<class T>
-  T atomic_fetch_xor(T* const ptr_to_value, const T value);
+template<class T>
+T atomic_fetch_rshift(T* const ptr_to_value, const unsigned shift);
+
+template<class T>
+T atomic_fetch_sub(T* const ptr_to_value, const T value);
+
+template<class T>
+T atomic_fetch_xor(T* const ptr_to_value, const T value);
 ```
 
 ## Description
@@ -159,4 +159,3 @@ and returns the previous value found at that address..
   Atomically executes `tmp = *ptr_to_value; *ptr_to_value ^= value; return tmp;`. 
   * `ptr_to_value`: address of the to be updated value.
   * `value`: value with which to combine the original value. 
-

--- a/source/API/core/atomics/atomic_load.md
+++ b/source/API/core/atomics/atomic_load.md
@@ -3,17 +3,17 @@
 Header File: `Kokkos_Core.hpp`
 
 Usage:
-  ```c++
-  value = atomic_load(ptr_to_value);
-  ```
+```c++
+value = atomic_load(ptr_to_value);
+```
 
 Atomically reads the value at the address given by `ptr_to_value`.
 
 ## Synopsis
 
 ```c++
-  template<class T>
-  T atomic_load(T* const ptr_to_value);
+template<class T>
+T atomic_load(T* const ptr_to_value);
 ```
 
 ## Description
@@ -26,5 +26,3 @@ Atomically reads the value at the address given by `ptr_to_value`.
   Atomically executes `value = *ptr_to_value; return value;`. 
   * `ptr_to_value`: address of the to be updated value.
   * `value`: value at address `ptr_to_value`.
-
-

--- a/source/API/core/atomics/atomic_op.md
+++ b/source/API/core/atomics/atomic_op.md
@@ -3,41 +3,41 @@
 Header File: `Kokkos_Core.hpp`
 
 Usage:
-  ```c++
-  atomic_[op](ptr_to_value,update_value);
-  ```
+```c++
+atomic_[op](ptr_to_value,update_value);
+```
 
 Atomically updates the `value` at the address given by `ptr_to_value` with `update_value` according to the relevant operation.
 
 ## Synopsis
 
 ```c++
-  template<class T>
-  void atomic_add(T* const ptr_to_value, const T value);
+template<class T>
+void atomic_add(T* const ptr_to_value, const T value);
 
-  template<class T>
-  void atomic_and(T* const ptr_to_value, const T value);
+template<class T>
+void atomic_and(T* const ptr_to_value, const T value);
 
-  template<class T>
-  void atomic_assign(T* const ptr_to_value, const T value);
+template<class T>
+void atomic_assign(T* const ptr_to_value, const T value);
 
-  template<class T>
-  void atomic_decrement(T* const ptr_to_value);
+template<class T>
+void atomic_decrement(T* const ptr_to_value);
 
-  template<class T>
-  void atomic_incrememt(T* const ptr_to_value);
+template<class T>
+void atomic_incrememt(T* const ptr_to_value);
 
-  template <class T>
-  void atomic_max(T* const ptr_to_value, const T value);
+template <class T>
+void atomic_max(T* const ptr_to_value, const T value);
 
-  template <class T>
-  void atomic_min(T* const ptr_to_value, const T value);
+template <class T>
+void atomic_min(T* const ptr_to_value, const T value);
 
-  template<class T>
-  void atomic_or(T* const ptr_to_value, const T value);
+template<class T>
+void atomic_or(T* const ptr_to_value, const T value);
 
-  template<class T>
-  void atomic_sub(T* const ptr_to_value, const T value);
+template<class T>
+void atomic_sub(T* const ptr_to_value, const T value);
 ```
 
 ## Description
@@ -119,5 +119,4 @@ Atomically updates the `value` at the address given by `ptr_to_value` with `upda
 
   Atomically executes `*ptr_to_value -= value`. 
   * `ptr_to_value`: address of the to be updated value.
-  * `value`: value to be substracted.. 
-
+  * `value`: value to be subtracted.

--- a/source/API/core/atomics/atomic_op_fetch.md
+++ b/source/API/core/atomics/atomic_op_fetch.md
@@ -3,51 +3,51 @@
 Header File: `Kokkos_Core.hpp`
 
 Usage:
-  ```c++
-  old_value =  atomic_[op]_fetch(ptr_to_value,update_value);
-  ```
+```c++
+old_value =  atomic_[op]_fetch(ptr_to_value,update_value);
+```
 
 Atomically updates the variable at the address given by `ptr_to_value` with `update_value` according to the relevant operation, 
-and returns the updated value found at that address..
+and returns the updated value found at that address.
 
 ## Synopsis
 
 ```c++
-  template<class T>
-  T atomic_add_fetch(T* const ptr_to_value, const T value);
+template<class T>
+T atomic_add_fetch(T* const ptr_to_value, const T value);
 
-  template<class T>
-  T atomic_and_fetch(T* const ptr_to_value, const T value);
+template<class T>
+T atomic_and_fetch(T* const ptr_to_value, const T value);
 
-  template<class T>
-  T atomic_div_fetch(T* const ptr_to_value, const T value);
+template<class T>
+T atomic_div_fetch(T* const ptr_to_value, const T value);
 
-  template<class T>
-  T atomic_lshift_fetch(T* const ptr_to_value, const unsigned shift);
+template<class T>
+T atomic_lshift_fetch(T* const ptr_to_value, const unsigned shift);
 
-  template <class T>
-  T atomic_max_fetch(T* const ptr_to_value, const T val);
+template <class T>
+T atomic_max_fetch(T* const ptr_to_value, const T val);
 
-  template <class T>
-  T atomic_min_fetch(T* const ptr_to_value, const T val);
+template <class T>
+T atomic_min_fetch(T* const ptr_to_value, const T val);
 
-  template<class T>
-  T atomic_mod_fetch(T* const ptr_to_value, const T value);
+template<class T>
+T atomic_mod_fetch(T* const ptr_to_value, const T value);
 
-  template<class T>
-  T atomic_mul_fetch(T* const ptr_to_value, const T value);
+template<class T>
+T atomic_mul_fetch(T* const ptr_to_value, const T value);
 
-  template<class T>
-  T atomic_or_fetch(T* const ptr_to_value, const T value);
-  
-  template<class T>
-  T atomic_rshift_fetch(T* const ptr_to_value, const unsigned shift);
+template<class T>
+T atomic_or_fetch(T* const ptr_to_value, const T value);
 
-  template<class T>
-  T atomic_sub_fetch(T* const ptr_to_value, const T value);
-  
-  template<class T>
-  T atomic_xor_fetch(T* const ptr_to_value, const T value);
+template<class T>
+T atomic_rshift_fetch(T* const ptr_to_value, const unsigned shift);
+
+template<class T>
+T atomic_sub_fetch(T* const ptr_to_value, const T value);
+
+template<class T>
+T atomic_xor_fetch(T* const ptr_to_value, const T value);
 ```
 
 ## Description
@@ -159,4 +159,3 @@ and returns the updated value found at that address..
   Atomically executes ` *ptr_to_value ^= value; return *ptr_to_value;`. 
   * `ptr_to_value`: address of the to be updated value.
   * `value`: value with which to combine the original value. 
-

--- a/source/API/core/atomics/atomic_store.md
+++ b/source/API/core/atomics/atomic_store.md
@@ -3,17 +3,17 @@
 Header File: `Kokkos_Core.hpp`
 
 Usage:
-  ```c++
-  atomic_store(ptr_to_value,new_value);
-  ```
+```c++
+atomic_store(ptr_to_value,new_value);
+```
 
 Atomically sets the value at the address given by `ptr_to_value` to `new_value`.
 
 ## Synopsis
 
 ```c++
-  template<class T>
-  void atomic_store(T* const ptr_to_value, const T new_value);
+template<class T>
+void atomic_store(T* const ptr_to_value, const T new_value);
 ```
 
 ## Description
@@ -26,5 +26,3 @@ Atomically sets the value at the address given by `ptr_to_value` to `new_value`.
   Atomically executes `*ptr_to_value = new_value;`. 
   * `ptr_to_value`: address of the to be updated value.
   * `new_value`: new value.
-
-


### PR DESCRIPTION
### THIS PR:
- changed order in API/core/atomics (to alphabetical order)
- removed unnecessary indentation and too many blank lines in 'API/core/atomics/atomic_compare_exchange'
- removed unnecessary indentation in 'API/core/atomics/atomic_compare_exchange_strong'
- removed unnecessary indentation in 'API/core/atomics/atomic_exchange'
- removed unnecessary indentation and too many blank lines in 'API/core/atomics/atomic_fetch_op'
- removed unnecessary indentation and too many blank lines in 'API/core/atomics/atomic_load'
- removed unnecessary indentation and too many blank lines in 'API/core/atomics/atomic_op'
- removed unnecessary indentation, dot and too many blank lines in 'API/core/atomics/atomic_op_fetch'
- removed unnecessary indentation and too many blank lines in 'API/core/atomics/atomic_store'