### PR TITLE
#34: API core fixes

### DIFF
--- a/source/API/core-index.rst
+++ b/source/API/core-index.rst
@@ -1,24 +1,22 @@
-
 API: Core
 #########
 
 .. toctree::
    :maxdepth: 1
 
-   ./core/Initialize-and-Finalize
-   ./core/View
+   ./core/fence
    ./core/parallel_for
    ./core/parallel_reduce
    ./core/parallel_scan
-   ./core/fence
-   ./core/Execution-Policies
+   ./core/atomics
    ./core/builtin_reducers
    ./core/CStyleMemManagement
-   ./core/Spaces
-   ./core/Task-Parallelism
-   ./core/atomics
-   ./core/Utilities
-   ./core/STL-Compatibility
-   ./core/Numerics
    ./core/Detection-Idiom
-
+   ./core/Execution-Policies
+   ./core/Initialize-and-Finalize
+   ./core/Numerics
+   ./core/Spaces
+   ./core/STL-Compatibility
+   ./core/Task-Parallelism
+   ./core/Utilities
+   ./core/View

--- a/source/API/core/Task-Parallelism.md
+++ b/source/API/core/Task-Parallelism.md
@@ -1,14 +1,15 @@
-# Task-Parallelism
+Task-Parallelism
+================
 
 Kokkos has support for lightweight task-based programming, which is currently pretty limited but we plan to substantially expand in the future.
 
 Will Kokkos Tasking work for my problem?
-========================================
+----------------------------------------
 
 Not all task-based problems are a good fit for the current Kokkos approach to tasking.  Currently, the tasking interface in Kokkos is  targetted at problems with kernels far too small to overcome the inherent overhead of top-level Kokkos data parallel launches—that is, small but plentiful data parallel tasks with a non-trivial dependency structure.  For tasks that fit this general scale model but have (very) trivial dependency structures, it may be easier to use [hierarchical parallelism](HierarchicalParallelism), potentially with a `Kokkos::Schedule<Dynamic>` scheduling policy (see, for instance, [this page](Kokkos%3A%3ARangePolicy)) for load balancing if necessary. 
 
 Basic Usage
-===========
+-----------
 
 Fundamentally, task parallelism is just another form of parallelism in Kokkos.  The same general idiom of pattern, policy, and functor applies as for ordinary [parallel dispatch](ParallelDispatch):
 

--- a/source/API/core/fence.md
+++ b/source/API/core/fence.md
@@ -1,4 +1,4 @@
-# `Kokkos::fence`
+# `fence()`
 
 Header File: `Kokkos_Core.hpp`
 
@@ -9,8 +9,8 @@ Kokkos::fence();
 ```
 
 Blocks on completion of all outstanding asynchronous Kokkos operations.
-That includes parallel dispatch (e.g. [parallel_for](Kokkos%3A%3Aparallel_for), [parallel_reduce](Kokkos%3A%3Aparallel_reduce) 
-and [parallel_scan](Kokkos%3A%3Aparallel_scan)) as well as asynchronous data operations such as three-argument [deep_copy](Kokkos%3A%3Adeep_copy).
+That includes parallel dispatch (e.g. [parallel_for()](parallel_for), [parallel_reduce()](parallel_reduce) 
+and [parallel_scan()](parallel_scan)) as well as asynchronous data operations such as three-argument [deep_copy](Kokkos%3A%3Adeep_copy).
 
 Note: there is a execution space instance specific `fence` too: [ExecutionSpaceConcept](Kokkos%3A%3AExecutionSpaceConcept)
 
@@ -61,7 +61,3 @@ Kokkos::fence();
 
 // do something with a and b
 ```
-
-
-
-~        

--- a/source/API/core/parallel_for.md
+++ b/source/API/core/parallel_for.md
@@ -1,12 +1,11 @@
-
 # `parallel_for()`
 
 Header File: `Kokkos_Core.hpp`
 
 Usage: 
 ```c++
-  Kokkos::parallel_for(name, policy, functor);
-  Kokkos::parallel_for(policy, functor);
+Kokkos::parallel_for(name, policy, functor);
+Kokkos::parallel_for(policy, functor);
 ```
 
 Dispatches parallel work defined by `functor` according to the *ExecutionPolicy* `policy`. The optional label `name` is

--- a/source/API/core/parallel_reduce.md
+++ b/source/API/core/parallel_reduce.md
@@ -1,4 +1,3 @@
-
 # `parallel_reduce()`
 
 Header File: `Kokkos_Core.hpp`
@@ -225,5 +224,3 @@ int main(int argc, char* argv[]) {
    Kokkos::finalize();
 }
 ```
-
-


### PR DESCRIPTION
### THIS PR:
- changed order in API/core (first functions, then alphabetical order)
- fixed headings and grammar in API/core/Task-Parallelism (previously incorrect rendering)
- fixed links and removed namespace in API/core/fence
- removed blank line and removed unnecessary indentation in API/core/parallel_for
- removed blank line in API/core/parallel_reduce