### PR TITLE
#32: Fix policies

### DIFF
--- a/source/API/core/Execution-Policies.rst
+++ b/source/API/core/Execution-Policies.rst
@@ -1,4 +1,3 @@
-
 Execution Policies
 ##################
 
@@ -13,7 +12,7 @@ Top Level Execution Policies
     * - Policy
       - Description
 
-    * * `RangePolicy <tbd>`__ 
+    * * `RangePolicy <tbd>`__
       * Each iterate is an integer in a contiguous range
 
     * * `MDRangePolicy <mdrangepolicy>`_
@@ -22,12 +21,10 @@ Top Level Execution Policies
     * * `TeamPolicy <tbd>`__
       * Assigns to each iterate in a contiguous range a team of threads
 
-
-
 Nested Execution Policies
 ============================
 
-Nested Execution Policies are used to dispatch parallel work inside of an already executing parallel region either dispatched with a `TeamPolicy <tbd>`__ or a task policy. 
+Nested Execution Policies are used to dispatch parallel work inside of an already executing parallel region either dispatched with a `TeamPolicy <tbd>`__ or a task policy.
 
 .. list-table::
     :widths: 25 75
@@ -37,15 +34,14 @@ Nested Execution Policies are used to dispatch parallel work inside of an alread
     * - Policy
       - Description
 
-    * * `TeamThreadRange <tbd>`__ 
+    * * `TeamThreadRange <tbd>`__
       * Used inside of a TeamPolicy kernel to perform nested parallel loops split over threads of a team.
-    
-    * * `TeamVectorRange <tbd>`__ 
-      * Used inside of a TeamPolicy kernel to perform nested parallel loops split over threads of a team and their vector lanes.
-    
-    * * `ThreadVectorRange <tbd>`__ 
-      * Used inside of a TeamPolicy kernel to perform nested parallel loops with vector lanes of a thread.
 
+    * * `TeamVectorRange <tbd>`__
+      * Used inside of a TeamPolicy kernel to perform nested parallel loops split over threads of a team and their vector lanes.
+
+    * * `ThreadVectorRange <tbd>`__
+      * Used inside of a TeamPolicy kernel to perform nested parallel loops with vector lanes of a thread.
 
 Common Arguments for all Execution Policies
 ===========================================
@@ -54,9 +50,7 @@ Execution Policies generally accept compile time arguments via template paramete
 
 .. tip::
 
-	Template arguments can be given in arbitrary order.
-
-
+    Template arguments can be given in arbitrary order.
 
 .. list-table::
     :widths: 30 30 40
@@ -67,34 +61,35 @@ Execution Policies generally accept compile time arguments via template paramete
       - Options
       - Purpose
 
-    * * ExecutionSpace 
-      * ``Serial``, ``OpenMP``, ``Threads``, ``Cuda``, ``HIP``, ``SYCL``, ``HPX`` 
+    * * ExecutionSpace
+      * ``Serial``, ``OpenMP``, ``Threads``, ``Cuda``, ``HIP``, ``SYCL``, ``HPX``
       * Specify the Execution Space to execute the kernel in. Defaults to ``Kokkos::DefaultExecutionSpace``
 
-    * * Schedule 
-      * ``Schedule<Dynamic>``, ``Schedule<Static>`` 
+    * * Schedule
+      * ``Schedule<Dynamic>``, ``Schedule<Static>``
       * Specify scheduling policy for work items. ``Dynamic`` scheduling is implemented through a work stealing queue. Default is machine and backend specific.
 
-    * * IndexType 
-      * ``IndexType<int>`` 
+    * * IndexType
+      * ``IndexType<int>``
       * Specify integer type to be used for traversing the iteration space. Defaults to ``int64_t``.
 
-    * * LaunchBounds 
-      * ``LaunchBounds<MaxThreads, MinBlocks>`` 
+    * * LaunchBounds
+      * ``LaunchBounds<MaxThreads, MinBlocks>``
       * Specifies hints to to the compiler about CUDA/HIP launch bounds.
 
-    * * WorkTag 
-      * ``SomeClass`` 
+    * * WorkTag
+      * ``SomeClass``
       * Specify the work tag type used to call the functor operator. Any arbitrary type defaults to ``void``.
 
 
 .. toctree::
-   :maxdepth: 1
 
-  ./policies/RangePolicy
+  ./policies/ExecutionPolicyConcept
   ./policies/MDRangePolicy
+  ./policies/NestedPolicies
+  ./policies/RangePolicy
+  ./policies/TeamHandleConcept
   ./policies/TeamPolicy
   ./policies/TeamThreadRange
   ./policies/TeamVectorRange
   ./policies/ThreadVectorRange
-

--- a/source/API/core/policies/ExecutionPolicyConcept.md
+++ b/source/API/core/policies/ExecutionPolicyConcept.md
@@ -1,0 +1,42 @@
+# `ExecutionPolicy`
+
+The concept of an `ExecutionPolicy` is the fundamental abstraction to represent "how" the execution of a Kokkos parallel pattern takes place.  This page talks practically about how to *use* the common features of execution policies in Kokkos; for a more formal and theoretical treatment, see [this document](../KokkosConcepts).
+
+> *Disclaimer*: There is nothing new about the term "concept" in C++; anyone who has ever used templates in C++ has used concepts whether they knew it or not.  Please do not be confused by the word "concept" itself, which is now more often associated with a shiny new C++20 language feature.  Here, "concept" just means "what you're allowed to do with a type that is a template parameter in certain places".
+
+## What is an `ExecutionPolicy`?
+
+The dominant parallel dispatch mechanism in Kokkos, described [elsewhere in the programming guide](../../../ProgrammingGuide/ParallelDispatch), involves a `parallel_pattern` (e.g., something like [`Kokkos::parallel_for`](../parallel_for) or [`Kokkos::parallel_reduce`](../parallel_reduce)), an `ExecutionPolicy`, and a `Functor`.  In a hand-wavy sense:
+
+```c++
+parallel_pattern(
+  ExecutionPolicy(),
+  Functor()
+);
+```
+
+The most basic ("beginner") case is actually a shortcut:
+
+```c++
+Kokkos::parallel_for(
+  42,
+  KOKKOS_LAMBDA (int n) { /* ... */ }
+);
+```
+
+is a "shortcut" for
+
+```c++
+Kokkos::parallel_for(
+  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(
+    Kokkos::DefaultExecutionSpace(), 0, 42
+  ),
+  KOKKOS_LAMBDA(int n) { /* ... */ }
+);
+```
+
+In this example, `Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>` is the `ExecutionPolicy` type.
+
+### Functionality
+
+All `ExecutionPolicy` types provide a nested type named `index_type`.

--- a/source/API/core/policies/MDRangePolicy.md
+++ b/source/API/core/policies/MDRangePolicy.md
@@ -3,20 +3,20 @@
 Header File: `Kokkos_Core.hpp`
 
 Usage: 
-  ```c++
-  Kokkos::MDRangePolicy<>(begin, end)
-  Kokkos::MDRangePolicy<>(Space, begin, end)
-  Kokkos::MDRangePolicy<ARGS>(begin, end, tiling)
-  Kokkos::MDRangePolicy<ARGS>(Space, begin, end, tiling)
-  ```
+```c++
+Kokkos::MDRangePolicy<>(begin, end)
+Kokkos::MDRangePolicy<>(Space, begin, end)
+Kokkos::MDRangePolicy<ARGS>(begin, end, tiling)
+Kokkos::MDRangePolicy<ARGS>(Space, begin, end, tiling)
+```
 
-`MDRangePolicy` defines an execution policy for a multi dimensional iteration space starting at a `begin` tuple and going to `end` with an open interval. The iteration space will be tiled, and the user can optionally provide tiling sizes. 
+`MDRangePolicy` defines an execution policy for a multidimensional iteration space starting at a `begin` tuple and going to `end` with an open interval. The iteration space will be tiled, and the user can optionally provide tiling sizes. 
 
 ## Interface 
-  ```c++
-  template<class ... Args>
-  class Kokkos::MDRangePolicy;
-  ```
+```c++
+template<class ... Args>
+class Kokkos::MDRangePolicy;
+```
 
 ## Parameters:
 
@@ -78,9 +78,7 @@ Usage:
 
 ## Examples
 
-  ```c++
-    MDRangePolicy<Rank<3>> policy_1({0,0,0},{N0,N1,N2});
-    MDRangePolicy<Cuda,Rank<3,Iterate::Right,Iterate::Left>> policy_2({5,5,5},{N0-5,N1-5,N2-5},{T0,T1,T2});
-  ```
-
-
+```c++
+MDRangePolicy<Rank<3>> policy_1({0,0,0},{N0,N1,N2});
+MDRangePolicy<Cuda,Rank<3,Iterate::Right,Iterate::Left>> policy_2({5,5,5},{N0-5,N1-5,N2-5},{T0,T1,T2});
+```

--- a/source/API/core/policies/NestedPolicies.md
+++ b/source/API/core/policies/NestedPolicies.md
@@ -1,0 +1,113 @@
+# `NestedPolicies`
+
+(PerTeam)=
+## `Kokkos::PerTeam`
+
+(PerThread)=
+## `Kokkos::PerThread`
+
+(TeamThreadRange)=
+## `Kokkos::TeamThreadRange`
+
+(TeamVectorRange)=
+## `Kokkos::TeamVectorRange`
+
+(ThreadVectorRange)=
+## `Kokkos::ThreadVectorRange`
+
+Header File: `Kokkos_Core.hpp`
+
+Usage: 
+```c++
+parallel_for(TeamThreadRange(team,begin,end), [=] (int i) {});
+parallel_for(ThreadVectorRange(team,begin,end), [=] (int i) {});
+single(PerTeam(team), [=] () {});
+single(PerThread(team), [=] () {});
+```
+
+Nested policies can be used for nested parallel patterns. In contrast to global policies, the public
+interface for nested policies is implemented as functions, in order to enable implicit templating on 
+the execution space type via the team handle. 
+
+### Synopsis 
+```c++
+Impl::TeamThreadRangeBoundariesStruct TeamThreadRange(TeamMemberType team, IndexType count);
+Impl::TeamThreadRangeBoundariesStruct TeamThreadRange(TeamMemberType team, IndexType begin, IndexType end);
+Impl::ThreadVectorRangeBoundariesStruct ThreadVectorRange(TeamMemberType team, IndexType count);
+Impl::ThreadVectorRangeBoundariesStruct ThreadVectorRange(TeamMemberType team, IndexType begin, IndexType end);
+Impl::ThreadSingleStruct PerTeam(TeamMemberType team);
+Impl::VectorSingleStruct PerThread(TeamMemberType team);
+```
+
+### Description
+
+ * ```c++
+   Impl::TeamThreadRangeBoundariesStruct TeamThreadRange(TeamMemberType team, IndexType count);
+   ```
+   Splits the index range `0` to `count-1` over the threads of the team. This call is potentially a
+   synchronization point for the team, and thus must meet the requirements of `team_barrier`.
+   * `team`: object meeting the requirements of TeamHandle
+   * `count`: index range length. 
+
+ * ```c++
+   Impl::TeamThreadRangeBoundariesStruct TeamThreadRange(TeamMemberType team, IndexType begin, IndexType end);
+   ```
+   Splits the index range `begin` to `end-1` over the threads of the team. This call is potentially a 
+   synchronization point for the team, and thus must meet the requirements of `team_barrier`.
+   * `team`: object meeting the requirements of TeamHandle
+   * `begin`: start index.
+   * `end`: end index.
+ * ```c++
+   Impl::ThreadVectorRangeBoundariesStruct ThreadVectorRange(TeamMemberType team, IndexType count);
+   ```
+   Splits the index range `0` to `count-1` over the vector lanes of the calling thread. It is not legal to 
+   call this function inside of a vector level loop. 
+   * `team`: object meeting the requirements of TeamHandle
+   * `count`: index range length. 
+ * ```c++
+   Impl::ThreadVectorRangeBoundariesStruct ThreadVectorRange(TeamMemberType team, IndexType begin, IndexType end);
+   ```
+   Splits the index range `begin` to `end-1` over the vector lanes of the calling thread. It is not legal to 
+   call this function inside of a vector level loop.
+   * `team`: object meeting the requirements of TeamHandle
+   * `begin`: start index.        
+   * `end`: end index. 
+ * ```c++ 
+   Impl::ThreadSingleStruct PerTeam(TeamMemberType team);
+   ```
+   When used in conjunction with the `single` pattern restricts execution to a single vector lane in the calling team. 
+   While not a synchronization event, this call must be encountered by the entire team, and thus meet the calling 
+   requirements of `team_barrier`. 
+   * `team`: object meeting the requirements of TeamHandle
+ * ```c++ 
+   Impl::VectorSingleStruct PerThread(TeamMemberType team);
+   ```
+   When used in conjunction with the `single` pattern restricts execution to a single vector lane in the calling thread. 
+   It is not legal to call this function inside of a vector level loop.
+   * `team`: object meeting the requirements of TeamHandle
+  
+### Examples
+
+```c++
+typedef TeamPolicy<>::member_type team_handle;
+parallel_for(TeamPolicy<>(N,AUTO,4), KOKKOS_LAMBDA (const team_handle& team) {
+  int n = team.league_rank();
+  parallel_for(TeamThreadRange(team,M), [&] (const int& i) {
+    int thread_sum;
+    parallel_reduce(ThreadVectorRange(team,K), [&] (const int& j, int& lsum) {
+      //...
+    },thread_sum);
+    single(PerThread(team), [&] () {
+      A(n,i) += thread_sum;
+    });
+  });
+  team.team_barrier();
+  int team_sum;
+  parallel_reduce(TeamThreadRange(team,M), [&] (const int& i, int& lsum) {
+    lsum += A(n,i);
+  },team_sum);
+  single(PerTeam(team),[&] () {
+    A_rowsum(n) += team_sum;
+  });
+});
+```

--- a/source/API/core/policies/RangePolicy.md
+++ b/source/API/core/policies/RangePolicy.md
@@ -3,62 +3,62 @@
 Header File: `Kokkos_Core.hpp`
 
 Usage: 
-  ```c++
-  Kokkos::RangePolicy<>(begin, end, args...)
-  Kokkos::RangePolicy<ARGS>(begin, end, args...)
-  Kokkos::RangePolicy<>(Space(), begin, end, args...)
-  Kokkos::RangePolicy<ARGS>(Space(), begin, end, args...)
-  ```
+```c++
+Kokkos::RangePolicy<>(begin, end, args...)
+Kokkos::RangePolicy<ARGS>(begin, end, args...)
+Kokkos::RangePolicy<>(Space(), begin, end, args...)
+Kokkos::RangePolicy<ARGS>(Space(), begin, end, args...)
+```
 
 RangePolicy defines an execution policy for a 1D iteration space starting at begin and going to end with an open interval. 
 
 ## Synopsis 
-  ```c++
-  template<class ... Args>
-  class Kokkos::RangePolicy {
-    typedef RangePolicy execution_policy;
-    typedef typename traits::index_type member_type ;
-    typedef typename traits::index_type index_type;
- 
-    //Inherited from PolicyTraits<Args...> 
-    using execution_space   = PolicyTraits<Args...>::execution_space;
-    using schedule_type     = PolicyTraits<Args...>::schedule_type;
-    using work_tag          = PolicyTraits<Args...>::work_tag;
-    using index_type        = PolicyTraits<Args...>::index_type;
-    using iteration_pattern = PolicyTraits<Args...>::iteration_pattern;
-    using launch_bounds     = PolicyTraits<Args...>::launch_bounds;
+```c++
+template<class ... Args>
+class Kokkos::RangePolicy {
+ typedef RangePolicy execution_policy;
+ typedef typename traits::index_type member_type ;
+ typedef typename traits::index_type index_type;
 
-    //Constructors
-    RangePolicy(const RangePolicy&) = default;
-    RangePolicy(RangePolicy&&) = default;
+ //Inherited from PolicyTraits<Args...> 
+ using execution_space   = PolicyTraits<Args...>::execution_space;
+ using schedule_type     = PolicyTraits<Args...>::schedule_type;
+ using work_tag          = PolicyTraits<Args...>::work_tag;
+ using index_type        = PolicyTraits<Args...>::index_type;
+ using iteration_pattern = PolicyTraits<Args...>::iteration_pattern;
+ using launch_bounds     = PolicyTraits<Args...>::launch_bounds;
 
-    inline RangePolicy();
+ //Constructors
+ RangePolicy(const RangePolicy&) = default;
+ RangePolicy(RangePolicy&&) = default;
 
-    template<class ... Args>
-    inline RangePolicy( const execution_space & work_space
-             , const member_type work_begin
-             , const member_type work_end
-             , Args ... args);
+ inline RangePolicy();
 
-    template<class ... Args>
-    inline RangePolicy( const member_type work_begin
-             , const member_type work_end
-             , Args ... args);
+ template<class ... Args>
+ inline RangePolicy( const execution_space & work_space
+          , const member_type work_begin
+          , const member_type work_end
+          , Args ... args);
+
+ template<class ... Args>
+ inline RangePolicy( const member_type work_begin
+          , const member_type work_end
+          , Args ... args);
 
 
-    // retrieve chunk_size
-    inline member_type chunk_size() const;
-    // set chunk_size to a discrete value
-    inline RangePolicy set_chunk_size(int chunk_size_);
+ // retrieve chunk_size
+ inline member_type chunk_size() const;
+ // set chunk_size to a discrete value
+ inline RangePolicy set_chunk_size(int chunk_size_);
 
-    // return ExecSpace instance provided to the constructor
-    KOKKOS_INLINE_FUNCTION const execution_space & space() const;
-    // return Range begin 
-    KOKKOS_INLINE_FUNCTION member_type begin() const;
-    // return Range end 
-    KOKKOS_INLINE_FUNCTION member_type end()   const;
-  };
-  ```
+ // return ExecSpace instance provided to the constructor
+ KOKKOS_INLINE_FUNCTION const execution_space & space() const;
+ // return Range begin 
+ KOKKOS_INLINE_FUNCTION member_type begin() const;
+ // return Range end 
+ KOKKOS_INLINE_FUNCTION member_type end()   const;
+};
+```
 
 ## Parameters:
 
@@ -76,7 +76,6 @@ RangePolicy defines an execution policy for a 1D iteration space starting at beg
 | WorkTag | `SomeClass` | Specify the work tag type used to call the functor operator. Any arbitrary type defaults to `void`. |
 
 ### Requirements:
-
 
 ## Public Class Members
 
@@ -99,22 +98,21 @@ RangePolicy defines an execution policy for a 1D iteration space starting at beg
 
  * `ChunkSize` : Provide a hint for optimal chunk-size to be used during scheduling.
 
-
 ## Examples
 
-  ```c++
-    RangePolicy<> policy_1(N);
-    RangePolicy<Cuda> policy_2(5,N-5);
-    RangePolicy<Schedule<Dynamic>, OpenMP> policy_3(n,m);
-    RangePolicy<IndexType<int>, Schedule<Dynamic>> policy_4(K);
-    RangePolicy<> policy_6(-3,N+3, ChunkSize(8));
-    RangePolicy<OpenMP> policy_7(OpenMP(), 0, N, ChunkSize(4));
-  ```
+```c++
+ RangePolicy<> policy_1(N);
+ RangePolicy<Cuda> policy_2(5,N-5);
+ RangePolicy<Schedule<Dynamic>, OpenMP> policy_3(n,m);
+ RangePolicy<IndexType<int>, Schedule<Dynamic>> policy_4(K);
+ RangePolicy<> policy_6(-3,N+3, ChunkSize(8));
+ RangePolicy<OpenMP> policy_7(OpenMP(), 0, N, ChunkSize(4));
+```
 
   Note: providing a single integer as a policy to a parallel pattern, implies a defaulted `RangePolicy`
 
-  ```c++
-    // These two calls are identical
-    parallel_for("Loop", N, functor);
-    parallel_for("Loop", RangePolicy<>(N), functor);
-  ```
+```c++
+ // These two calls are identical
+ parallel_for("Loop", N, functor);
+ parallel_for("Loop", RangePolicy<>(N), functor);
+```

--- a/source/API/core/policies/TeamHandleConcept.md
+++ b/source/API/core/policies/TeamHandleConcept.md
@@ -1,0 +1,192 @@
+# `TeamHandleConcept`
+
+Header File: `Kokkos_Core.hpp`
+
+TeamHandleConcept defines the concept for the `member_type` of `TeamPolicy` and `TeamTask`.
+The actual type is defined through the policies, but meets the following API requirements.
+Note that the specific classes are only part of the public API as provided by `TeamPolicy` and 
+`TeamTask` and only their parts as defined by the `TeamHandleConcept`. 
+The actual name of the class, as well as potential template parameters, existing
+constructors, member functions going beyond the concept, etc., are NOT part of the public Kokkos API
+and are thus subject to change. 
+
+## Synopsis 
+```c++
+class TeamHandleConcept {
+    public:
+    // Constructor, Destructor, Assignment
+    TeamHandleConcept( TeamHandleConcept && ) = default ;
+    TeamHandleConcept( TeamHandleConcept const & ) = default ;
+    ~TeamHandleConcept() = default ;
+    TeamHandleConcept & operator = ( TeamHandleConcept && ) = default ;
+    TeamHandleConcept & operator = ( TeamHandleConcept const & ) = default ;
+
+    // Indices
+    KOKKOS_INLINE_FUNCTION
+    int team_rank() const noexcept;
+    KOKKOS_INLINE_FUNCTION
+    int team_size() const noexcept;
+    KOKKOS_INLINE_FUNCTION
+    int league_rank() const noexcept;
+    KOKKOS_INLINE_FUNCTION
+    int league_size() const noexcept;
+
+    // Scratch Space
+    KOKKOS_INLINE_FUNCTION
+    const scratch_memory_space & team_shmem() const;
+    KOKKOS_INLINE_FUNCTION
+    const scratch_memory_space & team_scratch(int level) const;
+    KOKKOS_INLINE_FUNCTION
+    const scratch_memory_space & thread_scratch(int level) const;
+
+    // Team collectives
+    KOKKOS_INLINE_FUNCTION 
+    void team_barrier() const noexcept;
+    template<typename T>
+    KOKKOS_INLINE_FUNCTION
+    void team_broadcast( T & value , const int source_team_rank ) const noexcept;
+    template<class Closure, typename T>
+    KOKKOS_INLINE_FUNCTION
+    void team_broadcast( Closure const & f , T & value , const int source_team_rank) const noexcept;
+    template< typename ReducerType >
+    KOKKOS_INLINE_FUNCTION
+    void team_reduce( ReducerType const & reducer ) const noexcept;
+    template< typename T >
+    KOKKOS_INLINE_FUNCTION
+    T team_scan( T const & value , T * const global = 0 ) const noexcept;
+};
+```
+
+## Public Class Members
+
+### Constructors
+ 
+  * ```c++
+    TeamHandleConcept()
+    TeamHandleConcept(TeamHandleConcept && )
+    TeamHandleConcept(const TeamHandleConcept &)
+    ~TeamHandleConcept()
+    ``` 
+    Default, move and copy constructors as well as destructor. 
+
+### Assignment
+  * ```c++
+    TeamHandleConcept & operator = ( TeamHandleConcept && )
+    ```
+    Move assignment.
+  * ```c++
+    TeamHandleConcept & operator = ( const TeamHandleConcept & )
+    ```
+    Assignment operators.
+    Returns: `*this`.
+
+### Index Queries
+  * ```c++
+    inline int team_size() const noexcept;
+    ```
+    Returns: the number of threads associated with the team. 
+  * ```c++
+    inline int team_rank() const noexcept;
+    ```
+    Returns: the index `i` of the calling thread within the team with `0 <= i < team_size()`
+  * ```c++
+    inline int league_size() const noexcept;
+    ```
+    Returns: the number of teams/workitems launched in the kernel. 
+  * ```c++
+    inline int league_rank() const noexcept;
+    ```
+    Returns: the index `i` of the calling team within the league with `0 <= i < league_size()`
+    
+### Scratch Space Control
+  * ```c++
+    inline const scratch_memory_space & team_scratch(int level) const;
+    ```
+    This function returns a scratch memory handle shared by all threads in a team, 
+    which allows access to scratch memory. This handle can be given as the first 
+    argument to a `Kokkos::View` to make it use scratch memory. 
+    * `level`: The level of requested scratch memory is either `0` or `1`. 
+    Returns: a scratch memory handle to the team shared scratch memory specified by level. 
+  * ```c++
+    inline const scratch_memory_space & thread_scratch(int level) const;
+    ```
+    This function returns a scratch memory handle specific to the calling thread, 
+    which allows access to its private scratch memory. 
+    This handle can be given as the first argument to a `Kokkos::View` to make it use 
+    scratch memory. 
+    * `level`: The level of requested scratch memory is either `0` or `1`. 
+    Returns: a scratch memory handle to the thread scratch memory specified by level. 
+  * ```c++
+    inline const scratch_memory_space & team_shmem() const;
+    ```
+    Equivalent to calling `team_scratch(0)`.
+
+### Team Collective Operations
+  The following functions must be called collectively by all members of a team. These
+  calls must be lexically the same call, i.e. it is not legal to have some members of a team
+  call a collective in one branch and the others in another branch of the code (see example).
+
+  * ```c++
+    inline void team_barrier() const noexcept;
+    ```
+    All members of the team wait at the barrier, until the whole team arrived. This also issues
+    a memory fence. 
+  * ```c++
+    template<class T>
+    inline void team_broadcast( T & var , const int source_team_rank ) const noexcept;
+    ```
+    After this call `var` contains for every member of the team the value of `var` from the thread
+    for which `team_rank() == source_team_rank`.   
+    * `var`: a variable of type `T` which gets overwritten by the value of `var` from the source rank. 
+    * `source_team_rank`: identifies the broadcasting member of the team. 
+  * ```c++
+    template<class Closure, class T>
+    inline void team_broadcast( Closure const & f, T & var , const int source_team_rank ) const noexcept;
+    ```
+    After this call `var` contains for every member of the team the value of `var` from the thread
+    for which `team_rank() == source_team_rank` after applying `f`.
+    * `f`: a function object with an `void operator() ( T & )` which is applied to `var` before broadcasting it.
+    * `var`: a variable of type `T` which gets overwritten by the value of `f(var)` from the source rank. 
+    * `source_team_rank`: identifies the broadcasting member of the team. 
+  * ```c++
+    template< class ReducerType > 
+    inline void team_reduce( ReducerType const & reducer ) const noexcept;
+    ```
+    Performs a reduction accross all members of the team as specified by `reducer`. 
+    `ReducerType` must meet the concept of `Kokkos::Reducer`. 
+  * ```c++
+    template< class T >
+    inline T team_scan( const T & var , T * const global = NULL ) cosnt noexcept;
+    ```
+    Performs an exclusive scan over the `var` provided by the team members. 
+    Let `t = team_rank()` and `VALUES[t]` the value of `var` from thread `t`. 
+    Returns: `VALUES[0] + VALUES[1] + `...`+ VALUES[t-1]` or zero for `t==0`.
+    * `global` if provided will be set to `VALUES[0] + VALUES[1] + `...`+ VALUES[team_size()-1]`, must be the same 
+    pointer for every team member. 
+
+## Examples
+
+```c++
+typedef TeamPolciy<...> policy_type;
+parallel_for(policy_type(N,TEAM_SIZE).set_scratch_size(PerTeam(0,4096)), 
+             KOKKOS_LAMBDA (const typename policy_type::member_type& team_handle) {
+    int ts = team_handle.team_size(); // returns TEAM_SIZE
+    int tid = team_handle.team_rank(); // returns a number between 0 and TEAM_SIZE
+    int ls = team_handle.league_size(); // returns N
+    int lid = team_handle.league_rank(); // returns a number between 0 and N
+
+    int value = tid * 5;
+    team_handle.team_broadcast(value, 3); 
+    // value==15 on every thread
+    value += tid;
+    team_handle.team_broadcast([&] (int & var) { var*=2 }, value, 2); 
+    // value==34 on every thread
+    int global; 
+    int scan = team_handle.team_scan(tid+1, &global);
+    // scan == tid*(tid+1)/2 on every thread
+    // global == ts*(ts-1)/2 on every thread
+    Kokkos::View<int*, policy_type::execution_space::scratch_memory_type> 
+      a(team_handle.team_scratch(0), 1024); 
+    
+});
+```

--- a/source/API/core/policies/TeamPolicy.md
+++ b/source/API/core/policies/TeamPolicy.md
@@ -3,21 +3,21 @@
 Header File: `Kokkos_Core.hpp`
 
 Usage: 
-  ```c++
-  Kokkos::TeamPolicy<>( league_size, team_size [, vector_length])
-  Kokkos::TeamPolicy<ARGS>(league_size, team_size [, vector_length])
-  Kokkos::TeamPolicy<>(Space, league_size, team_size [, vector_length])
-  Kokkos::TeamPolicy<ARGS>(Space, league_size, team_size [, vector_length])
-  ```
+```c++
+Kokkos::TeamPolicy<>( league_size, team_size [, vector_length])
+Kokkos::TeamPolicy<ARGS>(league_size, team_size [, vector_length])
+Kokkos::TeamPolicy<>(Space, league_size, team_size [, vector_length])
+Kokkos::TeamPolicy<ARGS>(Space, league_size, team_size [, vector_length])
+```
 
 TeamPolicy defines an execution policy for a 1D iteration space starting at begin and going to end with an open interval. 
 
-See also: [TeamMember](Kokkos%3A%3ATeamHandleConcept)
+See also: [TeamMember](TeamHandleConcept)
 
 ## Synopsis 
-  ```c++
-  template<class ... Args>
-  class Kokkos::TeamPolicy {
+```c++
+template<class ... Args>
+class Kokkos::TeamPolicy {
     using execution_policy = TeamPolicy;
 
     //Inherited from PolicyTraits<Args...>  
@@ -80,8 +80,8 @@ See also: [TeamMember](Kokkos%3A%3ATeamHandleConcept)
 
     // return ExecSpace instance provided to the constructor
     KOKKOS_INLINE_FUNCTION const typename traits::execution_space & space() const;
-  };
-  ```
+};
+```
 
 ## Parameters:
 
@@ -99,7 +99,6 @@ See also: [TeamMember](Kokkos%3A%3ATeamHandleConcept)
 | WorkTag | `SomeClass` | Specify the work tag type used to call the functor operator. Any arbitrary type defaults to `void`. |
 
 ### Requirements:
-
 
 ## Public Class Members
 
@@ -169,7 +168,7 @@ See also: [TeamMember](Kokkos%3A%3ATeamHandleConcept)
     int team_size_max(const FunctorType& f, const ParallelReduceTag&) const;
     ```
     Query the maximum team size possible given a specific functor. 
-    The tag denotes whether this is for a `parallel_for` or a `parallel_reduce`.
+    The tag denotes whether this is for a [`parallel_for`](../parallel_for) or a [`parallel_reduce`](../parallel_reduce).
     Note: this is not a static function! The function will take into account settings
     for vector length and scratch size of `*this`. Using a value larger than the 
     return value will result in dispatch failure. 
@@ -184,7 +183,7 @@ See also: [TeamMember](Kokkos%3A%3ATeamHandleConcept)
     int team_size_recommended(const FunctorType& f, const ParallelReduceTag&) const;
     ```
     Query the recommended team size for the specific functor `f`. 
-    The tag denotes whether this is for a `parallel_for` or a `parallel_reduce`.
+    The tag denotes whether this is for a [`parallel_for`](../parallel_for) or a [`parallel_reduce`](../parallel_reduce).
     Note: this is not a static function! The function will take into account settings
     for vector length and scratch size of `*this`.
 
@@ -218,9 +217,9 @@ See also: [TeamMember](Kokkos%3A%3ATeamHandleConcept)
     ```
     This function returns the total scratch size requested. If `team_size` is not provided, the 
     team size for the calculation is used from the internal setting (i.e. the result of calling
-    `this->team_size()`). Otherwise the provided team size is used. 
+    `this->team_size()`). Otherwise, the provided team size is used. 
  
-    Returns: the value for the total scratch size size in bytes  in the specified scratch level.
+    Returns: the value for the total scratch size in bytes  in the specified scratch level.
 
   * ```c++
     int team_scratch_size(int level) const;
@@ -238,10 +237,10 @@ See also: [TeamMember](Kokkos%3A%3ATeamHandleConcept)
     Returns: the chunk size, set via `set_chunk_size()`.
 ## Examples
 
-  ```c++
-    TeamPolicy<> policy_1(N,AUTO);
-    TeamPolicy<Cuda> policy_2(N,T);
-    TeamPolicy<Schedule<Dynamic>, OpenMP> policy_3(N,AUTO,8);
-    TeamPolicy<IndexType<int>, Schedule<Dynamic>> policy_4(N,1,4);
-    TeamPolicy<OpenMP> policy_5(OpenMP(), N, AUTO);
-  ```
+```c++
+TeamPolicy<> policy_1(N,AUTO);
+TeamPolicy<Cuda> policy_2(N,T);
+TeamPolicy<Schedule<Dynamic>, OpenMP> policy_3(N,AUTO,8);
+TeamPolicy<IndexType<int>, Schedule<Dynamic>> policy_4(N,1,4);
+TeamPolicy<OpenMP> policy_5(OpenMP(), N, AUTO);
+```

--- a/source/API/core/policies/TeamThreadRange.md
+++ b/source/API/core/policies/TeamThreadRange.md
@@ -3,24 +3,24 @@
 Header File: `Kokkos_Core.hpp`
 
 Usage: 
-  ```c++
-    parallel_for(TeamThreadRange(team,range), [=] (int i) {...});
-    parallel_reduce(TeamThreadRange(team,begin,end), 
-      [=] (int i, double& lsum) {...},sum);
-  ```
+```c++
+parallel_for(TeamThreadRange(team,range), [=] (int i) {...});
+parallel_reduce(TeamThreadRange(team,begin,end), 
+  [=] (int i, double& lsum) {...},sum);
+```
 
-TeamThreadRange is a [nested execution policy](https://github.com/kokkos/kokkos/wiki/Execution-Policies#nested-execution-policies) used inside of hierarchical parallelism. 
+TeamThreadRange is a [nested execution policy](NestedPolicies) used inside hierarchical parallelism. 
 In contrast to global policies, the public interface for nested policies is implemented 
 as functions, in order to enable implicit templating on the execution space type via 
 the team handle.
 
 ## Synopsis 
-  ```c++
-   template<class TeamMemberType, class iType>
-    /* implementation defined */ TeamThreadRange(TeamMemberType team, iType count);
-   template<class TeamMemberType, class iType1, class iType2>
-    /* implementation defined */ TeamThreadRange(TeamMemberType team, iType1 begin, iType2 end);
-  ```
+```c++
+template<class TeamMemberType, class iType>
+/* implementation defined */ TeamThreadRange(TeamMemberType team, iType count);
+template<class TeamMemberType, class iType1, class iType2>
+/* implementation defined */ TeamThreadRange(TeamMemberType team, iType1 begin, iType2 end);
+```
 
 ## Description
 
@@ -37,7 +37,7 @@ the team handle.
         * Implementation defined type.
 
     *  **Requirements**
-        * `TeamMemberType` is a type that models [TeamHandle](Kokkos%3A%3ATeamHandleConcept)
+        * `TeamMemberType` is a type that models [TeamHandle](TeamHandleConcept)
         * `std::is_integral<iType>::value` is true.
         * Every member thread of `team` must call the operation in the same branch, i.e. it is not legal to have some 
           threads call this function in one branch, and the other threads of `team` call it in another branch.
@@ -58,7 +58,7 @@ the team handle.
 
     * **Requirements**
 
-        * `TeamMemberType` is a type that models [TeamHandle](Kokkos%3A%3ATeamHandleConcept)
+        * `TeamMemberType` is a type that models [TeamHandle](TeamHandleConcept)
         * `std::is_integral<iType1>::value` is true.
         * `std::is_integral<iType2>::value` is true.
         * Every member thread of `team` must call the operation in the same branch, i.e. it is not legal to have some
@@ -68,9 +68,9 @@ the team handle.
   
 ## Examples
 
-  ```c++
-   typedef TeamPolicy<>::member_type team_handle;
-   parallel_for(TeamPolicy<>(N,AUTO,4), KOKKOS_LAMBDA (const team_handle& team) {
+```c++
+typedef TeamPolicy<>::member_type team_handle;
+parallel_for(TeamPolicy<>(N,AUTO,4), KOKKOS_LAMBDA (const team_handle& team) {
      int n = team.league_rank();
      parallel_for(TeamThreadRange(team,M), [&] (const int& i) {
        A(n,i) = B(n) + i;
@@ -83,6 +83,6 @@ the team handle.
      single(PerTeam(team),[&] () {
        A_rowsum(n) += team_sum;
      });
-   });
-  ```
+});
+```
 

--- a/source/API/core/policies/TeamVectorRange.md
+++ b/source/API/core/policies/TeamVectorRange.md
@@ -3,24 +3,24 @@
 Header File: `Kokkos_Core.hpp`
 
 Usage: 
-  ```c++
-    parallel_for(TeamVectorRange(team,range), [=] (int i) {...});
-    parallel_reduce(TeamVectorRange(team,begin,end), 
-      [=] (int i, double& lsum) {...},sum);
-  ```
+```c++
+parallel_for(TeamVectorRange(team,range), [=] (int i) {...});
+parallel_reduce(TeamVectorRange(team,begin,end), 
+  [=] (int i, double& lsum) {...},sum);
+```
 
-TeamVectorRange is a [nested execution policy](https://github.com/kokkos/kokkos/wiki/Execution-Policies#nested-execution-policies) used inside of hierarchical parallelism. 
+TeamVectorRange is a [nested execution policy](NestedPolicies) used inside hierarchical parallelism. 
 In contrast to global policies, the public interface for nested policies is implemented 
 as functions, in order to enable implicit templating on the execution space type via 
 the team handle.
 
 ## Synopsis 
-  ```c++
-   template<class TeamMemberType, class iType>
-    /* implementation defined */ TeamVectorRange(TeamMemberType team, iType count);
-   template<class TeamMemberType, class iType1, class iType2>
-    /* implementation defined */ TeamVectorRange(TeamMemberType team, iType1 begin, iType2 end);
-  ```
+```c++
+template<class TeamMemberType, class iType>
+/* implementation defined */ TeamVectorRange(TeamMemberType team, iType count);
+template<class TeamMemberType, class iType1, class iType2>
+/* implementation defined */ TeamVectorRange(TeamMemberType team, iType1 begin, iType2 end);
+```
 
 ## Description
 
@@ -37,7 +37,7 @@ the team handle.
         * Implementation defined type.
 
     *  **Requirements**
-        * `TeamMemberType` is a type that models [TeamHandle](Kokkos%3A%3ATeamHandleConcept)
+        * `TeamMemberType` is a type that models [TeamHandle](TeamHandleConcept)
         * `std::is_integral<iType>::value` is true.
         * Every member thread of `team` must call the operation in the same branch, i.e. it is not legal to have some 
           threads call this function in one branch, and the other threads of `team` call it in another branch.
@@ -58,19 +58,18 @@ the team handle.
 
     * **Requirements**
 
-        * `TeamMemberType` is a type that models [TeamHandle](Kokkos%3A%3ATeamHandleConcept)
+        * `TeamMemberType` is a type that models [TeamHandle](TeamHandleConcept)
         * `std::is_integral<iType1>::value` is true.
         * `std::is_integral<iType2>::value` is true.
         * Every member thread of `team` must call the operation in the same branch, i.e. it is not legal to have some
           threads call this function in one branch, and the other threads of `team` call it in another branch..
         * `end >= begin ` is true;
 
-  
 ## Examples
 
-  ```c++
-   typedef TeamPolicy<>::member_type team_handle;
-   parallel_for(TeamPolicy<>(N,AUTO,4), KOKKOS_LAMBDA (const team_handle& team) {
+```c++
+typedef TeamPolicy<>::member_type team_handle;
+parallel_for(TeamPolicy<>(N,AUTO,4), KOKKOS_LAMBDA (const team_handle& team) {
      int n = team.league_rank();
      parallel_for(TeamVectorRange(team,M), [&] (const int& i) {
        A(n,i) = B(n) + i;
@@ -83,6 +82,5 @@ the team handle.
      single(PerTeam(team),[&] () {
        A_rowsum(n) += team_sum;
      });
-   });
-  ```
-
+});
+```

--- a/source/API/core/policies/ThreadVectorRange.md
+++ b/source/API/core/policies/ThreadVectorRange.md
@@ -3,26 +3,26 @@
 Header File: `Kokkos_Core.hpp`
 
 Usage: 
-  ```c++
-    parallel_for(ThreadVectorRange(team,range), [=] (int i) {...});
-    parallel_reduce(ThreadVectorRange(team,begin,end), 
-      [=] (int i, double& lsum) {...},sum);
-    parallel_scan(ThreadVectorRange(team,range), 
-      [=] (int i, double& lsum, bool final) {...});
-  ```
+```c++
+parallel_for(ThreadVectorRange(team,range), [=] (int i) {...});
+parallel_reduce(ThreadVectorRange(team,begin,end), 
+  [=] (int i, double& lsum) {...},sum);
+parallel_scan(ThreadVectorRange(team,range), 
+  [=] (int i, double& lsum, bool final) {...});
+```
 
-ThreadVectorRange is a [nested execution policy](https://github.com/kokkos/kokkos/wiki/Execution-Policies#nested-execution-policies) used inside of hierarchical parallelism. 
+ThreadVectorRange is a [nested execution policy](NestedPolicies) used inside hierarchical parallelism. 
 In contrast to global policies, the public interface for nested policies is implemented 
 as functions, in order to enable implicit templating on the execution space type via 
 the team handle.
 
 ## Synopsis 
-  ```c++
-   template<class TeamMemberType, class iType>
-    /* implementation defined */ ThreadVectorRange(TeamMemberType team, iType count);
-   template<class TeamMemberType, class iType1, class iType2>
-    /* implementation defined */ ThreadVectorRange(TeamMemberType team, iType1 begin, iType2 end);
-  ```
+```c++
+template<class TeamMemberType, class iType>
+/* implementation defined */ ThreadVectorRange(TeamMemberType team, iType count);
+template<class TeamMemberType, class iType1, class iType2>
+/* implementation defined */ ThreadVectorRange(TeamMemberType team, iType1 begin, iType2 end);
+```
 
 ## Description
 
@@ -39,11 +39,10 @@ the team handle.
         * Implementation defined type.
 
     *  **Requirements**
-        * `TeamMemberType` is a type that models [TeamHandle](Kokkos%3A%3ATeamHandleConcept)
+        * `TeamMemberType` is a type that models [TeamHandle](TeamHandleConcept)
         * `std::is_integral<iType>::value` is true.
         * `count >= 0 ` is true;
-        * This function can not be called inside a parallel operation dispatched using a
-          `TeamVectorRange` policy or `ThreadVectorRange` policy.
+        * This function can not be called inside a parallel operation dispatched using a [`TeamVectorRange`](TeamVectorRange) policy or `ThreadVectorRange` policy.
  
  * ```c++
    template<class TeamMemberType, class iType1, class iType2>
@@ -60,42 +59,40 @@ the team handle.
 
     * **Requirements**
 
-        * `TeamMemberType` is a type that models [TeamHandle](Kokkos%3A%3ATeamHandleConcept)
+        * `TeamMemberType` is a type that models [TeamHandle](TeamHandleConcept)
         * `std::is_integral<iType1>::value` is true.
         * `std::is_integral<iType2>::value` is true.
         * `end >= begin ` is true;
-        * This function can not be called inside a parallel operation dispatched using a
-          `TeamVectorRange` policy or `ThreadVectorRange` policy.
+        * This function can not be called inside a parallel operation dispatched using a [`TeamVectorRange`](TeamVectorRange) policy or `ThreadVectorRange` policy.
 
   
 ## Examples
 
-  ```c++
-   typedef TeamPolicy<>::member_type team_handle;
-   parallel_for(TeamPolicy<>(N,AUTO,4), KOKKOS_LAMBDA (const team_handle& team) {
-     int n = team.league_rank();
-     parallel_for(TeamThreadRange(team,M), [&] (const int i) {
-       parallel_for(ThreadVectorRange(team,K), [&] (const int j) {
-         A(n,i,j) = B(n,i) + j;
-       });
-     });
-     team.team_barrier();
-     int team_sum;
-     parallel_reduce(TeamThreadRange(team,M), [&] (const int& i, int& threadsum) {
-       int tsum = 0;
-       parallel_reduce(ThreadVectorRange(team,M), [&] (const int& j, int& lsum) {
-         lsum += A(n,i,j);
-       },tsum);
-       single(PerThread(team),[&] () {
-         threadsum += tsum;
-       });
-     },team_sum);
-       
-       lsum += A(n,i);
-     },team_sum);
-     single(PerTeam(team),[&] () {
-       A_rowsum(n) += team_sum;
-     });
+```c++
+typedef TeamPolicy<>::member_type team_handle;
+parallel_for(TeamPolicy<>(N,AUTO,4), KOKKOS_LAMBDA (const team_handle& team) {
+ int n = team.league_rank();
+ parallel_for(TeamThreadRange(team,M), [&] (const int i) {
+   parallel_for(ThreadVectorRange(team,K), [&] (const int j) {
+     A(n,i,j) = B(n,i) + j;
    });
-  ```
-
+ });
+ team.team_barrier();
+ int team_sum;
+ parallel_reduce(TeamThreadRange(team,M), [&] (const int& i, int& threadsum) {
+   int tsum = 0;
+   parallel_reduce(ThreadVectorRange(team,M), [&] (const int& j, int& lsum) {
+     lsum += A(n,i,j);
+   },tsum);
+   single(PerThread(team),[&] () {
+     threadsum += tsum;
+   });
+ },team_sum);
+   
+   lsum += A(n,i);
+ },team_sum);
+ single(PerTeam(team),[&] () {
+   A_rowsum(n) += team_sum;
+ });
+});
+```


### PR DESCRIPTION
### THIS PR:
- fixed warning, removed blank lines and added ExecutionPolicyConcept, MDRangePolicy, NestedPolicies in Execution-Policies.rst
- fixed links in ExecutionPolicyConcept and added missing to API/core/policies
- fixed indentation, formatted in NestedPolicies and added missing to API/core/policies
- removed doubled text, fixed headings and fixed indentation in TeamHandleConcept and added missing to API/core/policies
- fixed indentation, grammar and removed blank lines in MDRangePolicy.md
- removed blank lines and fixed indentation in RangePolicy.md
- fixed links, fixed indentation, removed blank lines and fixed grammar in TeamPolicy.md
- fixed indentation and fixed links in TeamThreadRange.md
- fixed grammar, indentation, removed blank lines and fixed links in TeamVectorRange.md
- fixed links and grammar and fixed indentation in ThreadVectorRange.md