### PR TITLE
#32: Fix initialize finalize numerics std algorithms

### DIFF
--- a/source/API/core/initialize_finalize/ScopeGuard.md
+++ b/source/API/core/initialize_finalize/ScopeGuard.md
@@ -1,0 +1,57 @@
+# Kokkos::ScopeGuard
+
+Header File: `Kokkos_Core.hpp`
+
+Usage: 
+```c++
+Kokkos::ScopeGuard(narg, arg);
+Kokkos::ScopeGuard(args);
+```
+
+`ScopeGuard` is a class which ensure that `Kokkos::initialize` and
+`Kokkos::finalize` are called correctly even in the presence of unhandled
+exceptions and multiple libraries trying to "own" Kokkos initialization.
+`ScopeGuard` calls `Kokkos::initialize` in its constructor only if
+`Kokkos::is_initialized()` is false, and calls `Kokkos::finalize` in its
+destructor only if it called `Kokkos::initialize` in its constructor.
+
+## Interface
+
+```c++
+Kokkos::ScopeGuard(int& narg, char* arg[]);
+```
+
+```c++
+Kokkos::ScopeGuard(const InitArguments& args);
+```
+
+```c++
+~ScopeGuard();
+```
+
+### Parameters:
+
+  * narg:  number of command line arguments
+  * arg: array of command line arguments, valid arguments are listed below.
+  * args: structure of valid Kokkos arguments
+
+Note that all of the parameters above are passed to the `Kokkos::initialize` called internally.  See [Kokkos::initialize](initialize) for more details.
+ 
+### Requirements
+  * `Kokkos::ScopeGuard` object should be constructed before user initiated Kokkos objects 
+
+### Semantics
+  * Calls `Kokkos::initialize` only if `Kokkos::is_initialized()` is false.
+  * Arguments are passed directly to `Kokkos::initialize` if it is called.
+  * Kokkos::ScopeGuard::~ScopeGuard calls `Kokkos::finalize` only if the constructor of this object called `Kokkos::initialize`.
+
+### Example
+
+```c++
+int main(int argc, char** argv) {
+  Kokkos::ScopeGuard kokkos(argc, argv);
+  Kokkos::View<double*> my_view("my_view", 10);
+  // my_view destructor called before Kokkos::finalize
+  // ScopeGuard destructor called, calls Kokkos::finalize
+}
+```

--- a/source/API/core/initialize_finalize/finalize.md
+++ b/source/API/core/initialize_finalize/finalize.md
@@ -6,19 +6,17 @@ Shut down all enabled Kokkos backends and free all associated resources.
 This function should be called after calling all other Kokkos API functions,
 *including Kokkos object destructors*.
 
-Programs are ill-formed if they do not call this function after calling `Kokkos::initialize`.
-
+Programs are ill-formed if they do not call this function after calling [`Kokkos::initialize`](initialize).
 
 Usage: 
 ```c++
-   Kokkos::finalize();
+Kokkos::finalize();
 ```
 
 ## Interface
 
-
-```cpp
-  Kokkos::finalize();
+```c++
+Kokkos::finalize();
 ```
 
 ### Parameters:

--- a/source/API/core/initialize_finalize/initialize.md
+++ b/source/API/core/initialize_finalize/initialize.md
@@ -14,11 +14,11 @@ including Kokkos object constructors.  The function has two overloads.  One take
 
 ## Interface
 
-```cpp
+```c++
   Kokkos::initialize(int& narg, char* arg[]);
 ```
 
-```cpp
+```c++
   Kokkos::initialize(const InitArguments& args);
 ```
 
@@ -31,11 +31,11 @@ including Kokkos object constructors.  The function has two overloads.  One take
      * `--kokkos-threads=INT`,`--threads=INT`: specify total number of threads or number of threads per NUMA region if used in conjunction with the `--numa` option.
      * `--kokkos-numa=INT`,`--numa=INT`: specify number of NUMA regions used by each process. 
      * `--device`,`--device-id`: specify device id to be used by Kokkos (CUDA,HIP,SYCL) 
-     * `--num-devices=INT[,INT]`: used when running MPI jobs. Specify number of devices per node to be used. see [Initialization](Initialization) for more detail.
+     * `--num-devices=INT[,INT]`: used when running MPI jobs. Specify number of devices per node to be used. see [Initialization](../../../ProgrammingGuide/Initialization) for more detail.
 
   * args: structure of valid Kokkos arguments
 
-```cpp
+```c++
 struct InitArguments {
   int num_threads;
   int num_numa;

--- a/source/API/core/numerics/mathematical-constants.md
+++ b/source/API/core/numerics/mathematical-constants.md
@@ -52,5 +52,5 @@ KOKKOS_FUNCTION void example() {
 
 ---
 **See also**  
-[Common mathematical functions](Mathematical-Functions)  
-[Numeric traits](Numeric-Traits)  
+[Common mathematical functions](mathematical-functions)  
+[Numeric traits](numeric-traits)  

--- a/source/API/core/numerics/mathematical-functions.md
+++ b/source/API/core/numerics/mathematical-functions.md
@@ -143,5 +143,5 @@ _`func`_\* denotes functions not available with the SYCL backend
 
 ---
 **See also**  
-[Mathematical constants](Mathematical-Constants)  
-[Numeric traits](Numeric-Traits)  
+[Mathematical constants](mathematical-constants)  
+[Numeric traits](numeric-traits)  

--- a/source/API/core/numerics/numeric-traits.md
+++ b/source/API/core/numerics/numeric-traits.md
@@ -94,5 +94,5 @@ legacy_std_numeric_limits_infinity() {
 
 ---
 **See also**  
-[Mathematical constants](Mathematical-Constants)  
-[Common mathematical functions](Mathematical-Functions)  
+[Mathematical constants](mathematical-constants)  
+[Common mathematical functions](mathematical-functions)  

--- a/source/API/std-algorithms/StdMinMaxElement.md
+++ b/source/API/std-algorithms/StdMinMaxElement.md
@@ -1,4 +1,3 @@
-
 # Minimum/maximum
 
 Header File: `Kokkos_Core.hpp`
@@ -16,7 +15,7 @@ Currently supported (see below the full details):
 
 ## `Kokkos::Experimental::min_element`
 
-```cpp
+```c++
 //
 // overload set accepting iterators
 //
@@ -97,7 +96,7 @@ auto min_element(const std::string& label,                              (8)
   `value_type`, where `value_type` is the value type of `IteratorType` (for 1,2,3,4)
   or the value type of `view` (for 5,6,7,8) and must not modify `a,b`.
   - must conform to:
-  ```cpp
+  ```c++
   struct Comparator
   {
      KOKKOS_INLINE_FUNCTION
@@ -132,7 +131,7 @@ The following special cases apply:
 
 ### Example
 
-```cpp
+```c++
 namespace KE = Kokkos::Experimental;
 Kokkos::View<double*> a("a", 13);
 // fill a somehow
@@ -174,7 +173,7 @@ auto res = KE::min_element(Kokkos::DefaultExecutionSpace(), a, CustomLessThanCom
 
 ## `Kokkos::Experimental::max_element`
 
-```cpp
+```c++
 //
 // overload set accepting iterators
 //
@@ -251,7 +250,7 @@ The following special cases apply:
 
 ### Example
 
-```cpp
+```c++
 namespace KE = Kokkos::Experimental;
 Kokkos::View<double*> a("a", 13);
 // fill a somehow
@@ -293,7 +292,7 @@ auto res = KE::max_element(Kokkos::DefaultExecutionSpace(), a, CustomLessThanCom
 
 ## `Kokkos::Experimental::minmax_element`
 
-```cpp
+```c++
 //
 // overload set accepting iterators
 //
@@ -376,7 +375,7 @@ The following special cases apply:
 
 ### Example
 
-```cpp
+```c++
 namespace KE = Kokkos::Experimental;
 Kokkos::View<double*> a("a", 11);
 

--- a/source/API/std-algorithms/StdModSeq.md
+++ b/source/API/std-algorithms/StdModSeq.md
@@ -1,4 +1,3 @@
-
 # Modifying Sequence
 
 Header File: `Kokkos_Core.hpp`
@@ -41,7 +40,7 @@ Currently supported (see below the full details):
 
 ## `Kokkos::Experimental::fill`
 
-```cpp
+```c++
 template <class ExecutionSpace, class IteratorType, class T>
 void fill(const ExecutionSpace& exespace,                                    (1)
           IteratorType first, IteratorType last,
@@ -95,7 +94,7 @@ None
 
 ### Example
 
-```cpp
+```c++
 namespace KE = Kokkos::Experimental;
 Kokkos::View<double*> a("a", 13);
 
@@ -115,7 +114,7 @@ KE::fill(Kokkos::OpenMP(), KE::begin(a), KE::end(a), 14.);
 
 ## `Kokkos::Experimental::fill_n`
 
-```cpp
+```c++
 template <class ExecutionSpace, class IteratorType, class SizeType, class T>
 IteratorType fill_n(const ExecutionSpace& exespace,                             (1)
                     IteratorType first,
@@ -162,7 +161,7 @@ Otherwise, it returns `first` (for 1,2) or `Kokkos::begin(view)` (for 3,4).
 
 ### Example
 
-```cpp
+```c++
 namespace KE = Kokkos::Experimental;
 Kokkos::View<double*> a("a", 13);
 // do something with a
@@ -184,7 +183,7 @@ KE::fill_n(Kokkos::OpenMP(), KE::begin(a), 10, newValue);
 
 ## `Kokkos::Experimental::replace`
 
-```cpp
+```c++
 template <class ExecutionSpace, class IteratorType, class T>
 void replace(const ExecutionSpace& exespace,                                 (1)
              IteratorType first, IteratorType last,
@@ -239,7 +238,7 @@ None
 
 ### Example
 
-```cpp
+```c++
 namespace KE = Kokkos::Experimental;
 Kokkos::View<double*> a("a", 13);
 // do something with a
@@ -258,7 +257,7 @@ KE::replace("mylabel", Kokkos::OpenMP(), a, oldValue, newValue);
 
 ## `Kokkos::Experimental::replace_if`
 
-```cpp
+```c++
 template <class ExecutionSpace, class IteratorType, class UnaryPredicateType, class T>
 void replace_if(const ExecutionSpace& exespace,                              (1)
                 IteratorType first, IteratorType last,
@@ -298,7 +297,7 @@ the range `[first, last)` (overloads 1,2) or in `view` (overloads 3,4).
   is the value type of `IteratorType` (for 1,2) or the value type of `view` (for 3,4),
   and must not modify `v`.
   - must conform to:
-  ```cpp
+  ```c++
   struct Predicate
   {
      KOKKOS_INLINE_FUNCTION
@@ -318,7 +317,7 @@ None
 
 ### Example
 
-```cpp
+```c++
 template <class ValueType>
 struct IsPositiveFunctor {
   KOKKOS_INLINE_FUNCTION
@@ -347,7 +346,7 @@ KE::replace_if("mylabel", Kokkos::OpenMP(), a,
 
 ## `Kokkos::Experimental::replace_copy`
 
-```cpp
+```c++
 template <class ExecutionSpace, class InputIteratorType, class OutputIteratorType, class T>
 OutputIteratorType replace_copy(const ExecutionSpace& exespace,               (1)
                                 InputIteratorType first_from,
@@ -427,7 +426,7 @@ Iterator to the element *after* the last element copied.
 
 ## `Kokkos::Experimental::replace_copy_if`
 
-```cpp
+```c++
 template <
   class ExecutionSpace,
   class InputIteratorType, class OutputIteratorType,
@@ -508,7 +507,7 @@ Iterator to the element *after* the last element copied.
 
 ## `Kokkos::Experimental::copy`
 
-```cpp
+```c++
 template <class ExecutionSpace, class InputIteratorType, class OutputIteratorType>
 OutputIteratorType copy(const ExecutionSpace& exespace,                      (1)
                         InputIteratorType first_from,
@@ -580,7 +579,7 @@ Iterator to the destination element *after* the last element copied.
 
 ## `Kokkos::Experimental::copy_n`
 
-```cpp
+```c++
 template <class ExecutionSpace, class InputIteratorType, class SizeType, class OutputIteratorType>
 OutputIteratorType copy_n(const ExecutionSpace& exespace,                    (1)
                           InputIteratorType first_from,
@@ -647,7 +646,7 @@ Otherwise, returns `first_to` (for 1,2) or `Kokkos::begin(view_to)` (for 3,4).
 
 ## `Kokkos::Experimental::copy_backward`
 
-```cpp
+```c++
 template <class ExecutionSpace, class InputIteratorType, class OutputIteratorType>
 OutputIteratorType copy_backward(const ExecutionSpace& exespace,                (1)
                                  InputIteratorType first_from,
@@ -720,7 +719,7 @@ Iterator to the last element copied.
 
 ## `Kokkos::Experimental::copy_if`
 
-```cpp
+```c++
 template <
   class ExecutionSpace, class InputIteratorType, class OutputIteratorType, class UnaryPredicateType
 >
@@ -796,7 +795,7 @@ Iterator to the destination element *after* the last element copied.
 
 ## `Kokkos::Experimental::generate`
 
-```cpp
+```c++
 template <class ExecutionSpace, class IteratorType, class GeneratorType>
 void generate(const ExecutionSpace& exespace,                                (1)
               IteratorType first, IteratorType last,
@@ -843,7 +842,7 @@ range `[first, last)` (overloads 1,2) or in the `view` (overloads 3,4).
   - must be accessible from `exespace`
 - `g`:
   - functor of the form:
-  ```cpp
+  ```c++
   struct Generate
   {
       KOKKOS_INLINE_FUNCTION
@@ -864,7 +863,7 @@ None
 
 ## `Kokkos::Experimental::generate_n`
 
-```cpp
+```c++
 template <class ExecutionSpace, class IteratorType, class SizeType, class GeneratorType>
 IteratorType generate_n(const ExecutionSpace& exespace,                      (1)
                         IteratorType first, SizeType n,
@@ -920,7 +919,7 @@ Otherwise, returns `first` (for 1,2) or `Kokkos::begin(view)` (for 3,4).
 
 ## `Kokkos::Experimental::transform`
 
-```cpp
+```c++
 template <class ExecutionSpace, class InputIterator, class OutputIterator, class UnaryOperation>
 OutputIterator transform(const ExecutionSpace& exespace,                        (1)
                          InputIterator first_from, InputIterator last_from,
@@ -1055,7 +1054,7 @@ Iterator to the element *after* the last element transformed.
 
 ## `Kokkos::Experimental::reverse`
 
-```cpp
+```c++
 template <class ExecutionSpace, class IteratorType, class T>
 void reverse(const ExecutionSpace& exespace,                                    (1)
              IteratorType first, IteratorType last);
@@ -1107,7 +1106,7 @@ None
 
 ## `Kokkos::Experimental::reverse_copy`
 
-```cpp
+```c++
 template <class ExecutionSpace, class InputIterator, class OutputIterator>
 OutputIterator reverse_copy(const ExecutionSpace& exespace,                  (1)
                             InputIterator first_from,
@@ -1179,7 +1178,7 @@ Iterator to the element *after* the last element copied.
 
 ## `Kokkos::Experimental::move`
 
-```cpp
+```c++
 template <class ExecutionSpace, class InputIterator, class OutputIterator>
 OutputIterator move(const ExecutionSpace& exespace,                          (1)
                     InputIterator first_from,
@@ -1250,7 +1249,7 @@ Iterator to the element *after* the last element moved.
 
 ## `Kokkos::Experimental::move_backward`
 
-```cpp
+```c++
 template <class ExecutionSpace, class InputIterator, class OutputIterator>
 OutputIterator move_backward(const ExecutionSpace& exespace,                 (1)
                              InputIterator first_from,
@@ -1309,7 +1308,7 @@ Iterator to the element *after* the last element moved.
 
 ## `Kokkos::Experimental::swap_ranges`
 
-```cpp
+```c++
 template <class ExecutionSpace, class Iterator1, class Iterator2>
 Iterator2 swap_ranges(const ExecutionSpace& exespace,                        (1)
                       Iterator1 first1, Iterator1 last1,
@@ -1375,7 +1374,7 @@ Iterator to the element *after* the last element swapped.
 
 ### `Kokkos::Experimental::unique`
 
-```cpp
+```c++
 template <class ExecutionSpace, class IteratorType>
 IteratorType unique(const ExecutionSpace& exespace,                          (1)
                     IteratorType first, IteratorType last);
@@ -1460,7 +1459,7 @@ Iterator to the element *after* the new logical end of the range
 
 ### `Kokkos::Experimental::unique_copy`
 
-```cpp
+```c++
 template <class ExecutionSpace, class InputIterator, class OutputIterator>
 OutputIterator unique_copy(const ExecutionSpace& exespace,                    (1)
                            InputIterator first_from, InputIterator last_from,
@@ -1570,7 +1569,7 @@ Iterator to the element *after* the last element copied in the destination range
 
 ## `Kokkos::Experimental::rotate`
 
-```cpp
+```c++
 template <class ExecutionSpace, class IteratorType>
 IteratorType rotate(const ExecutionSpace& exespace,                            (1)
                     IteratorType first,
@@ -1638,7 +1637,7 @@ new range and `n_first - 1` becomes the last element.
 
 ## `Kokkos::Experimental::rotate_copy`
 
-```cpp
+```c++
 template <class ExecutionSpace, class InputIterator, class OutputIterator>
 OutputIterator rotate_copy(const ExecutionSpace& exespace,                   (1)
                            InputIterator first_from,
@@ -1720,7 +1719,7 @@ Iterator to the element *after* the last element copied.
 
 ## `Kokkos::Experimental::remove`
 
-```cpp
+```c++
 template <class ExecutionSpace, class Iterator, class ValueType>
 Iterator remove(const ExecutionSpace& exespace,                             (1)
                 Iterator first, Iterator last,
@@ -1789,7 +1788,7 @@ Iterator to the element *after* the new logical end.
 
 ## `Kokkos::Experimental::remove_if`
 
-```cpp
+```c++
 template <class ExecutionSpace, class Iterator, class UnaryPredicateType>
 Iterator remove_if(const ExecutionSpace& exespace,                           (1)
                    Iterator first, Iterator last,
@@ -1843,7 +1842,7 @@ and the physical size of the container is unchanged.
   is the value type of `IteratorType` (for 1,2) or of `view` (for 3,4),
   and must not modify `v`.
   - must conform to:
-  ```cpp
+  ```c++
   struct Predicate
   {
      KOKKOS_INLINE_FUNCTION
@@ -1866,7 +1865,7 @@ Iterator to the element *after* the new logical end.
 
 ## `Kokkos::Experimental::remove_copy`
 
-```cpp
+```c++
 template <
   class ExecutionSpace,
   class InputIterator, class OutputIterator,
@@ -1951,7 +1950,7 @@ Iterator to the element after the last element copied.
 
 ## `Kokkos::Experimental::remove_copy_if`
 
-```cpp
+```c++
 template <
   class ExecutionSpace,
   class InputIterator, class OutputIterator,
@@ -2015,7 +2014,7 @@ those for which `pred` returns `true`.
   is the value type of `InputIteratorType` (for 1,2) or of `view_from` (for 3,4),
   and must not modify `v`.
   - must conform to:
-  ```cpp
+  ```c++
   struct Predicate
   {
      KOKKOS_INLINE_FUNCTION
@@ -2039,7 +2038,7 @@ Iterator to the element after the last element copied.
 
 ## `Kokkos::Experimental::shift_left`
 
-```cpp
+```c++
 template <class ExecutionSpace, class IteratorType>
 IteratorType shift_left(const ExecutionSpace& exespace,                 (1)
                         IteratorType first,
@@ -2102,7 +2101,7 @@ Otherwise, returns `first`.
 
 ## `Kokkos::Experimental::shift_right`
 
-```cpp
+```c++
 template <class ExecutionSpace, class IteratorType>
 IteratorType shift_right(const ExecutionSpace& exespace,                  (1)
                          IteratorType first,

--- a/source/API/std-algorithms/StdNonModSeq.md
+++ b/source/API/std-algorithms/StdNonModSeq.md
@@ -1,4 +1,3 @@
-
 # NonModifying Sequence
 
 Header File: `Kokkos_Core.hpp`
@@ -7,7 +6,7 @@ Header File: `Kokkos_Core.hpp`
 
 ## Kokkos::Experimental::find
 
-```cpp
+```c++
 template <class ExecutionSpace, class InputIterator, class T>
 InputIterator find(const ExecutionSpace& exespace,                              (1)
                    InputIterator first, InputIterator last,
@@ -59,7 +58,7 @@ Returns an iterator to the *first* element in `[first, last)` that equals `value
 - (2,3): iterator to the first element that equals `value`, or `Kokkos::Experimental::end(view)` if none is found
 
 ### Example
-```cpp
+```c++
 namespace KE = Kokkos::Experimental;
 using view_type = Kokkos::View<int*>;
 view_type a("a", 15);
@@ -76,7 +75,7 @@ auto it2 = KE::find(Kokkos::OpenMP(), KE::begin(a), KE::end(a), 5);
 
 ## Kokkos::Experimental::find_if
 
-```cpp
+```c++
 template <class ExecutionSpace, class InputIterator, class PredicateType>
 InputIterator find_if(const ExecutionSpace& exespace,                              (1)
                       InputIterator first, InputIterator last,
@@ -115,7 +114,7 @@ Returns an iterator to the *first* element in `[first, last)` for which the pred
   - unary predicate which returns `true` for the required element; `pred(v)` must be valid to be called from the execution space passed, and convertible to bool for every
  argument `v` of type (possible const) `value_type`, where `value_type` is the value type of `InputIterator`, and must not modify `v`.
   - must conform to:
-  ```cpp
+  ```c++
   struct Predicate
   {
      KOKKOS_INLINE_FUNCTION
@@ -135,7 +134,7 @@ Returns an iterator to the *first* element in `[first, last)` for which the pred
 - (2,3): iterator to the first element that equals `value`, or `Kokkos::Experimental::end(view)` if none is found
 
 ### Example
-```cpp
+```c++
 namespace KE = Kokkos::Experimental;
 
 template<class ValueType>

--- a/source/API/std-algorithms/StdNumeric.md
+++ b/source/API/std-algorithms/StdNumeric.md
@@ -1,4 +1,3 @@
-
 # Numeric
 
 Header File: `Kokkos_Core.hpp`
@@ -6,21 +5,20 @@ Header File: `Kokkos_Core.hpp`
 **All algorithms are currently in the `Kokkos::Experimental` namespace.**
 
 Currently supported (see below the full details):
- - [`reduce`](#kokkosexperimentalreduce)
- - [`transform_reduce`](#kokkosexperimentaltransform_reduce)
- - [`exclusive_scan`](#kokkosexperimentalexclusive_scan)
- - [`transform_exclusive_scan`](#kokkosexperimentaltransform_exclusive_scan)
- - [`inclusive_scan`](#kokkosexperimentalinclusive_scan)
- - [`transform_inclusive_scan`](#kokkosexperimentaltransform_inclusive_scan)
- - [`adjacent_difference`](#kokkosexperimentaladjant_difference)
-
+ - [`reduce`](kokkosexperimentalreduce)
+ - [`transform_reduce`](kokkosexperimentaltransform_reduce)
+ - [`exclusive_scan`](kokkosexperimentalexclusive_scan)
+ - [`transform_exclusive_scan`](kokkosexperimentaltransform_exclusive_scan)
+ - [`inclusive_scan`](kokkosexperimentalinclusive_scan)
+ - [`transform_inclusive_scan`](kokkosexperimentaltransform_inclusive_scan)
+ - [`adjacent_difference`](kokkosexperimentaladjant_difference)
 
 ------
 
-
+(kokkosexperimentalreduce)=
 ## `Kokkos::Experimental::reduce`
 
-```cpp
+```c++
 //
 // overload set A
 //
@@ -142,7 +140,7 @@ ValueType reduce(const std::string& label, const ExecutionSpace& exespace,      
   Must be valid to be called from the execution space passed, and callable with
   two arguments `a,b` of type (possible const) `ValueType`, and must not modify `a,b`.
   - Must conform to:
-  ```cpp
+  ```c++
   struct JoinFunctor {
 	KOKKOS_FUNCTION
 	constexpr ValueType operator()(const ValueType& a, const ValueType& b) const {
@@ -164,14 +162,12 @@ ValueType reduce(const std::string& label, const ExecutionSpace& exespace,      
 
 The reduction result.
 
-
-
 ------
 
-
+(kokkosexperimentaltransform_reduce)=
 ## `Kokkos::Experimental::transform_reduce`
 
-```cpp
+```c++
 //
 // overload set A
 //
@@ -369,7 +365,7 @@ ValueType transform_reduce(const std::string& label,                            
   Must be valid to be called from the execution space passed, and callable with
   two arguments `a,b` of type (possible const) `ValueType`, and must not modify `a,b`.
   - Must conform to:
-  ```cpp
+  ```c++
   struct JoinFunctor {
 	KOKKOS_FUNCTION
 	constexpr ValueType operator()(const ValueType& a,
@@ -394,7 +390,7 @@ ValueType transform_reduce(const std::string& label,                            
   where `value_type_{a,b}` are the value types of `first1` and `first2` (for 1,2,5,6)
   or the value types of `first_view` and `second_view` (for 3,4,7,8), and must not modify `a,b`.
   - Must conform to:
-  ```cpp
+  ```c++
   struct BinaryTransformer {
 	KOKKOS_FUNCTION
 	constexpr return_type operator()(const value_type_a & a, const value_type_b & b) const {
@@ -411,7 +407,7 @@ ValueType transform_reduce(const std::string& label,                            
   where `value_type` is the value type of `first1` (for 9,10)
   or the value type of `first_view` (for 11,12), and must not modify `v`.
   - Must conform to:
-  ```cpp
+  ```c++
   struct UnaryTransformer {
 	KOKKOS_FUNCTION
 	constexpr value_type operator()(const value_type & v) const {
@@ -424,14 +420,12 @@ ValueType transform_reduce(const std::string& label,                            
 
 The reduction result.
 
-
-
 ------
 
-
+(kokkosexperimentalexclusive_scan)=
 ## `Kokkos::Experimental::exclusive_scan`
 
-```cpp
+```c++
 //
 // overload set A
 //
@@ -531,7 +525,6 @@ the results to the range beginning at `first_dest` (5,6) or to `view_dest` (7,8)
 
 Exclusive means that the i-th input element is not included in the i-th sum.
 
-
 ### Parameters and Requirements
 
 - `exespace`:
@@ -556,7 +549,7 @@ Exclusive means that the i-th input element is not included in the i-th sum.
   is the value type of `InputIteratorType` (for 1,2,5,6) or the value type
   of `view_from` (for 3,4,7,8), and must not modify `a,b`.
   - must conform to:
-  ```cpp
+  ```c++
   struct BinaryOp
   {
      KOKKOS_INLINE_FUNCTION
@@ -583,13 +576,12 @@ Exclusive means that the i-th input element is not included in the i-th sum.
 
 Iterator to the element *after* the last element written.
 
-
 ------
 
-
+(kokkosexperimentaltransform_exclusive_scan)=
 ## `Kokkos::Experimental::transform_exclusive_scan`
 
-```cpp
+```c++
 template <
   class ExecutionSpace, class InputIteratorType,
   class OutputIteratorType, class ValueType,
@@ -665,7 +657,7 @@ and written to `view_dest`
   where `value_type` is the value type of `first_from` (for 1,2)
   or the value type of `view_from` (for 3,4), and must not modify `v`.
   - Must conform to:
-  ```cpp
+  ```c++
   struct UnaryOp {
 	KOKKOS_FUNCTION
 	constexpr value_type operator()(const value_type & v) const {
@@ -677,14 +669,12 @@ and written to `view_dest`
 
 Iterator to the element *after* the last element written.
 
-
-
 ------
 
-
+(kokkosexperimentalinclusive_scan)=
 ## `Kokkos::Experimental::inclusive_scan`
 
-```cpp
+```c++
 //
 // overload set A
 //
@@ -840,15 +830,12 @@ Inclusive means that the i-th input element is included in the i-th sum.
 
 Iterator to the element *after* the last element written.
 
-
-
-
 ------
 
-
+(kokkosexperimentaltransform_inclusive_scan)=
 ## `Kokkos::Experimental::transform_inclusive_scan`
 
-```cpp
+```c++
 template <
   class ExecutionSpace, class InputIteratorType,
   class OutputIteratorType, class BinaryOpType, class UnaryOpType>
@@ -970,14 +957,12 @@ Inclusive means that the i-th input element is included in the i-th sum.
 
 Iterator to the element *after* the last element written.
 
-
-
 ------
 
-
+(kokkosexperimentaladjant_difference)=
 ## `Kokkos::Experimental::adjacent_difference`
 
-```cpp
+```c++
 template <class ExecutionSpace, class InputIteratorType, class OutputIteratorType>
 OutputIteratorType adjacent_difference(const ExecutionSpace& exespace,                    (1)
                                        InputIteratorType first_from,
@@ -1086,7 +1071,7 @@ auto adjacent_difference(const std::string& label,                              
   is the value type of `InputIteratorType` (for 1,2,3,4) or the value type
   of `view_from` (for 5,6,7,8), and must not modify `a,b`.
   - must conform to:
-  ```cpp
+  ```c++
   struct BinaryOp
   {
      KOKKOS_INLINE_FUNCTION

--- a/source/API/std-algorithms/StdPartioningOps.md
+++ b/source/API/std-algorithms/StdPartioningOps.md
@@ -1,4 +1,3 @@
-
 # Partitioning
 
 Header File: `Kokkos_Core.hpp`
@@ -16,7 +15,7 @@ Currently supported (see below the full details):
 
 ## `Kokkos::Experimental::is_partitioned`
 
-```cpp
+```c++
 template <class ExecutionSpace, class InputIterator, class PredicateType>
 bool is_partitioned(const ExecutionSpace& exespace,                              (1)
                     InputIterator first, InputIterator last,
@@ -67,7 +66,7 @@ If `[first, last)` or `view` is empty, returns `true`.
   is the value type of `IteratorType` (for 1,2) or the value type of `view` (for 3,4),
   and must not modify `v`.
   - must conform to:
-  ```cpp
+  ```c++
   struct Predicate
   {
      KOKKOS_INLINE_FUNCTION
@@ -86,7 +85,7 @@ If `[first, last)` or `view` is empty, returns `true`.
 - `false`: otherwise
 
 ### Example
-```cpp
+```c++
 namespace KE = Kokkos::Experimental;
 
 template<class ValueType>
@@ -112,7 +111,7 @@ const auto res = KE::is_partitioned(exespace, KE::cbegin(a), KE::cend(a), IsNega
 
 ## `Kokkos::Experimental::partition_point`
 
-```cpp
+```c++
 template <class ExecutionSpace, class IteratorType, class PredicateType>
 IteratorType partition_point(const ExecutionSpace& exespace,                   (1)
                              IteratorType first, IteratorType last,
@@ -164,7 +163,7 @@ or `last` if all elements satisfy `pred`.
 
 ## `Kokkos::Experimental::partition_copy`
 
-```cpp
+```c++
 template <
   class ExecutionSpace,
   class InputIteratorType,
@@ -270,7 +269,7 @@ auto partition_copy(const std::string& label,                                   
   is the value type of `InputIteratorType` (for 1,2) or the value type of `view_from` (for 3,4),
   and must not modify `v`.
   - must conform to:
-  ```cpp
+  ```c++
   struct Predicate
   {
      KOKKOS_INLINE_FUNCTION

--- a/source/API/std-algorithms/StdSorting.md
+++ b/source/API/std-algorithms/StdSorting.md
@@ -1,4 +1,3 @@
-
 # Sorting
 
 Header File: `Kokkos_Core.hpp`
@@ -9,12 +8,11 @@ Currently supported (see below the full details):
  - [`is_sorted`](#kokkosexperimentalis_sorted)
  - [`is_sorted_until`](#kokkosexperimentalis_sorted_until)
 
-
 ------
 
 ## `Kokkos::Experimental::is_sorted`
 
-```cpp
+```c++
 //
 // overload set accepting iterators
 //
@@ -95,7 +93,7 @@ bool is_sorted(const std::string& label, const ExecutionSpace& exespace,    (8)
   `value_type`, where `value_type` is the value type of `IteratorType` (for 1,2,3,4)
   or the value type of `view` (for 5,6,7,8) and must not modify `a,b`.
   - must conform to:
-  ```cpp
+  ```c++
   struct Comparator
   {
      KOKKOS_INLINE_FUNCTION
@@ -127,7 +125,7 @@ True if the elements are sorted in descending order.
 
 ## `Kokkos::Experimental::is_sorted_until`
 
-```cpp
+```c++
 //
 // overload set accepting iterators
 //


### PR DESCRIPTION
### THIS PR:
- fixed links, changed cpp to c++ code block, removed blank lines in finalize.md
- fixed links and changed cpp to c++ code block in initialize.md
- fixed links in mathematical-constants.md
- fixed links in mathematical-functions.md
- fixed links in numeric-traits.md
- fixed links and changed cpp to c++ code block in ScopeGuard.md
- added missing ScopeGuard to API/core/initialize_finalize
- changed cpp to c++ code block in StdMinMaxElement.md
- changed cpp to c++ code block in StdModSeq.md
- changed cpp to c++ code block in StdNonModSeq.md
- fixed links, removed blank lines, fixed indentation in StdNumeric.md
- changed cpp to c++ code block in StdPartioningOps.md
- changed cpp to c++ code block in StdSorting.md