### PR TITLE
#32: Fix API core

### DIFF
--- a/source/API/core/CStyleMemManagement.md
+++ b/source/API/core/CStyleMemManagement.md
@@ -1,7 +1,6 @@
-
 # C-style memory management
 
-
+(kokkos_malloc)=
 ## `Kokkos::kokkos_malloc`
 
 Defined in header `<Kokkos_Core.hpp>`
@@ -16,7 +15,7 @@ template <class MemorySpace = typename Kokkos::DefaultExecutionSpace::memory_spa
 void* kokkos_malloc(size_t size);
 ```
 
-Allocate `size` bytes of uninitialized storage on the specified memory space `MemorySpace` plus some extra space for meta data such as the label.
+Allocate `size` bytes of uninitialized storage on the specified memory space [`MemorySpace`](memory_spaces) plus some extra space for metadata such as the label.
 
 If allocation succeeds, returns a pointer to the lowest (first) byte in the allocated memory block that is suitably aligned for any scalar type.
 
@@ -34,16 +33,15 @@ If allocation fails, an exception of type `Kokkos::Experimental::RawMemoryAlloca
 ### Return value
 
 On success, returns the pointer to the beginning of newly allocated memory.
-To avoid a memory leak, the returned pointer must be deallocated with [`Kokkos::kokkos_free()`](Kokkos%3A%3Akokkos_free) or [`Kokkos::realloc()`](Kokkos%3A%3Akokkos_realloc).
+To avoid a memory leak, the returned pointer must be deallocated with [`Kokkos::kokkos_free()`](kokkos_free) or [`Kokkos::realloc()`](kokkos_realloc).
 
 ### Exceptions
 
 On failure, throws `Kokkos::Experimental::RawMemoryAllocationFailure`.
 
-
 <br/>
 
-
+(kokkos_realloc)=
 ## `Kokkos::kokkos_realloc`
 
 Defined in header `<Kokkos_Core.hpp>`
@@ -53,7 +51,7 @@ template <class MemorySpace = typename Kokkos::DefaultExecutionSpace::memory_spa
 void* kokkos_realloc(void* ptr, size_t new_size);
 ```
 
-Reallocates the given area of memory. It must be previously allocated by [`Kokkos::kokkos_malloc()`](Kokkos%3A%3Akokkos_malloc) or [`Kokkos::kokkos_realloc()`](Kokkos%3A%3Akokkos_realloc) on the same memory space `MemorySpace` and not yet freed with [`Kokkos::kokkos_free()`](Kokkos%3A%3Akokkos_free), otherwise, the results are undefined.
+Reallocates the given area of memory. It must be previously allocated by [`Kokkos::kokkos_malloc()`](kokkos_malloc) or [`Kokkos::kokkos_realloc()`](kokkos_realloc) on the same memory space [`MemorySpace`](memory_spaces) and not yet freed with [`Kokkos::kokkos_free()`](kokkos_free), otherwise, the results are undefined.
 
 ### Parameters
 
@@ -66,18 +64,17 @@ Reallocates the given area of memory. It must be previously allocated by [`Kokko
 
 ### Return value
 
-On success, returns a pointer to the beginning of the newly allocated memory. To avoid a memory leak, the returned pointer must be deallocated with [`Kokkos::kokkos_free()`](Kokkos%3A%3Akokkos_free), the original pointer `ptr` is invalidated and any access to it is undefined behavior (even if reallocation was in-place).
+On success, returns a pointer to the beginning of the newly allocated memory. To avoid a memory leak, the returned pointer must be deallocated with [`Kokkos::kokkos_free()`](kokkos_free), the original pointer `ptr` is invalidated and any access to it is undefined behavior (even if reallocation was in-place).
 
-On failure, returns a null pointer. The original pointer ptr remains valid and may need to be deallocated with [`Kokkos::kokkos_free()`](Kokkos%3A%3Akokkos_free).
+On failure, returns a null pointer. The original pointer ptr remains valid and may need to be deallocated with [`Kokkos::kokkos_free()`](kokkos_free).
 
 ### Exceptions
 
 On failure, throws `Kokkos::Experimental::RawMemoryAllocationFailure`.
 
-
 <br/>
 
-
+(kokkos_free)=
 ## `Kokkos::kokkos_free`
 
 Defined in header `<Kokkos_Core.hpp>`
@@ -87,7 +84,7 @@ template <class MemorySpace = typename Kokkos::DefaultExecutionSpace::memory_spa
 void kokkos_free(void* ptr);
 ```
 
-Deallocates the space previously allocated by [`Kokkos::kokkos_malloc()`](Kokkos%3A%3Akokkos_malloc) or [`Kokkos::kokkos_realloc()`](Kokkos%3A%3Akokkos_realloc) on the specified memory space `MemorySpace`.
+Deallocates the space previously allocated by [`Kokkos::kokkos_malloc()`](kokkos_malloc) or [`Kokkos::kokkos_realloc()`](kokkos_realloc) on the specified memory space `MemorySpace`.
 
 If `ptr` is a null pointer, the function does nothing.
 

--- a/source/API/core/Initialize-and-Finalize.rst
+++ b/source/API/core/Initialize-and-Finalize.rst
@@ -6,7 +6,7 @@ Kokkos::initialize
 
 Initializes Kokkos internal objects and all enabled Kokkos backends.
 
-See [Kokkos::initialize](Kokkos%3A%3Ainitialize) for details.
+See `Kokkos::initialize <initialize_finalize/initialize.html>`_ for details.
 
 
 Kokkos::finalize
@@ -14,15 +14,15 @@ Kokkos::finalize
 
 Shutdown Kokkos initialized execution spaces and release internally managed resources.
 
-See [Kokkos::finalize](Kokkos%3A%3Afinalize) for details.
+See `Kokkos::finalize <initialize_finalize/finalize.html>`_ for details.
 
 
 Kokkos::ScopeGuard
 ------------------
 
-`Kokkos::ScopeGuard` is a class which aggregates the resources managed by Kokkos.  ScopeGuard will call `Kokkos::initialize` when constructed and `Kokkos::finalize` when destructed, thus the Kokkos context is automatically managed via the scope of the ScopeGuard object.
+`Kokkos::ScopeGuard` is a class which aggregates the resources managed by Kokkos. ScopeGuard will call `Kokkos::initialize` when constructed and `Kokkos::finalize` when destructed, thus the Kokkos context is automatically managed via the scope of the ScopeGuard object.
 
-See [Kokkos::ScopeGuard](Kokkos%3A%3AScopeGuard) for details.
+See `Kokkos::ScopeGuard <initialize_finalize/ScopeGuard.html>`_ for details.
 
 ScopeGuard aids in the following common mistake which is allowing Kokkos objects to live past `Kokkos::finalize`:
 
@@ -55,3 +55,4 @@ In the above example, `my_view` will not go out of scope until the end of the ma
 
    ./initialize_finalize/initialize
    ./initialize_finalize/finalize
+   ./initialize_finalize/ScopeGuard

--- a/source/API/core/KokkosConcepts.md
+++ b/source/API/core/KokkosConcepts.md
@@ -1,0 +1,292 @@
+# Kokkos Concepts
+
+## Introduction
+
+Kokkos has been using concept-driven design essentially since its inception.  Until recently, there has been no readily-available mechanism for expressing these concepts in code.  (In fact, there hasn't really even been a generally agreed-upon approach to *documenting* concepts.)  With the merging of C++ Concepts as a language feature into the working draft, their implementation in multiple compilers, and the acceptance of the first concept-driven library feature, ranges, into the standard, it is time to consider formally specifying and documenting the concepts Kokkos uses in generic code.  Beyond this, the recent rapid expansion in (and corresponding demand for) new Kokkos backends makes the lack of a hardened, formal specification for basic Kokkos concepts more acute than ever.  With several new backend projects on the near horizon—SYCL, resilience, and HPX, just to name a few—now is the best time to formalize the core concepts in Kokkos so that we can begin to iteratively harden the concept set that Kokkos uses in generic code.  Additionally, since the promotion to Kokkos 3.0 includes a plan to deprecate many non-general features of certain execution spaces, now is a good time to take a more holistic approach to the execution space concept and the concepts it interacts with.
+
+## Approach
+
+In addition to the experience we have garnered over the past several years of participation in the ISO-C++ executor specification effort, we should use the approach in "Design of Concept Libraries for C++" (2011) by Sutton and Stroustrup as a guide.  In particular, we should design based on the *concepts = constraints + axioms* philosophy, which focuses on balancing flexibility of use with ease of learning.  This is not far from the design philosophy we already take—for instance, we don't really have separate "concepts" for the range policies given to `parallel_for` and `parallel_reduce`, even though a pure constraints-based approach may not see a need to make these two the same (the algorithms do very slightly different things with them, after all).  By combining constraints sets that are "similar enough" (as we always have done in the past), we can maintain the flexibility we need while minimizing cognitive load on users.
+
+## Overview
+
+When it comes to cognitive load, perhaps even more important than limiting the total number of concepts is limiting the number of *subsumption hierarchies* of concepts.  Experience with C++ ranges has also shown that limiting the branching width of these hierarchies increases ease of learning.  Roughly speaking and from a high-level perspective, the major user-visible concept hierarchies that Kokkos currently uses are:
+
+* [`ExecutionSpace`](execution_spaces)
+* [`MemorySpace`](memory_spaces)
+* [`ExecutionPolicy`](Execution-Policies) (includes, for instance, [`RangePolicy`](policies/RangePolicy))
+* [`TeamMember`](policies/TeamHandleConcept)
+* `Functor`
+
+Some minor hierarchies include:
+
+* `MemoryLayout`
+* `Reducer`
+* `TaskScheduler`
+
+Some things currently being treated as concepts (according to `Kokkos_Concepts.hpp`) that are really more like enumerations (or something similar) are:
+
+* `MemoryTraits`
+* Several things used only with execution policies:
+    * `Schedule`
+    * The `IndexType<>` tag
+    * The `LaunchBounds<>` tag
+    * `IterationPattern` (a.k.a. `Kokkos::Iterate`)
+
+There is also some question as to whether [`Kokkos::View`](view/view) (and friends) should be presented as a concept rather than just a class template, given the existence of act-alike class templates such as `DualView` and `OffsetView` external to Kokkos.   
+
+## The `ExecutionSpace` Concept
+
+Working off the functionality currently common to `Serial`, `Cuda`, `OpenMP`, `Threads`, `ROCm`, and `OpenMPTarget`, the current state of the Kokkos [`ExeuctionSpace`](ExecutionSpaceConcept) concept looks something like:
+
+```c++
+template <typename Ex>
+concept ExecutionSpace =
+  CopyConstructible<Ex> &&
+  DefaultConstructible<Ex> &&
+  Destructible<Ex> &&
+  // Member type requirements:
+  requires() {
+    typename Ex::execution_space;
+    std::is_same_v<Ex, typename Ex::execution_space>;
+    typename Ex::memory_space;
+    is_memory_space<typename Ex::memory_space>::value;
+    typename Ex::size_type;
+    std::is_integral_v<typename Ex::size_type>;
+    typename Ex::array_layout;
+    is_array_layout<typename Ex::array_layout>::value;
+    typename Ex::scratch_memory_space;
+    is_memory_space<typename Ex::scratch_memory_space>::value;
+    typename Ex::device_type;
+  } &&
+  // Required methods:
+  requires(Ex ex, std::ostream& ostr, bool detail) {
+    { ex.in_parallel() } -> bool;
+    { ex.fence() };
+    { ex.name() } -> const char*;
+    { ex.print_configuration(ostr) };
+    { ex.print_configuration(ostr, detail) };
+  } &&
+```
+
+Where we've extrapolated from the recent progress on execution space instances that many methods currently implemented as static methods eventually need only be instance methods in the general case.
+
+### Implementation Requirements
+
+Further requirements cannot be expressed without additional types constrained by additional concepts (this is a well-known limitation of the concepts mechanism in C++, and is necessary to preserve decidability of the type system).  Though some argue for using an archetype pattern to get around this (whereby an archetype with an implementation-private name designed to meet the requirements of the extra concept is used in the definition of constraints), the state of practice appears to be converging on a strategy that involves creating an additional named concept templated on all relevant types and constraining them together, which can then be used at relevant call site.  Most argue that this is a necessary artifact of the language feature, but that constraining concepts together in this way does not count as an "extra" concept for the purposes of cognitive load assessment.  Applying this approach and assuming the intention is for things like [`Kokkos::parallel_for`](parallel_for) to remain as algorithms rather than customization points, we get some further requirements from the `Kokkos::Impl` namespace:
+
+```c++
+template <typename Ex, typename ExPol, typename F, typename ResultType = int>
+concept ExecutionSpaceOf =
+  ExecutionSpace<Ex> &&
+  ExecutionPolicyOf<ExPol, Ex> && // defined below
+  Functor<F> && // defined below
+  // Requirements imposed by Kokkos_Parallel.hpp
+  requires(Ex ex, ExPol const& policy, F f, ResultType& total) {
+    // This is technically not exactly correct, since an rvalue reference qualified
+    // execute() method would meet these requirements and wouldn't work with Kokkos,
+    // but for brevity:
+    { Impl::ParallelFor<F, ExPol, Ex>(f, policy).execute(); }
+    { Impl::ParallelScan<F, ExPol, Ex>(f, policy).execute(); }
+    { Impl::ParallelScanWithTotal<F, ExPol, Ex>(f, policy, total).execute(); }
+  }
+
+template <typename Ex, typename ExPol, typename F, typename Red>
+concept ExecutionSpaceOfReduction =
+  ExecutionSpaceOf<Ex, ExPol, F> &&
+  Reducer<Red> &&
+  // Requirements imposed by Kokkos_Parallel_Reduce.hpp
+  requires(
+    Ex ex, ExPol const& policy, F f, Red red,
+    Impl::ParallelReduce<F, ExPol, Red, Ex>& closure
+  ) {
+    { Impl::ParallelReduce<F, ExPol, Red, Ex>(f, policy); }
+    { closure.execute(); }
+  }
+```
+
+Perhaps, though, these should be part of some internal concepts (`ImplExecutionSpaceOf`, for instance) and the user-visible concept should exclude these requirements.
+
+Support for `UniqueToken` adds the following requirements:
+
+```c++
+template <typename Ex>
+concept UniqueTokenExecutionSpace =
+  requires(
+    Experimental::UniqueToken<Ex, Experimental::UniqueTokenScope::Instance> const& itok,
+    Experimental::UniqueToken<Ex, Experimental::UniqueTokenScope::Global> const& gtok,
+    typename Ex::size_type size
+  ) {
+    typename Experimental::UniqueToken<Ex, Experimental::UniqueTokenScope::Global>::size_type;
+    std::is_same_v<Ex, typename Experimental::UniqueToken<Ex, Experimental::UniqueTokenScope::Global>::execution_space>;
+    { itok.size() } -> typename Ex::size_type;
+    { gtok.size() } -> typename Ex::size_type;
+    { itok.acquire() } -> typename Ex::size_type;
+    { gtok.acquire() } -> typename Ex::size_type;
+    { itok.release(size) };
+    { gtok.release(size) };
+  }
+  && CopyConstructible<Experimental::UniqueToken<Ex, Experimental::UniqueTokenScope::Instance>>
+  && DefaultConstructible<Experimental::UniqueToken<Ex, Experimental::UniqueTokenScope::Instance>>
+  && CopyConstructible<Experimental::UniqueToken<Ex, Experimental::UniqueTokenScope::Global>>
+  && DefaultConstructible<Experimental::UniqueToken<Ex, Experimental::UniqueTokenScope::Global>>;
+```
+
+### An Additional Concept for `DeviceExecutionSpace`?
+
+All the device execution spaces, in their current state, have two extra member functions, `sleep()` and `wake()`.  It's unclear whether this is intended to be general, but if it is, there is an additional concept in the hierarchy:
+
+```c++
+template <typename Ex>
+concept DeviceExecutionSpace =
+  ExecutionSpace<Ex> &&
+  requires(Ex ex) {
+    { ex.sleep() };
+    { ex.wake() };
+  }
+```
+
+### Some *de facto* Requirements
+
+There are other places where we're providing partial specializations using concrete execution spaces, such as `Impl::TeamPolicyInternal`.  These also qualify as "requirements" on an `ExecutionSpace`, just like `Impl::ParallelFor<...>`.  In many of these cases, it would be nice if we could refactor some things to use a less "all-or-nothing" approach to customization than partial class template specialization.
+
+### Design Thoughts
+
+The first thing that comes to mind is that `CopyConstructible<T> && DefaultConstructible<T> && Destructible<T>` is very close to `SemiRegular<T>`; all we need to do is add `operator==()`.
+
+TODO more here
+
+
+## The `MemorySpace` Concept
+
+Looking at the common functionality in the current implementations of `CudaSpace`, `CudaUVMSpace`, `HostSpace`, `OpenMPTargetSpace`, and `HBWSpace`, the current concept for `MemorySpace` looks something like:
+
+```c++
+template <typename Mem>
+concept MemorySpace =
+  CopyConstructible<Mem> &&
+  DefaultConstructible<Mem> &&
+  Destructible<Mem> &&
+  // Member type requirements:
+  requires() {
+    std::is_same_v<Mem, typename Mem::memory_space>;
+    Kokkos::is_execution_space<typename Mem::execution_space>::value;
+    typename Mem::device_type;
+  }
+  // Required methods:
+  requires(Mem m, size_t size, void* ptr) {
+    { m.name() } -> const char*;
+    { m.allocate(size) } -> void*;
+    { m.deallocate(ptr, size) };
+  };
+```
+
+### Implementation Requirements
+
+Most of the ways that the `MemorySpace` concept is used in generic contexts by Kokkos are in the `Impl` namespace.  
+
+```c++
+template <typename Mem>
+concept ImplMemorySpace =
+  MemorySpace<Mem> &&
+  DefaultConstructible<Impl::SharedAllocationRecord<Mem, void>> &&
+  Destructible<Impl::SharedAllocationRecord<Mem, void>>
+  requires(
+    Mem mem, std::string label, size_t size,
+    void* ptr, std::ostream& ostr, bool detail,
+    Impl::SharedAllocationRecord<Mem, void> record,
+    void (*dealloc)(Impl::SharedAllocationRecord<void, void>*)
+  ) {
+    { Impl::SharedAllocationRecord<Mem, void>(mem, label, size) };
+    { Impl::SharedAllocationRecord<Mem, void>(mem, label, size, dealloc) };
+    { record.get_label() } -> std::string;
+    { Impl::SharedAllocationRecord<Mem, void>::allocate_tracked(mem, label, size) } 
+      -> void*;
+    { Impl::SharedAllocationRecord<Mem, void>::reallocate_tracked(ptr, size) }
+      -> void*;
+    { Impl::SharedAllocationRecord<Mem, void>::deallocate_tracked(ptr) };
+    { Impl::SharedAllocationRecord<Mem, void>::print_records(ostr, mem) };
+    { Impl::SharedAllocationRecord<Mem, void>::print_records(ostr, mem, detail) };
+    { Impl::SharedAllocationRecord<Mem, void>::get_record(ptr) }
+      -> Impl::SharedAllocationRecord<Mem, void>*
+  };
+
+template <typename Mem1, typename Mem2, typename Ex>
+concept ImplRelatableMemorySpaces =
+  ImplMemorySpace<Mem1> &&
+  ImplMemorySpace<Mem2> &&
+  ExecutionSpace<Ex> &&
+  requires(const void* ptr) {
+    { Impl::MemorySpaceAccess<Mem1, Mem2>::assignable } -> bool;
+    { Impl::MemorySpaceAccess<Mem1, Mem2>::accessible } -> bool;
+    { Impl::MemorySpaceAccess<Mem1, Mem2>::deepcopy } -> bool;
+    { Impl::VerifyExecutionCanAccessMemorySpace<Mem1, Mem2>::value } -> bool;
+    { Impl::VerifyExecutionCanAccessMemorySpace<Mem1, Mem2>::verify() };
+    { Impl::VerifyExecutionCanAccessMemorySpace<Mem1, Mem2>::verify(ptr) };
+  } &&
+  requires(Ex ex, void* dst, const void* src, size_t n) {
+    { Impl::DeepCopy<Mem1, Mem2, Ex>(dst, src, n) };
+    { Impl::DeepCopy<Mem1, Mem2, Ex>(exec, dst, src, n) };
+  }
+```
+
+
+## The `ExecutionPolicy` Concept
+
+This is where I think we have the most work to do.  We could achieve a significant complexity reduction by unifying disparate interfaces for, e.g., `RangePolicy<...>` and `ThreadVectorRange<...>`, into one hierarchy.
+
+Looking at the current implementations of `RangePolicy<...>`, `MDRangePolicy<...>`, `TeamPolicy`, `Impl::TeamThreadRangeBoundariesStruct`, and `Impl::TeamVectorRangeBoundariesStruct`, all that I can find in common is: 
+
+```c++
+template <typename ExPol>
+concept BasicExecutionPolicy =
+  CopyConstructible<ExPol> &&
+  Destructible<ExPol> &&
+  requires(ExPol ex) {
+    ExPol::index_type;      
+  }
+```
+
+That is, of course, not a useful concept.  If we exclude `Impl::TeamThreadRangeBoundariesStruct` and `Impl::TeamVectorRangeBoundariesStruct`, we get the tag also:
+
+```c++
+template <typename ExPol>
+concept ExecutionPolicy =
+  BasicExecutionPolicy<ExPol> &&
+  requires(ExPol ex) {
+    std::is_same_v<ExPol, typename ExPol::execution_policy>;
+  }
+```
+
+which indicates that the policies that can be given to parallel algorithms inside of other algorithms weren't intended to be part of the same concept as the others (though I would argue maybe they should).  `TeamPolicy` and `RangePolicy` both have functions for managing chunk sizes:
+
+```c++
+template <typename ExPol>
+concept ChunkedExecutionPolicy =
+  ExecutionPolicy<ExPol> &&
+  requires(ExPol ex, typename ExPol::index_type size) {
+    { ex.chunk_size() } -> typename ExPol::index_type;
+    { ex.set_chunk_size(size) } -> ExPol&
+  }
+```
+
+Chunk size is, of course, a bit more complicated with `MDRangePolicy`, but the generalization to chunks in each dimension is pretty straightforward, so we could unify concepts a bit here.  The `IterateTile` abstraction is pretty nice, and seems like it could unify these concepts to reduce the amount of duplicate code in places like `impl/Kokkos_OpenMP_Parallel.hpp`.
+
+It would be nice if there were some way to reduce the conceptual surface area by allowing users to think of a `RangePolicy` as a special case of `MDRangePolicy` with rank of 1, and to allow users to think of `RangePolicy` as a special case of `TeamPolicy` with `N` teams of size 1 each.  Of course, we'd still provide the current interface as a shortcut, and would probably teach it the current way, but when users advance to the point where they're using all of these, it would be nice to have them think about one thing with two different axes rather than three different things.
+
+Finally, it's not entirely clear to me why we need separate concepts for `TeamThreadRange` and `ThreadVectorRange`.  In my mind, multiple levels of nested parallelism is just another axis along which to extend the execution policy concept, and it's not clear to me why we need to use up extra conceptual overhead to describe specific points in that hierarchy.  (Again, I don't have any objections to the names specifically, just the extra cognitive load.)
+
+It's entirely possible that there isn't significant simplification to be made here.  Maybe the current separation of concerns is the simplest possible.  But as long as we're looking at hardening Kokkos concepts, we should at least explore this space.
+
+
+## The `TeamMember` Concept
+
+TODO
+
+## The `Functor` Concept
+
+TODO
+
+## A Note on Implementation Delegation
+
+TODO

--- a/source/API/core/ParallelForTag.md
+++ b/source/API/core/ParallelForTag.md
@@ -1,0 +1,34 @@
+# `ParallelForTag()`
+
+Header File: `Kokkos_ExecPolicy.hpp`
+
+A tag used in team size calculation functions to indicate that the functor for which a team size is being requested is being used in a [`parallel_for`](parallel_for)
+
+Usage: 
+```c++
+using PolicyType = Kokkos::TeamPolicy<>; 
+PolicyType policy;
+int recommended_team_size = policy.team_size_recommended(
+  Functor, Kokkos::ParallelForTag());
+```
+
+## Synopsis 
+```c++
+struct ParallelForTag{};
+```
+
+## Public Class Members
+
+  None
+
+### Typedefs
+   
+ None
+
+### Constructors
+ 
+ Default
+
+### Functions
+
+ None

--- a/source/API/core/ParallelReduceTag.md
+++ b/source/API/core/ParallelReduceTag.md
@@ -1,0 +1,34 @@
+# `ParallelReduceTag()`
+
+Header File: `Kokkos_ExecPolicy.hpp`
+
+A tag used in team size calculation functions to indicate that the functor for which a team size is being requested is being used in a [`parallel_reduce`](parallel_reduce)
+
+Usage: 
+```c++
+using PolicyType = Kokkos::TeamPolicy<>; 
+PolicyType policy;
+int recommended_team_size = policy.team_size_recommended(
+  Functor, Kokkos::ParallelReduceTag());
+```
+
+## Synopsis 
+```c++
+struct ParallelReduceTag{};
+```
+
+## Public Class Members
+
+ None
+
+### Typedefs
+   
+ None
+
+### Constructors
+ 
+ Default
+
+### Functions
+
+ None

--- a/source/API/core/ParallelScanTag.md
+++ b/source/API/core/ParallelScanTag.md
@@ -1,0 +1,34 @@
+# `ParallelScanTag()`
+
+Header File: `Kokkos_ExecPolicy.hpp`
+
+A tag used in team size calculation functions to indicate that the functor for which a team size is being requested is being used in a [`parallel_scan`](parallel_scan)
+
+Usage: 
+```c++
+using PolicyType = Kokkos::TeamPolicy<>; 
+PolicyType policy;
+int recommended_team_size = policy.team_size_recommended(
+  Functor, Kokkos::ParallelScanTag());
+```
+
+## Synopsis 
+```c++
+struct ParallelScanTag{};
+```
+
+## Public Class Members
+
+  None
+
+### Typedefs
+   
+ None
+
+### Constructors
+ 
+ Default
+
+### Functions
+
+ None

--- a/source/API/core/STL-Compatibility.rst
+++ b/source/API/core/STL-Compatibility.rst
@@ -1,12 +1,13 @@
-
-
 STL Compatibility Issues
 ========================
 
-Kokkos developers strive to implement the Kokkos macros in a manner compatible with the latest versions of the C++ language and with the C++ Standard Library (STL). However deviations from this approach occur when necessary, as is the case for the following STL classes (std::*). The STL class does not work properly on GPUs so parallel Kokkos classes have been developed. This section documents the specific deviations and provides usage guidance for developers. Select the links below to see the details.
+Kokkos developers strive to implement the Kokkos macros in a manner compatible with the latest versions of the
+C++ language and with the C++ Standard Library (STL). However deviations from this approach occur when necessary,
+as is the case for the following STL classes `(std::*)`. The STL class does not work properly on GPUs so parallel Kokkos
+classes have been developed. This section documents the specific deviations and provides usage guidance for developers.
+Select the links below to see the details.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    ./stl-compat/pair
-   .. ./stl-compat/array

--- a/source/API/core/SpaceAccessibility.md
+++ b/source/API/core/SpaceAccessibility.md
@@ -1,7 +1,6 @@
-
 # Space Accessibility
 
-`Kokkos::SpaceAccessibility<>` is a traits class template that takes an [`ExecutionSpace` type](ExecutionSpaceConcept) or [`MemorySpace` type](MemorySpaceConcept) as the first template argument and a `MemorySpace` type as the second type and expresses details about the relationship between those entities.  Given memory space types `MSp1` and `MSp2` and an execution space type `Ex`, the following expressions will be valid with the specified meaning:
+`Kokkos::SpaceAccessibility<>` is a traits class template that takes an [`ExecutionSpace` type](ExecutionSpaceConcept) or [`MemorySpace` type](MemorySpaceConcept) as the first template argument and a [`MemorySpace`](MemorySpaceConcept) type as the second type and expresses details about the relationship between those entities.  Given memory space types `MSp1` and `MSp2` and an execution space type `Ex`, the following expressions will be valid with the specified meaning:
 
 ---
 
@@ -25,7 +24,7 @@ Equivalent to `Kokkos::SpaceAccessibility<MSp1::execution_space, MSp2>::accessib
 Kokkos::SpaceAccessibility<MSp1, MSp2>::assignable
 ```
 
-A compile-time value convertible to `bool` guaranteed to be `true` if and only if it is valid within the Kokkos programming model to assign values from  any (otherwise valid) instance of `Kokkos::View` type `V2` (with `std::is_same<V2::memory_space, MSp2>::value` equal to `true`) to references retrieved from any (otherwise valid) instance of a `View` type `V1` (with `std::is_same<V1::memory_space, MSp1>::value` equal to `true`).
+A compile-time value convertible to `bool` guaranteed to be `true` if and only if it is valid within the Kokkos programming model to assign values from  any (otherwise valid) instance of [`Kokkos::View`](view/view) type `V2` (with `std::is_same<V2::memory_space, MSp2>::value` equal to `true`) to references retrieved from any (otherwise valid) instance of a `View` type `V1` (with `std::is_same<V1::memory_space, MSp1>::value` equal to `true`).
 
 ---
 
@@ -35,14 +34,13 @@ Kokkos::SpaceAccessibility<Ex, MSp1>::assignable
 
 Equivalent to `Kokkos::SpaceAccessibility<Ex::memory_space, MSp1>::assignable`.
 
-
 ---
 
 ```c++
 Kokkos::SpaceAccessibility<MSp1, MSp2>::deepcopy
 ```
 
-A compile-time value convertible to `bool` guaranteed to be `true` if and only if it is valid within the Kokkos programming model to [`Kokkos::deep_copy`](Kokkos%3A%3Adeep_copy) from any (otherwise valid) instance of `Kokkos::View` type `V2` (with `std::is_same<V2::memory_space, MSp2>::value` equal to `true`) to any (otherwise valid and otherwise compatible) instance of a `View` type `V1` (with `std::is_same<V1::memory_space, MSp1>::value` equal to `true`).  In other words, if `v2` is a valid instance of `V2` and `v1` is a valid instance of `V1` (with shape and other attributes otherwise compatible with `v2`), the following expression will be well-defined and valid in the Kokkos programming model:
+A compile-time value convertible to `bool` guaranteed to be `true` if and only if it is valid within the Kokkos programming model to [`Kokkos::deep_copy`](view/deep_copy) from any (otherwise valid) instance of [`Kokkos::View`](view/view) type `V2` (with `std::is_same<V2::memory_space, MSp2>::value` equal to `true`) to any (otherwise valid and otherwise compatible) instance of a `View` type `V1` (with `std::is_same<V1::memory_space, MSp1>::value` equal to `true`).  In other words, if `v2` is a valid instance of `V2` and `v1` is a valid instance of `V1` (with shape and other attributes otherwise compatible with `v2`), the following expression will be well-defined and valid in the Kokkos programming model:
 
 ```c++
 Kokkos::deep_copy(v1, v2);
@@ -56,18 +54,15 @@ Kokkos::SpaceAccessibility<Ex, MSp1>::deepcopy
 
 Equivalent to `Kokkos::SpaceAccessibility<Ex::memory_space, MSp1>::deepcopy`.
 
-
 ---
 
-
 Additionally, the following nested type names will be defined:
-
 
 ```c++
 Kokkos::SpaceAccessibility<Ex, MSp1>::space
 ```
 
-An "intercessory" memory space that should be used to deep copy memory for access by any instance of `Ex`.  Formally, a type meeting the [requirements of `Kokkos::Device`](Kokkos%3A%3ADevice) with the following expressions all `true` at compile-time:
+An "intercessory" memory space that should be used to deep copy memory for access by any instance of `Ex`.  Formally, a type meeting the requirements of `Kokkos::Device` with the following expressions all `true` at compile-time:
 
 - `Kokkos::SpaceAccessibility<Ex, Kokkos::SpaceAccessibility<Ex, MSp1>::space::memory_space>::accessible`
 - `Kokkos::SpaceAccessibility<Kokkos::SpaceAccessibility<Ex, MSp1>::space::memory_space, MSp1>::deepcopy`

--- a/source/API/core/Task-Parallelism.md
+++ b/source/API/core/Task-Parallelism.md
@@ -6,12 +6,12 @@ Kokkos has support for lightweight task-based programming, which is currently pr
 Will Kokkos Tasking work for my problem?
 ----------------------------------------
 
-Not all task-based problems are a good fit for the current Kokkos approach to tasking.  Currently, the tasking interface in Kokkos is  targetted at problems with kernels far too small to overcome the inherent overhead of top-level Kokkos data parallel launches—that is, small but plentiful data parallel tasks with a non-trivial dependency structure.  For tasks that fit this general scale model but have (very) trivial dependency structures, it may be easier to use [hierarchical parallelism](HierarchicalParallelism), potentially with a `Kokkos::Schedule<Dynamic>` scheduling policy (see, for instance, [this page](Kokkos%3A%3ARangePolicy)) for load balancing if necessary. 
+Not all task-based problems are a good fit for the current Kokkos approach to tasking.  Currently, the tasking interface in Kokkos is  targetted at problems with kernels far too small to overcome the inherent overhead of top-level Kokkos data parallel launches—that is, small but plentiful data parallel tasks with a non-trivial dependency structure.  For tasks that fit this general scale model but have (very) trivial dependency structures, it may be easier to use [hierarchical parallelism](../../ProgrammingGuide/HierarchicalParallelism), potentially with a `Kokkos::Schedule<Dynamic>` scheduling policy (see, for instance, [this page](policies/RangePolicy)) for load balancing if necessary. 
 
 Basic Usage
 -----------
 
-Fundamentally, task parallelism is just another form of parallelism in Kokkos.  The same general idiom of pattern, policy, and functor applies as for ordinary [parallel dispatch](ParallelDispatch):
+Fundamentally, task parallelism is just another form of parallelism in Kokkos.  The same general idiom of pattern, policy, and functor applies as for ordinary [parallel dispatch](../../ProgrammingGuide/ParallelDispatch):
 
 ![parallel-dispatch](https://raw.githubusercontent.com/wiki/kokkos/kokkos/ProgrammingGuide/figures/parallel-dispatch.png)
 
@@ -34,7 +34,7 @@ struct MyTask {
 };
 ```
 
-Similar to [team parallelism](HierarchicalParallelism), the first parameter is the team handle, which has all of the same functionality as the one produced by a `Kokkos::TeamPolicy`, with a few extras.  Like with `Kokkos::parallel_reduce()`, the output is expressed through the second parameter.  Note that there is currently no lambda interface to Kokkos Tasking.
+Similar to [team parallelism](../../ProgrammingGuide/HierarchicalParallelism), the first parameter is the team handle, which has all of the same functionality as the one produced by a `Kokkos::TeamPolicy`, with a few extras.  Like with `Kokkos::parallel_reduce()`, the output is expressed through the second parameter.  Note that there is currently no lambda interface to Kokkos Tasking.
 
 Task Patterns
 -------------

--- a/source/API/core/Traits.md
+++ b/source/API/core/Traits.md
@@ -1,0 +1,31 @@
+# Traits
+
+(is_array_layout)=
+## is_array_layout
+
+Boolean type trait to detect types that model the Layout concept.
+
+(is_execution_policy)=
+## is_execution_policy
+
+Boolean type trait to detect types that model [ExecutionPolicy concept](policies/ExecutionPolicyConcept).
+
+(is_memory_space)=
+## is_memory_space
+
+Boolean type trait to detect types that model [MemorySpace concept](MemorySpaceConcept).
+
+(is_memory_traits)=
+## is_memory_traits
+
+Boolean type trait to detect specializations of `Kokkos::MemoryTraits`.
+
+(is_reducer)=
+## is_reducer
+
+Boolean type trait to detect types that model the [Reducer concept](builtinreducers/ReducerConcept).
+
+(is_space)=
+## is_space
+
+Boolean type trait to detect types that model the Space concept.

--- a/source/API/core/Utilities.rst
+++ b/source/API/core/Utilities.rst
@@ -1,10 +1,9 @@
-
 Utilities
 =========
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
-   ./utilities/timer
-   ./utilities/complex
    ./utilities/abort
+   ./utilities/complex
+   ./utilities/timer

--- a/source/API/core/View.rst
+++ b/source/API/core/View.rst
@@ -1,17 +1,17 @@
-
 View and related
 ================
 
 .. toctree::
    :maxdepth: 1
 
-   ./view/view
-   ./view/view_alloc
-   ./view/subview
-   ./view/resize
-   ./view/realloc
-   ./view/deep_copy
    ./view/create_mirror
+   ./view/deep_copy
    ./view/layoutLeft
    ./view/layoutRight
    ./view/layoutStride
+   ./view/realloc
+   ./view/resize
+   ./view/subview
+   ./view/view
+   ./view/view_alloc
+   ./view/view_like


### PR DESCRIPTION
### THIS PR:
- added anchors and fixed links and grammar in API/core/CStyleMemManagement
- added `ScopeGuard` to API/core/Initialize-and-Finalize
- added missing KokkosConceptsto API/core, added links and fixed grammar
- added missing ParallelForTag to API/core and added links to ParallelForTag.md
- added missing ParallelReduceTag to API/core and added links and fixed indentation in ParallelReduceTag.md
- added missing ParallelScanTag to API/core and added links and fixed indentation in ParallelScanTag.md
- formatted ParallelForTag, ParallelScanTag, ParallelReduceTag fo consistency in menu
- removed blank lines and fixed links in SpaceAccessibility.md
- removed blank lines, formatted, removed missing reference and change tree max depth in STL-Compatibility.rst
- fixed links in Task-Parallelism.md
- added missing Traits to API/core
- added `KokkosConcepts` and `Traits` to API/core-index
- removed blank lines, reordered API/core/Utilities and changed tree depth in Utilities.rst
- removed blank lines, reordered API/core/View