### PR TITLE
#32: Fix API core view

### DIFF
--- a/source/API/core/view/create_mirror.md
+++ b/source/API/core/view/create_mirror.md
@@ -2,10 +2,10 @@
 
 Header File: `Kokkos_Core.hpp`
 
-A common desired use case is to have a memory allocation in GPU memory and an identical memory allocation in CPU memory, such that copying from one to another is straightforward. To satisfy this use case and others, Kokkos has facilities for dealing with "mirrors" of View. A "mirror" of a View type `A` is loosely defined a View type `B` such that Views of type `B` are accessible from the CPU and `deep_copy` between Views of type `A` and `B` are direct. The most common functions for dealing with mirrors are `create_mirror`, `create_mirror_view` and `create_mirror_view_and_copy`.
+A common desired use case is to have a memory allocation in GPU memory and an identical memory allocation in CPU memory, such that copying from one to another is straightforward. To satisfy this use case and others, Kokkos has facilities for dealing with "mirrors" of View. A "mirror" of a View type `A` is loosely defined a View type `B` such that Views of type `B` are accessible from the CPU and [`deep_copy`](deep_copy) between Views of type `A` and `B` are direct. The most common functions for dealing with mirrors are `create_mirror`, `create_mirror_view` and `create_mirror_view_and_copy`.
 
 Usage:
-```cpp
+```c++
 auto host_mirror = create_mirror(a_view);
 auto host_mirror_view = create_mirror_view(a_view);
 
@@ -15,8 +15,7 @@ auto host_mirror_view_space = create_mirror_view(ExecSpace(),a_view);
 
 ## Synopsis
 
-```cpp
-
+```c++
 template <class ViewType>
 typename ViewType::HostMirror create_mirror(ViewType const&);
 
@@ -52,81 +51,81 @@ ImplMirrorType create_mirror_view_and_copy(Space const& space, ViewType const&);
 
 ## Description
 
-* ```cpp
+* ```c++
   template <class ViewType>
   typename ViewType::HostMirror create_mirror(ViewType const& src);
   ```
-  Creates a new host accessible `View` with the same layout and padding as `src`.
+  Creates a new host accessible [`View`](view) with the same layout and padding as `src`.
   * `src`: a `Kokkos::View`.
 
-* ```cpp
+* ```c++
   template <class ViewType>
   typename ViewType::HostMirror create_mirror(decltype(Kokkos::ViewAllocateWithoutInitializing()),
                                               ViewType const& src);
   ```
-  Creates a new host accessible `View` with the same layout and padding as `src`. The new view will have uninitialized data.
+  Creates a new host accessible [`View`](view) with the same layout and padding as `src`. The new view will have uninitialized data.
   * `src`: a `Kokkos::View`.
 
-* ```cpp
+* ```c++
   template <class Space, class ViewType>
   ImplMirrorType create_mirror(Space const& space, ViewType const&);
   ```
-  Creates a new `View` with the same layout and padding as `src` but with a device type of `Space::device_type`.
+  Creates a new [`View`](view) with the same layout and padding as `src` but with a device type of `Space::device_type`.
   * `src`: a `Kokkos::View`.
-  * `Space`: a class meeting the requirements of `ExecutionSpaceConcept` or `MemorySpaceConcept`
+  * `Space`: a class meeting the requirements of [`ExecutionSpaceConcept`](ExecutionSpaceConcept) or [`MemorySpaceConcept`](MemorySpaceConcept)
   * `ImplMirrorType`: an implementation defined specialization of `Kokkos::View`.
 
-* ```cpp
+* ```c++
   template <class Space, class ViewType>
   ImplMirrorType create_mirror(decltype(Kokkos::ViewAllocateWithoutInitializing()),
                                Space const& space, ViewType const&);
   ```
-  Creates a new `View` with the same layout and padding as `src` but with a device type of `Space::device_type`. The new view will have uninitialized data.
+  Creates a new [`View`](view) with the same layout and padding as `src` but with a device type of `Space::device_type`. The new view will have uninitialized data.
   * `src`: a `Kokkos::View`.
-  * `Space`: a class meeting the requirements of `ExecutionSpaceConcept` or `MemorySpaceConcept`
+  * `Space`: a class meeting the requirements of [`ExecutionSpaceConcept`](ExecutionSpaceConcept) or [`MemorySpaceConcept`](MemorySpaceConcept)
   * `ImplMirrorType`: an implementation defined specialization of `Kokkos::View`.
 
-* ```cpp
+* ```c++
   template <class ViewType>
   typename ViewType::HostMirror create_mirror_view(ViewType const& src);
   ```
   If `src` is not host accessible (i.e. if `SpaceAccessibility<HostSpace,ViewType::memory_space>::accessible` is `false`)
-  it creates a new host accessible `View` with the same layout and padding as `src`. Otherwise returns `src`.
+  it creates a new host accessible [`View`](view) with the same layout and padding as `src`. Otherwise returns `src`.
   * `src`: a `Kokkos::View`.
 
-* ```cpp
+* ```c++
   template <class ViewType>
   typename ViewType::HostMirror create_mirror_view(decltype(Kokkos::ViewAllocateWithoutInitializing()),
                                                    ViewType const& src);
   ```
   If `src` is not host accessible (i.e. if `SpaceAccessibility<HostSpace,ViewType::memory_space>::accessible` is `false`)
-  it creates a new host accessible `View` with the same layout and padding as `src`. The new view will have uninitialized data. Otherwise returns `src`.
+  it creates a new host accessible [`View`](view) with the same layout and padding as `src`. The new view will have uninitialized data. Otherwise returns `src`.
   * `src`: a `Kokkos::View`.
 
-* ```cpp
+* ```c++
   template <class Space, class ViewType>
   ImplMirrorType create_mirror_view(Space const& space, ViewType const&);
   ```
   If `std::is_same<typename Space::memory_space, typename ViewType::memory_space>::value` is `false`,
-  creates a new `View` with the same layout and padding as `src` but with a device type of `Space::device_type`.
+  creates a new [`View`](view) with the same layout and padding as `src` but with a device type of `Space::device_type`.
   Otherwise returns `src`.
   * `src`: a `Kokkos::View`.
-  * `Space`: a class meeting the requirements of `ExecutionSpaceConcept` or `MemorySpaceConcept`
+  * `Space`: a class meeting the requirements of [`ExecutionSpaceConcept`](ExecutionSpaceConcept) or [`MemorySpaceConcept`](MemorySpaceConcept)
   * `ImplMirrorType`: an implementation defined specialization of `Kokkos::View`.
 
-* ```cpp
+* ```c++
   template <class Space, class ViewType>
   ImplMirrorType create_mirror_view(decltype(Kokkos::ViewAllocateWithoutInitializing()),
                                     Space const& space, ViewType const&);
   ```
   If `std::is_same<typename Space::memory_space, typename ViewType::memory_space>::value` is `false`,
-  creates a new `View` with the same layout and padding as `src` but with a device type of `Space::device_type`. The new view will have uninitialized data.
+  creates a new [`View`](view) with the same layout and padding as `src` but with a device type of `Space::device_type`. The new view will have uninitialized data.
   Otherwise returns `src`.
   * `src`: a `Kokkos::View`.
-  * `Space`: a class meeting the requirements of `ExecutionSpaceConcept` or `MemorySpaceConcept`
+  * `Space`: a class meeting the requirements of [`ExecutionSpaceConcept`](ExecutionSpaceConcept) or [`MemorySpaceConcept`](MemorySpaceConcept)
   * `ImplMirrorType`: an implementation defined specialization of `Kokkos::View`.
 
-* ```cpp
+* ```c++
   template <class Space, class ViewType>
   ImplMirrorType create_mirror_view_and_copy(Space const& space, ViewType const&);
   ```
@@ -134,5 +133,5 @@ ImplMirrorType create_mirror_view_and_copy(Space const& space, ViewType const&);
   creates a new `Kokkos::View` with the same layout and padding as `src` but with a device type of `Space::device_type` and
   conducts a `deep_copy` from `src` to the new view if one was created. Otherwise returns `src`.
   * `src`: a `Kokkos::View`.
-  * `Space`: a class meeting the requirements of `ExecutionSpaceConcept` or `MemorySpaceConcept`
+  * `Space`: a class meeting the requirements of [`ExecutionSpaceConcept`](ExecutionSpaceConcept) or [`MemorySpaceConcept`](MemorySpaceConcept)
   * `ImplMirrorType`: an implementation defined specialization of `Kokkos::View`.

--- a/source/API/core/view/deep_copy.md
+++ b/source/API/core/view/deep_copy.md
@@ -4,48 +4,48 @@ Header File: `Kokkos_Core.hpp`
 
 Usage: 
 ```c++
-  Kokkos::deep_copy(exec_space, dest, src);
-  Kokkos::deep_copy(dest, src);
+Kokkos::deep_copy(exec_space, dest, src);
+Kokkos::deep_copy(dest, src);
 ```
 
-Copies data from `src` to `dest`, where `src` and `dest` can be [Kokkos::View](Kokkos%3A%3AView)s or scalars under certain circumstances.
+Copies data from `src` to `dest`, where `src` and `dest` can be [Kokkos::View](view)s or scalars under certain circumstances.
 
 ## Interface
 
-```cpp
+```c++
 template <class ExecSpace, class ViewDest, class ViewSrc>
 void Kokkos::deep_copy(const ExecSpace& exec_space, 
                        const ViewDest& dest,
                        const ViewSrc& src);
 ```
 
-```cpp
+```c++
 template <class ExecSpace, class ViewDest>
 void Kokkos::deep_copy(const ExecSpace& exec_space, 
                        const ViewDest& dest,
                        const typename ViewDest::value_type& src);
 ```
 
-```cpp
+```c++
 template <class ExecSpace, class ViewSrc>
 void Kokkos::deep_copy(const ExecSpace& exec_space, 
                        ViewSrc::value_type& dest,
                        const ViewSrc& src);
 ```
 
-```cpp
+```c++
 template <class ViewDest, class ViewSrc>
 void Kokkos::deep_copy(const ViewDest& dest,
                        const ViewSrc& src);
 ```
 
-```cpp
+```c++
 template <class ViewDest>
 void Kokkos::deep_copy(const ViewDest& dest,
                        const typename ViewDest::value_type& src);
 ```
 
-```cpp
+```c++
 template <class ViewSrc>
 void Kokkos::deep_copy(ViewSrc::value_type& dest,
                        const ViewSrc& src);
@@ -53,23 +53,23 @@ void Kokkos::deep_copy(ViewSrc::value_type& dest,
 
 ### Parameters:
 
-  * ExecSpace: An [ExecutionSpace](API-Spaces)
-  * ViewDest:A [view-like type](ViewLike) with a non-const `value_type` 
-  * ViewSrc: A [view-like type](ViewLike).
+  * ExecSpace: An [ExecutionSpace](../execution_spaces)
+  * ViewDest:A [view-like type](view_like) with a non-const `value_type` 
+  * ViewSrc: A [view-like type](view_like).
 
 ### Requirements:
 
-  * If `src` and `dest` are [Kokkos::View](Kokkos%3A%3AView)s, then all the following are true:
+  * If `src` and `dest` are [Kokkos::View](view)s, then all the following are true:
      * `std::is_same<ViewDest::non_const_value_type, ViewSrc::non_const_value_type>::value == true`
      * `src.rank == dest.rank` (or, for `Kokkos::DynRankView`, `src.rank() == dest.rank()`)
      * For all `k` in `[0, dest.rank)` `dest.extent(k) == src.extent(k)` (or the same as `dest.rank()`
-     * `src.span_is_contiguous() && dest.span_is_contiguous() && std::is_same<ViewDest::array_layout,ViewSrc::array_layout>::value`, *or* there exists an [ExecutionSpace](API-Spaces) `copy_space` (either given or defaulted) such that both `SpaceAccessibility<copy_space, ViewDest::memory_space>::accessible == true` and `SpaceAccessibility<copy_space,ViewSrc::memory_space>::accessible == true`.
-  * If `src` is a [Kokkos::View](Kokkos%3A%3AView) and `dest` is a scalar, then `src.rank == 0` is true.
+     * `src.span_is_contiguous() && dest.span_is_contiguous() && std::is_same<ViewDest::array_layout,ViewSrc::array_layout>::value`, *or* there exists an [ExecutionSpace](../execution_spaces) `copy_space` (either given or defaulted) such that both `SpaceAccessibility<copy_space, ViewDest::memory_space>::accessible == true` and `SpaceAccessibility<copy_space,ViewSrc::memory_space>::accessible == true`.
+  * If `src` is a [Kokkos::View](view) and `dest` is a scalar, then `src.rank == 0` is true.
 
 ## Semantics
 
-* If no [ExecutionSpace](API-Spaces) argument is provided, all outstanding operations (kernels, copy operation) in any execution spaces will be finished before the copy is executed, and the copy operation is finished before the call returns.
-* If an [ExecutionSpace](API-Spaces) argument `exec_space` is provided the call is potentially asynchronous—i.e., the call returns before the copy operation is executed. In that case the copy operation will occur only after any already submitted work to `exec_space` is finished, and the copy operation will be finished before any work submitted to `exec_space` after the `deep_copy` call returns is executed. Note: the copy operation is only synchronous with respect to work in the specific execution space instance, but not necessarily with work in other instances of the same type. This behaves analogous to issuing a `cudaMemcpyAsync` into a specific CUDA stream, without any additional synchronization.
+* If no [ExecutionSpace](../execution_spaces) argument is provided, all outstanding operations (kernels, copy operation) in any execution spaces will be finished before the copy is executed, and the copy operation is finished before the call returns.
+* If an [ExecutionSpace](../execution_spaces) argument `exec_space` is provided the call is potentially asynchronous—i.e., the call returns before the copy operation is executed. In that case the copy operation will occur only after any already submitted work to `exec_space` is finished, and the copy operation will be finished before any work submitted to `exec_space` after the `deep_copy` call returns is executed. Note: the copy operation is only synchronous with respect to work in the specific execution space instance, but not necessarily with work in other instances of the same type. This behaves analogous to issuing a `cudaMemcpyAsync` into a specific CUDA stream, without any additional synchronization.
 
 ## Examples
 

--- a/source/API/core/view/layoutLeft.md
+++ b/source/API/core/view/layoutLeft.md
@@ -6,32 +6,32 @@ This Kokkos Layout, when provided to a multidimensional View, lays out memory su
 
 Usage: 
 
-  ```c++
-  Kokkos::View<float*, Kokkos::LayoutLeft> my_view;
-  ```
+```c++
+Kokkos::View<float*, Kokkos::LayoutLeft> my_view;
+```
 
 ## Synopsis 
-  ```c++
-  struct LayoutLeft {
+```c++
+struct LayoutLeft {
 
-  typedef LayoutLeft array_layout;
+typedef LayoutLeft array_layout;
 
-  size_t dimension[ARRAY_LAYOUT_MAX_RANK];
+size_t dimension[ARRAY_LAYOUT_MAX_RANK];
 
-  enum { is_extent_constructible = true };
+enum { is_extent_constructible = true };
 
-  LayoutLeft(LayoutLeft const&) = default;
-  LayoutLeft(LayoutLeft&&)      = default;
-  LayoutLeft& operator=(LayoutLeft const&) = default;
-  LayoutLeft& operator=(LayoutLeft&&) = default;
+LayoutLeft(LayoutLeft const&) = default;
+LayoutLeft(LayoutLeft&&)      = default;
+LayoutLeft& operator=(LayoutLeft const&) = default;
+LayoutLeft& operator=(LayoutLeft&&) = default;
 
-  KOKKOS_INLINE_FUNCTION
-  explicit constexpr LayoutLeft(size_t N0 = 0, size_t N1 = 0, size_t N2 = 0,
-                                size_t N3 = 0, size_t N4 = 0, size_t N5 = 0,
-                                size_t N6 = 0, size_t N7 = 0)
-      : dimension{N0, N1, N2, N3, N4, N5, N6, N7} {}
-	};
-  ```
+KOKKOS_INLINE_FUNCTION
+explicit constexpr LayoutLeft(size_t N0 = 0, size_t N1 = 0, size_t N2 = 0,
+                            size_t N3 = 0, size_t N4 = 0, size_t N5 = 0,
+                            size_t N6 = 0, size_t N7 = 0)
+  : dimension{N0, N1, N2, N3, N4, N5, N6, N7} {}
+};
+```
 
 ## Public Class Members
 
@@ -53,31 +53,31 @@ Usage:
 
 ### Constructors
 
-  * LayoutLeft(LayoutLeft const&) = default;
+  * `LayoutLeft(LayoutLeft const&) = default;`
 
     Default copy constructor, element-wise copies the other Layout
 
-  * LayoutLeft(LayoutLeft&&)      = default;
+  * `LayoutLeft(LayoutLeft&&) = default;`
  
     Default move constructor, element-wise moves the other Layout
 
   * 
-  ```c++
-  KOKKOS_INLINE_FUNCTION
-  explicit constexpr LayoutLeft(size_t N0 = 0, size_t N1 = 0, size_t N2 = 0,
-                                size_t N3 = 0, size_t N4 = 0, size_t N5 = 0,
-                                size_t N6 = 0, size_t N7 = 0);
-  ```
+```c++
+KOKKOS_INLINE_FUNCTION
+explicit constexpr LayoutLeft(size_t N0 = 0, size_t N1 = 0, size_t N2 = 0,
+                            size_t N3 = 0, size_t N4 = 0, size_t N5 = 0,
+                            size_t N6 = 0, size_t N7 = 0);
+```
   
-  Constructor that takes in up to 8 sizes, to set the sizes of the corresponding dimenesions of the Layout
+  Constructor that takes in up to 8 sizes, to set the sizes of the corresponding dimensions of the Layout
 
 ### Assignment operators
 
-  * LayoutLeft& operator=(LayoutLeft const&) = default;
+  * `LayoutLeft& operator=(LayoutLeft const&) = default;`
 
     Default copy assignment, element-wise copies the other Layout
 
-  * LayoutLeft& operator=(LayoutLeft&&) = default;
+  * `LayoutLeft& operator=(LayoutLeft&&) = default;`
 
     Default move assignment, element-wise moves the other Layout
 

--- a/source/API/core/view/layoutRight.md
+++ b/source/API/core/view/layoutRight.md
@@ -6,32 +6,32 @@ This Kokkos Layout, when provided to a multidimensional View, lays out memory su
 
 Usage: 
 
-  ```c++
-  Kokkos::View<float*, Kokkos::LayoutRight> my_view;
-  ```
+```c++
+Kokkos::View<float*, Kokkos::LayoutRight> my_view;
+```
 
 ## Synopsis 
-  ```c++
-  struct LayoutRight {
+```c++
+struct LayoutRight {
 
-  typedef LayoutRight array_layout;
+typedef LayoutRight array_layout;
 
-  size_t dimension[ARRAY_LAYOUT_MAX_RANK];
+size_t dimension[ARRAY_LAYOUT_MAX_RANK];
 
-  enum { is_extent_constructible = true };
+enum { is_extent_constructible = true };
 
-  LayoutRight(LayoutRight const&) = default;
-  LayoutRight(LayoutRight&&)      = default;
-  LayoutRight& operator=(LayoutRight const&) = default;
-  LayoutRight& operator=(LayoutRight&&) = default;
+LayoutRight(LayoutRight const&) = default;
+LayoutRight(LayoutRight&&)      = default;
+LayoutRight& operator=(LayoutRight const&) = default;
+LayoutRight& operator=(LayoutRight&&) = default;
 
-  KOKKOS_INLINE_FUNCTION
-  explicit constexpr LayoutRight(size_t N0 = 0, size_t N1 = 0, size_t N2 = 0,
-                                size_t N3 = 0, size_t N4 = 0, size_t N5 = 0,
-                                size_t N6 = 0, size_t N7 = 0)
-      : dimension{N0, N1, N2, N3, N4, N5, N6, N7} {}
-	};
-  ```
+KOKKOS_INLINE_FUNCTION
+explicit constexpr LayoutRight(size_t N0 = 0, size_t N1 = 0, size_t N2 = 0,
+                            size_t N3 = 0, size_t N4 = 0, size_t N5 = 0,
+                            size_t N6 = 0, size_t N7 = 0)
+  : dimension{N0, N1, N2, N3, N4, N5, N6, N7} {}
+};
+```
 
 ## Public Class Members
 
@@ -53,23 +53,23 @@ Usage:
 
 ### Constructors
 
-  * LayoutRight(LayoutRight const&) = default;
+  * `LayoutRight(LayoutRight const&) = default;`
 
     Default copy constructor, element-wise copies the other Layout
 
-  * LayoutRight(LayoutRight&&)      = default;
+  * `LayoutRight(LayoutRight&&) = default;`
  
     Default move constructor, element-wise moves the other Layout
 
   * 
-  ```c++
-  KOKKOS_INLINE_FUNCTION
-  explicit constexpr LayoutRight(size_t N0 = 0, size_t N1 = 0, size_t N2 = 0,
-                                size_t N3 = 0, size_t N4 = 0, size_t N5 = 0,
-                                size_t N6 = 0, size_t N7 = 0);
-  ```
+```c++
+KOKKOS_INLINE_FUNCTION
+explicit constexpr LayoutRight(size_t N0 = 0, size_t N1 = 0, size_t N2 = 0,
+                            size_t N3 = 0, size_t N4 = 0, size_t N5 = 0,
+                            size_t N6 = 0, size_t N7 = 0);
+```
   
-  Constructor that takes in up to 8 sizes, to set the sizes of the corresponding dimenesions of the Layout
+  Constructor that takes in up to 8 sizes, to set the sizes of the corresponding dimensions of the Layout
 
 ### Assignment operators
 

--- a/source/API/core/view/layoutStride.md
+++ b/source/API/core/view/layoutStride.md
@@ -8,15 +8,15 @@ Most frequently encountered when taking a noncontiguous subview of some larger v
 
 Usage: 
 
-  ```c++
-  Kokkos::View<float***> full_mesh; // an entire mesh
-  Kokkos::View<float**, Kokkos::LayoutStride> mesh_subcomponent;
-  mesh_subcomponent = Kokkos::subview(full_mesh,Kokkos::ALL(), 0, Kokkos::ALL()); // take x and z components
-  ```
+```c++
+Kokkos::View<float***> full_mesh; // an entire mesh
+Kokkos::View<float**, Kokkos::LayoutStride> mesh_subcomponent;
+mesh_subcomponent = Kokkos::subview(full_mesh,Kokkos::ALL(), 0, Kokkos::ALL()); // take x and z components
+```
 
 ## Synopsis 
-  ```c++
-  struct LayoutStride {
+```c++
+struct LayoutStride {
     typedef LayoutStride array_layout;
   
     size_t dimension[ARRAY_LAYOUT_MAX_RANK];
@@ -41,8 +41,8 @@ Usage:
                                     size_t S4 = 0, size_t N5 = 0, size_t S5 = 0,
                                     size_t N6 = 0, size_t S6 = 0, size_t N7 = 0,
                                     size_t S7 = 0);
-  };
-  ```
+};
+```
 
 ## Public Class Members
 
@@ -68,26 +68,26 @@ Usage:
 
 ### Constructors
 
-  * LayoutStride(LayoutStride const&) = default;
+  * `LayoutStride(LayoutStride const&) = default;`
 
     Default copy constructor, element-wise copies the other Layout
 
-  * LayoutStride(LayoutStride&&)      = default;
+  * `LayoutStride(LayoutStride&&) = default;`
  
     Default move constructor, element-wise moves the other Layout
 
   * 
-  ```c++
-  KOKKOS_INLINE_FUNCTION
-  explicit constexpr LayoutStride(size_t N0 = 0, size_t S0 = 0, size_t N1 = 0,
-                                  size_t S1 = 0, size_t N2 = 0, size_t S2 = 0,
-                                  size_t N3 = 0, size_t S3 = 0, size_t N4 = 0,
-                                  size_t S4 = 0, size_t N5 = 0, size_t S5 = 0,
-                                  size_t N6 = 0, size_t S6 = 0, size_t N7 = 0,
-                                  size_t S7 = 0);
-  ```
+```c++
+KOKKOS_INLINE_FUNCTION
+explicit constexpr LayoutStride(size_t N0 = 0, size_t S0 = 0, size_t N1 = 0,
+                              size_t S1 = 0, size_t N2 = 0, size_t S2 = 0,
+                              size_t N3 = 0, size_t S3 = 0, size_t N4 = 0,
+                              size_t S4 = 0, size_t N5 = 0, size_t S5 = 0,
+                              size_t N6 = 0, size_t S6 = 0, size_t N7 = 0,
+                              size_t S7 = 0);
+```
   
-  Constructor that takes in up to 8 sizes, to set the sizes of the corresponding dimenesions of the Layout
+  Constructor that takes in up to 8 sizes, to set the sizes of the corresponding dimensions of the Layout
 
 ### Assignment operators
 

--- a/source/API/core/view/resize.md
+++ b/source/API/core/view/resize.md
@@ -3,10 +3,10 @@
 Header File: `Kokkos_Core.hpp`
 
 Usage:
-  ```c++
-  resize(view,n0,n1,n2,n3);
-  resize(view,layout);
-  ```
+```c++
+resize(view,n0,n1,n2,n3);
+resize(view,layout);
+```
 
 Reallocates a view to have the new dimensions. Can grow or shrink, and will preserve content of the common subextents.
 
@@ -45,7 +45,6 @@ void resize(const I& arg_prop, Kokkos::View<T, P...>& v,
 ```
 
 ## Description
-
 
 * ```c++
   template <class T, class... P>
@@ -114,4 +113,3 @@ void resize(const I& arg_prop, Kokkos::View<T, P...>& v,
     Kokkos::resize(Kokkos::WithoutInitializing, v, 2, 3);
     ```
     Resize a `Kokkos::View` with dynamic rank 2 to have dynamic extent 2 and 3 respectively preserving previous content. After this call, the new content is uninitialized.
-

--- a/source/API/core/view/subview.md
+++ b/source/API/core/view/subview.md
@@ -3,9 +3,9 @@
 Header File: `Kokkos_Core.hpp`
 
 Usage:
-  ```c++
-  auto s = subview(view,std::pair<int,int>(5,191),Kokkos::ALL,1);
-  ```
+```c++
+auto s = subview(view,std::pair<int,int>(5,191),Kokkos::ALL,1);
+```
 
 Creates a `Kokkos::View` viewing a subset of another `Kokkos::View`.
 
@@ -56,23 +56,19 @@ IMPL_DETAIL subview(const ViewType& v, Args ... args);
 ## Examples
 
 ```c++
+Kokkos::View<double***[5]> a("A",N0,N1,N2);
 
-  Kokkos::View<double***[5]> a("A",N0,N1,N2);
+auto s  = Kokkos::subview(a,
+              std::pair<int,int>(3,15),
+              5,
+              Kokkos::ALL,
+              Kokkos::ALL);
+for(int i0 = 0; i0 < s.extent(0); i0++) 
+for(int i1 = 0; i1 < s.extent(1); i1++) 
+for(int i2 = 0; i2 < s.extent(2); i2++) {
+  assert(s(i0,i1,i2) == a(i0+3,5,i1,i2));
+}
 
-  auto s  = Kokkos::subview(a,
-                std::pair<int,int>(3,15),
-                5,
-                Kokkos::ALL,
-                Kokkos::ALL);
-  for(int i0 = 0; i0 < s.extent(0); i0++) 
-  for(int i1 = 0; i1 < s.extent(1); i1++) 
-  for(int i2 = 0; i2 < s.extent(2); i2++) {
-    assert(s(i0,i1,i2) == a(i0+3,5,i1,i2));
-  }
-
-  auto s3415 = Kokkos::subview(a,3,4,1,5);
-  assert(s3415() == a(3,4,1,5));
+auto s3415 = Kokkos::subview(a,3,4,1,5);
+assert(s3415() == a(3,4,1,5));
 ```
-
-
-

--- a/source/API/core/view/view.md
+++ b/source/API/core/view/view.md
@@ -9,7 +9,7 @@ Its semantics are similar to that of `std::shared_ptr`.
 
 ## Interface
 
-```cpp
+```c++
 template <class DataType [, class LayoutType] [, class MemorySpace] [, class MemoryTraits]>
 class View;
 ```
@@ -23,18 +23,17 @@ Template parameters other than `DataType` are optional, but ordering is enforced
     * `const int***[5][3]`: 5D View of `int` with 3 runtime and 2 compile dimensions. The data is `const`.
     * `Foo[6][2]`: 2D View of a class `Foo` with 2 compile time dimensions.
   * `LayoutType`: determines the mapping of indices into the underlying 1D memory storage. Custom Layouts can be implemented, but Kokkos comes with some built-in ones: 
-    * `LayoutRight`: strides increase from the right most to the left most dimension. The last dimension has a stride of one. This corresponds to how C multi dimensional arrays (`[][][]`) are laid out in memory. 
-    * `LayoutLeft`: strides increase from the left most to the right most dimension. The first dimension has a stride of one. This is the layout Fortran uses for its arrays. 
-    * `LayoutStride`: strides can be arbitrary for each dimension. 
+    * [`LayoutRight`](layoutRight): strides increase from the right most to the left most dimension. The last dimension has a stride of one. This corresponds to how C multi dimensional arrays (`[][][]`) are laid out in memory. 
+    * [`LayoutLeft`](layoutLeft): strides increase from the left most to the right most dimension. The first dimension has a stride of one. This is the layout Fortran uses for its arrays. 
+    * [`LayoutStride`](layoutStride): strides can be arbitrary for each dimension. 
   * `MemorySpace`: Controls the storage location. If omitted the default memory space of the default execution space is used (i.e. `Kokkos::DefaultExecutionSpace::memory_space`)
   * `MemoryTraits`: Sets access properties via enum parameters for the templated `Kokkos::MemoryTraits<>` class. Enums can be combined bit combined. Posible values:
     * `Unmanaged`: The View will not be reference counted. The allocation has to be provided to the constructor.
-    * `Atomic`: All accesses to the view will use atomic operations. 
+    * [`Atomic`](../atomics): All accesses to the view will use atomic operations. 
     * `RandomAccess`: Hint that the view is used in a random access manner. If the view is also `const` this will trigger special load operations on GPUs (i.e. texture fetches).
     * `Restrict`: There is no aliasing of the view by other data structures in the current scope. 
 
 ### Requirements:
-  
 
 ## Public Class Members
 

--- a/source/API/core/view/view_alloc.md
+++ b/source/API/core/view/view_alloc.md
@@ -18,7 +18,7 @@ Create View allocation parameter bundle from argument list. Valid argument list 
 
 ## Synopsis
 
-```cpp
+```c++
 template <class... Args>
 **implementation-detail**
 view_alloc(Args const&... args);
@@ -31,7 +31,7 @@ view_wrap(Args const&... args);
 
 ## Description
 
-* ```cpp
+* ```c++
   template <class... Args>
   **implementation-detail**
   view_alloc(Args const&... args);
@@ -41,7 +41,7 @@ view_wrap(Args const&... args);
   Restrictions:
   * `args`: Cannot contain a pointer to memory.
 
-* ```cpp
+* ```c++
   template <class... Args>
   **implementation-detail**
   view_alloc(Args const&... args);

--- a/source/API/core/view/view_like.md
+++ b/source/API/core/view/view_like.md
@@ -1,0 +1,9 @@
+# View-like Types
+
+View-like types are loosely defined as the set of class templates that behave like [Kokkos::View](view) from an interface perspective. There is not a full formal definition of what this means yet, which means there is no way for users to add to this list in a way that the new class is recognized by Kokkos facilities operating on View-like things. In Kokkos these class templates are considered View-like: 
+  * [Kokkos::View](view) 
+  * [Kokkos::DynRankView](../../containers/DynRankView)
+  * [Kokkos::OffsetView](../../containers/Offset-View)
+  * [Kokkos::DynamicView](../../containers/DynamicView)
+
+Notably, [Kokkos::DualView](../../containers/DualView) and [Kokkos::ScatterView](../../containers/ScatterView) are **not** included in this category.

--- a/source/ProgrammingGuide/View.md
+++ b/source/ProgrammingGuide/View.md
@@ -109,7 +109,7 @@ You might also want a View of some class that itself contains Views. If you want
 A View of Views would have an "outer View," with zero or more "inner Views." [Section 6.2.2](view_types_of_data) above explains how the outer View's constructor would work.  The outer View's constructor does not just allocate memory; it also initializes the allocation by iterating over it using a [`Kokkos::parallel_for`](../API/core/parallel_for), and invoking the entry type's default constructor for each entry.  If the View's execution space is `Cuda`, then that means the entry type's default constructor needs to be correct to call on device. That is a problem, because the entry type in this case is itself View. View's constructor wants to allocate memory, and thus does not work on device. Kokkos parallel regions generally forbid memory allocation.
 
 You could create the outer View without initializing, like this:
-```cpp
+```c++
 using Kokkos::View;
 using Kokkos::view_alloc;
 using Kokkos::WithoutInitializing;
@@ -138,7 +138,7 @@ Here is how to create a View of Views, where each inner View has a separate owni
   7. Get rid of the outer View as you normally would.
 
 Here is an example:
-```cpp
+```c++
 using Kokkos::Cuda;
 using Kokkos::CudaSpace;
 using Kokkos::CudaUVMSpace;
@@ -246,7 +246,7 @@ For efficiency, View allocation and reference counting turn off inside of Kokkos
 ### 6.2.6 Lifetime
 
 The lifetime of an allocation begins when a View is constructed by an allocating constructor such as
-```cpp
+```c++
 Kokkos::View<int*> b("b", 10);
 ```
 The lifetime of an allocation ends when there are no more Views which reference that allocation (see reference counting above).
@@ -254,7 +254,7 @@ The lifetime of an allocation ends when there are no more Views which reference 
 Kokkos requires that the lifetime of all allocations ends before the call to [`Kokkos::finalize`](../API/core/initialize_finalize/finalize)!
 
 For example, the following is incorrect usage of Kokkos:
-```cpp
+```c++
 int main() {
   Kokkos::initialize();
   Kokkos::View<double*> p("constructed view", 100);


### PR DESCRIPTION
### THIS PR:
- added links, changed cpp to c++ code block in create_mirror.md
- fixed indentation, links, changed cpp to c++ code block in deep_copy.md
- fixed indentation, formatted and fixed grammar layoutLeft.md
- fixed indentation, formatted and fixed grammar layoutRight.md
- fixed indentation, formatted and fixed grammar layoutStride.md
- removed blank lines and fixed indentation in resize.md
- removed blank lines, fixed indentation in subview.md
- added `view_like` to View.rst
- changed cpp to c++ code block in View.md
- added missing view_like to API/core/view
- changed cpp to c++ code block in view_alloc.md
- fixed links in view_like.md
- added links, removed blank line and changed cpp to c++ code block in view.md