### PR TITLE
#32: Fix API containers

### DIFF
--- a/source/API/containers/Bitset.md
+++ b/source/API/containers/Bitset.md
@@ -1,4 +1,3 @@
-
 # `Bitset`
 
 Header file: `Kokkos_Bitset.hpp`
@@ -25,13 +24,13 @@ class Bitset;
 ### Static Constants
 
 ```c++
-  static constexpr unsigned BIT_SCAN_REVERSE   = 1u
-  static constexpr unsigned MOVE_HINT_BACKWARD = 2u
+static constexpr unsigned BIT_SCAN_REVERSE   = 1u
+static constexpr unsigned MOVE_HINT_BACKWARD = 2u
 
-  static constexpr unsigned BIT_SCAN_FORWARD_MOVE_HINT_FORWARD = 0u
-  static constexpr unsigned BIT_SCAN_REVERSE_MOVE_HINT_FORWARD = BIT_SCAN_REVERSE
-  static constexpr unsigned BIT_SCAN_FORWARD_MOVE_HINT_BACKWARD = MOVE_HINT_BACKWARD
-  static constexpr unsigned BIT_SCAN_REVERSE_MOVE_HINT_BACKWARD = BIT_SCAN_REVERSE | MOVE_HINT_BACKWARD
+static constexpr unsigned BIT_SCAN_FORWARD_MOVE_HINT_FORWARD = 0u
+static constexpr unsigned BIT_SCAN_REVERSE_MOVE_HINT_FORWARD = BIT_SCAN_REVERSE
+static constexpr unsigned BIT_SCAN_FORWARD_MOVE_HINT_BACKWARD = MOVE_HINT_BACKWARD
+static constexpr unsigned BIT_SCAN_REVERSE_MOVE_HINT_BACKWARD = BIT_SCAN_REVERSE | MOVE_HINT_BACKWARD
 ```
 
 * ```BIT_SCAN_REVERSE``` : Bit mask for scanning direction
@@ -57,59 +56,59 @@ class Bitset;
 ### Constructors
 
 ```c++
-    Bitset(unsigned arg_size = 0u)
+Bitset(unsigned arg_size = 0u)
 ```
 Host/Device: Construct a bitset with ```arg_size``` bits.
 
 ## Data Access Functions
 
 ```c++
-  unsigned size() const
+unsigned size() const
 ```
   Host/Device: return the number of bits.
 
 ```c++
-  unsigned count() const
+unsigned count() const
 ```
   Host: return the number of bits which are set to ```1```.
 
 ```c++
-  void set()
+void set()
 ```
   Host: set all the bits to ```1```.
 
 ```c++
-  void reset();
-  void clear();
+void reset();
+void clear();
 ```
   Host/Device: set all the bits to ```0```.
 
 ```c++
-  void set(unsigned i)
+void set(unsigned i)
 ```
   Device: set the ```i```'th bit to ```1```.
 
 ```c++
-  void reset(unsigned i)
+void reset(unsigned i)
 ```
   Device: set the ```i```'th bit to ```0```.
 
 ```c++
-  bool test(unsigned i) const
+bool test(unsigned i) const
 ```
   Device: return ```true``` if and only if the ```i```'th bit is set to ```1```.
 
 ```c++
-  unsigned max_hint() const
+unsigned max_hint() const
 ```
   Host/Device: used with ```find_any_set_near(...)``` & ```find_any_reset_near(...)``` functions.
   Returns the max number of times those functions should be call
   when searching for an available bit.
 
 ```c++
-  Kokkos::pair<bool, unsigned> find_any_set_near(
-      unsigned hint,
-      unsigned scan_direction = BIT_SCAN_FORWARD_MOVE_HINT_FORWARD) const
+Kokkos::pair<bool, unsigned> find_any_set_near(
+  unsigned hint,
+  unsigned scan_direction = BIT_SCAN_FORWARD_MOVE_HINT_FORWARD) const
 ```
   Host/Device: starting at the `hint` position,
                find the first bit set to ```1```.
@@ -122,9 +121,9 @@ Host/Device: Construct a bitset with ```arg_size``` bits.
   otherwise, it occurs at a larger index than ```hint```.
 
 ```c++
-  Kokkos::pair<bool, unsigned> find_any_unset_near(
-      unsigned hint,
-      unsigned scan_direction = BIT_SCAN_FORWARD_MOVE_HINT_FORWARD) const;
+Kokkos::pair<bool, unsigned> find_any_unset_near(
+  unsigned hint,
+  unsigned scan_direction = BIT_SCAN_FORWARD_MOVE_HINT_FORWARD) const;
 ```
   Host/Device: starting at the `hint` position,
                find the first bit set to ```0```.
@@ -137,12 +136,9 @@ Host/Device: Construct a bitset with ```arg_size``` bits.
   otherwise, it occurs at a larger index than ```hint```.
 
 ```c++
-  constexpr bool is_allocated() const
+constexpr bool is_allocated() const
 ```
   Host/Device: the bits are allocated on the device.
-
-<br/>
-
 
 # `ConstBitset`
 
@@ -160,19 +156,19 @@ class ConstBitset
 ### Constructors / assignment
 
 ```c++
-  ConstBitset()
+ConstBitset()
 ```
   Host/Device: Construct a bitset with no bits.
 
 ```c++
-  ConstBitset(ConstBitset const& rhs) = default
-  ConstBitset& operator=(ConstBitset const& rhs) = default
+ConstBitset(ConstBitset const& rhs) = default
+ConstBitset& operator=(ConstBitset const& rhs) = default
 ```
   Copy constructor/assignment operator.
 
 ```c++
-  ConstBitset(Bitset<Device> const& rhs)
-  ConstBitset& operator=(Bitset<Device> const& rhs)
+ConstBitset(Bitset<Device> const& rhs)
+ConstBitset& operator=(Bitset<Device> const& rhs)
 ```
   Host/Device: Copy/assign a ```Bitset``` to a ```ConstBitset```.
 
@@ -182,12 +178,12 @@ class ConstBitset
   Host/Device: return the number of bits.
 
 ```c++
-  unsigned count() const
+unsigned count() const
 ```
    Host/Device: return the number of bits which are set to ```1```.
 
 ```c++
-  bool test(unsigned i) const
+bool test(unsigned i) const
 ```
   Host/Device: Return ```true``` if and only if the ```i```'th bit set to ```1```.
 
@@ -211,4 +207,3 @@ template <typename DstDevice, typename SrcDevice>
 void deep_copy(ConstBitset<DstDevice>& dst, ConstBitset<SrcDevice> const& src)
 ```
 Copy a ```ConstBitset``` from ```src``` on ```SrcDevice``` to ```dst``` on ```DstDevice```.
-

--- a/source/API/containers/DualView.md
+++ b/source/API/containers/DualView.md
@@ -1,9 +1,8 @@
-
 # `DualView`
 
 Container to manage mirroring a Kokkos::View that references device memory with a Kokkos::View that references host memory.  The class provides capabilities to manage data which exists in two different memory spaces at the same time.  It supports views with the same layout on two memory spaces as well as modified flags for both allocations.  Users are responsible for updating the modified flags manually if they change the data in either memory space, by calling the sync() method, which is templated on the device with the modified data.  Users may also synchronize data by calling the modify() function, which is templated on the device that requires synchronization (i.e., the target of the one-way copy operation).
  
-The DualView class also provides convenience methods such as realloc, resize and capacity which call the appropriate methods of the underlying [Kokkos::View](Kokkos%3A%3AView) objects.
+The DualView class also provides convenience methods such as realloc, resize and capacity which call the appropriate methods of the underlying [Kokkos::View](../core/view/view) objects.
  
 The four template arguments are the same as those of Kokkos::View.
  
@@ -18,18 +17,18 @@ The four template arguments are the same as those of Kokkos::View.
 Usage:
 
 ```c++
-    using view_type = Kokkos::DualView<Scalar**, 
-                                       Kokkos::LayoutLeft, 
-                                       Device>
-    view_type a("A", n, m);
+using view_type = Kokkos::DualView<Scalar**, 
+                                   Kokkos::LayoutLeft, 
+                                   Device>
+view_type a("A", n, m);
 
-    Kokkos::deep_copy(a.d_view, 1);
-    a.template modify<typename view_type::execution_space>();
-    a.template sync<typename view_type::host_mirror_space>();
+Kokkos::deep_copy(a.d_view, 1);
+a.template modify<typename view_type::execution_space>();
+a.template sync<typename view_type::host_mirror_space>();
 
-    Kokkos::deep_copy(a.h_view, 2);
-    a.template modify<typename ViewType::host_mirror_space>();
-    a.template sync<typename ViewType::execution_space>();
+Kokkos::deep_copy(a.h_view, 2);
+a.template modify<typename ViewType::host_mirror_space>();
+a.template sync<typename ViewType::execution_space>();
 ```
 
 ## Synopsis
@@ -321,6 +320,4 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
 
 
 };
-
-
 ```

--- a/source/API/containers/DynRankView.md
+++ b/source/API/containers/DynRankView.md
@@ -1,17 +1,16 @@
-
 # `DynRankView`
 
 Header File: `Kokkos_DynRankView.hpp`
 
 Usage: 
 
-`DynRankView` is a potentially reference counted multi dimensional array with compile time layouts and memory space.
+`DynRankView` is a potential reference counted multidimensional array with compile time layouts and memory space.
 Its semantics are similar to that of `std::shared_ptr`.
 The `DynRankView` differs from the [[View|Kokkos::View]] in that its rank is not provided with the `DataType` template parameter; it is determined dynamically based on the number of extent arguments passed to the constructor. The rank has an upper bound of 7 dimensions.
 
 ## Interface
 
-```cpp
+```c++
 template <class DataType [, class LayoutType] [, class MemorySpace] [, class MemoryTraits]>
 class DynRankView;
 ```
@@ -34,7 +33,6 @@ Template parameters other than `DataType` are optional, but ordering is enforced
     * `Restrict`: There is no aliasing of the view by other data structures in the current scope. 
 
 ### Requirements:
-  
 
 ## Public Class Members
 
@@ -47,7 +45,6 @@ Template parameters other than `DataType` are optional, but ordering is enforced
 ### Typedefs
 
 #### Data Types
-
  *  `data_type`: the `DataType` of the DynRankView.
  *  `const_data_type`: const version of `DataType`, same as `data_type` if that is already const.
  *  `non_const_data_type`: non-const version of `DataType`, same as `data_type` if that is already non-const.
@@ -84,7 +81,6 @@ Template parameters other than `DataType` are optional, but ordering is enforced
  *  `specialize`: a specialization tag used for partial specialization of the mapping construct underlying a Kokkos DynRankView.
 
 ### Constructors
-
   * `DynRankView()`: default constructor. No allocations are made, no reference counting happens. All extents are zero and its data pointer is `nullptr` and its rank is set to 0.
   * `DynRankView( const DynRankView<DT, Prop...>& rhs)`: Copy constructor with compatible DynRankViews. Follows DynRankView assignment rules. 
   * `DynRankView( DynRankView&& rhs)`: move constructor
@@ -124,13 +120,13 @@ Template parameters other than `DataType` are optional, but ordering is enforced
   * ```c++
     reference_type operator() (const IntType& ... indices) const
     ```
-    Returns a value of `reference_type` which may or not be referenceable itself. The number of index arguments must match the `rank` of the view.
+    Returns a value of `reference_type` which may or not be reference itself. The number of index arguments must match the `rank` of the view.
     See notes on `reference_type` for properties of the return type. 
 
   * ```c++
     reference_type access (const IntType& i0=0, ... , const IntType& i6=0) const
     ```
-    Returns a value of `reference_type` which may or not be referenceable itself. The number of index arguments must be equal or larger than the `rank` of the view.
+    Returns a value of `reference_type` which may or not be reference itself. The number of index arguments must be equal or larger than the `rank` of the view.
     Index arguments beyond `rank` must be `0`, which will be enforced if `KOKKOS_DEBUG` is defined. 
     See notes on `reference_type` for properties of the return type. 
 
@@ -258,7 +254,6 @@ These rules only cover cases where both layouts are one of `LayoutLeft`, `Layout
 
 
 ## Examples
-
 
 ```c++
 #include<Kokkos_Core.hpp>

--- a/source/API/containers/DynamicView.md
+++ b/source/API/containers/DynamicView.md
@@ -1,4 +1,3 @@
-
 # `DynamicView`
 
 Header File: `Kokkos_DynamicView.hpp`
@@ -6,27 +5,26 @@ Header File: `Kokkos_DynamicView.hpp`
 Usage: 
 Kokkos DynamicView is a potentially reference-counted rank 1 array, without layout, that can be dynamically resized on the host.
 
-  ```c++
-  const int chunk_size = 16*1024;
-  Kokkos::Experimental::DynamicView<double*> view("v", chunk_size, 10*chunk_size);
-  view.resize_serial(3*chunk_size);
-  Kokkos::parallel_for("InitializeData", 3*chunk_size, KOKKOS_LAMBDA ( const int i) {
-      view(i) = i;
-    });
-  ```
+```c++
+const int chunk_size = 16*1024;
+Kokkos::Experimental::DynamicView<double*> view("v", chunk_size, 10*chunk_size);
+view.resize_serial(3*chunk_size);
+Kokkos::parallel_for("InitializeData", 3*chunk_size, KOKKOS_LAMBDA ( const int i) {
+  view(i) = i;
+});
+```
 
 ## Synopsis 
 
   A rank 1 View-like class, instances can be dynamically resized on the host up to an upper limit provided by users at construction.
 
-  ```c++
-  template< typename DataType , typename ... P >
-  class DynamicView : public Kokkos::ViewTraits< DataType , P ... >
-  {
-  public:
+```c++
+template< typename DataType , typename ... P >
+class DynamicView : public Kokkos::ViewTraits< DataType , P ... >
+{
+public:
     typedef Kokkos::ViewTraits< DataType , P ... >  traits ;
-  private:
-  
+private:
     template< class , class ... > friend class DynamicView ;
     typedef Kokkos::Impl::SharedAllocationTracker  track_type ;
     template< class Space , bool = Kokkos::Impl::MemorySpaceAccess< Space , typename traits::memory_space >::accessible > struct verify_space;
@@ -38,7 +36,7 @@ Kokkos DynamicView is a potentially reference-counted rank 1 array, without layo
     unsigned                       m_chunk_max ;   // number of entries in the chunk array - each pointing to a chunk of extent == m_chunk_size entries
     unsigned                       m_chunk_size ;  // 2 << (m_chunk_shift - 1)
   
-  public:
+public:
     typedef DynamicView< typename traits::data_type, typename traits::device_type > array_type ;
     typedef DynamicView< typename traits::const_data_type, typename traits::device_type > const_type ;
     typedef DynamicView< typename traits::non_const_data_type, typename traits::device_type > non_const_type ;
@@ -128,8 +126,8 @@ Kokkos DynamicView is a potentially reference-counted rank 1 array, without layo
   
     explicit inline
     DynamicView( const std::string & arg_label, const unsigned min_chunk_size, const unsigned max_extent );
-  };
-  ```
+};
+```
   
 ## Public Class Members
 
@@ -286,4 +284,4 @@ Kokkos DynamicView is a potentially reference-counted rank 1 array, without layo
   * ```c++
     bool is_allocated() const;
     ```
-    Returns true if the View points to a valid set of allocated memory chunks.  Note that this will return false until resize_serial is called with a size greater than 0.  
+    Returns true if the View points to a valid set of allocated memory chunks.  Note that this will return false until resize_serial is called with a size greater than 0.

--- a/source/API/containers/Offset-View.md
+++ b/source/API/containers/Offset-View.md
@@ -1,4 +1,3 @@
-
 # `OffsetView`
 
 The OffsetView is in the Experimental namespace.
@@ -11,14 +10,14 @@ Sometimes, it is advantageous to have the indices of an array begin at something
 An OffsetView must have a label, and at least one dimension.  Only runtime extents are supported, but otherwise the semantics of an OffsetView are similar to those of a View.  
 
 ```c++
- const size_t min0 = ...; 
- const size_t max0 = ...; 
- const size_t min1 = ...; 
- const size_t max1 = ...; 
- const size_t min2 = ...; 
- const size_t max2 = ...; 
+const size_t min0 = ...; 
+const size_t max0 = ...; 
+const size_t min1 = ...; 
+const size_t max1 = ...; 
+const size_t min2 = ...; 
+const size_t max2 = ...; 
 
- OffsetView<int***> a("someLabel", {min0, max0}, {min1, max1},{min2, max2});
+OffsetView<int***> a("someLabel", {min0, max0}, {min1, max1},{min2, max2});
 ```
 Construction from a layout is also allowed.  
 

--- a/source/API/containers/StaticCrsGraph.md
+++ b/source/API/containers/StaticCrsGraph.md
@@ -1,0 +1,21 @@
+# `StaticCrsGraph`
+
+The StaticCrsGraph is a Compressed row storage array with the row map, the column indices and the non-zero entries stored in 3 different Kokkos::Views.  Appropriate types and functions are provided to simplify manipulation and access to CRS data on either a host or device.
+
+Usage:
+
+```C++
+using StaticCrsGraphType = Kokkos::StaticCrsGraph<unsigned, Space, void, void, unsigned>;
+StaticCrsGraphType graph();
+
+const int begin = graph.row_map[0];
+const int end = graph.row_map[1];
+
+double sum = 0;
+for (int i = begin; i < end; i++) {
+  Kokkos::View<unsigned, Space> v(graph.entries(i));
+  for (int j = 0; j < v.extent(0); j++) {
+     sum += v(j);
+  }
+}
+```

--- a/source/API/containers/Unordered-Map.md
+++ b/source/API/containers/Unordered-Map.md
@@ -1,11 +1,10 @@
-
 # `UnorderedMap`
 
-Kokkos's unordered map is designed to efficently handle tens of thousands of concurrent insertions.  Consequently, the API is signifcantly different from the standard unordered_map.  The two key differences are *fixed capacity* and *index based*.
+Kokkos's unordered map is designed to efficiently handle tens of thousands of concurrent insertions.  Consequently, the API is significantly different from the standard unordered_map.  The two key differences are *fixed capacity* and *index based*.
 
 *Fixed capacity*:  The capacity of the unordered_map is fix when inside a parallel algorithm.  This means that an insert can fail when the capacity of the map is exceeded.  The capacity of the map can be changed (rehash) from the host.
 
-*Index based*:  Instead of returning pointers or iterators (which would not work when moving between memory spaces) the map uses integer indexes.  This also allows the map to store data in cache friendly ways.  The availablity of indexes is managed by an internal atomic bitset based on `uint32_t`.
+*Index based*:  Instead of returning pointers or iterators (which would not work when moving between memory spaces) the map uses integer indexes.  This also allows the map to store data in cache friendly ways.  The availability of indexes is managed by an internal atomic bitset based on `uint32_t`.
 
 An `UnorderedMap` behaves like an unordered set if the template parameter `Value` is void.
 
@@ -93,7 +92,6 @@ public:
 
 There are 3 potential states for every insertion which are reported by the `UnorderedMapInsertResult`: success, existing, and failed.  `success` implies that the current thread has successfully inserted its key/value pair.  `existing` implies that the key is already in the map and its current value is unchanged.  `failed` means that either the capacity of the map was exhausted or that a free index was not found with a bounded search of the internal atomic bitset.  A `failed` insertion requires the user to increase the capacity (`rehash`) and restart the algoritm.
 
-
 ## Iteration
 
 Iterating over Kokkos' `UnorderedMap` is different from iterating over a standard container.  The pattern is to iterate over the capacity of the map and check if the current index is valid.
@@ -110,7 +108,3 @@ parallel_for(umap.capacity(), KOKKOS_LAMBDA (uint32_t i) {
   }
 });
 ```
-
-
-
-

--- a/source/API/containers/vector.md
+++ b/source/API/containers/vector.md
@@ -1,0 +1,150 @@
+# `vector`
+
+The Kokkos Vector is semantically similar to the std::vector, but it is designed to overcome issues with memory allocations and copies when working with devices that have different memory spaces.  The Kokkos::Vector is a Rank-1 DualView that implements the same interface as the std::vector.  This allows programs that rely heavily on std::vector to grant access to program data from within a non-host execution space.  Note that many of the std::vector compatible functions are host only, so access may be limited based on kernel complexity.  Below is a synopsis of the class and the description for each method specifies whether it is supported on the host, device or both. 
+
+Usage:
+
+```C++
+Kokkos::vector<Scalar, Device> v(n,1);
+v.push_back(2);
+v.resize(n+3);
+v.[n+1] = 3;
+v.[n+2] = 4;
+```
+
+## Synopsis
+```C++
+template <class Scalar, class Arg1Type = void>
+class vector : public DualView<Scalar*, LayoutLeft, Arg1Type> {
+
+// Typedefs 
+
+  // Scalar value type
+  typedef Scalar value_type;
+
+  // Scalar pointer type
+  typedef Scalar* pointer;
+
+  // Const Scalar pointer type
+  typedef const Scalar* const_pointer;
+
+  // Scalar reference type
+  typedef Scalar& reference;
+
+  // Const Scalar reference type
+  typedef const Scalar& const_reference;
+  
+  // Iterator type
+  typedef Scalar* iterator;
+
+  // Const iterator type
+  typedef const Scalar* const_iterator;
+
+  // Accessor [Host only]
+  KOKKOS_INLINE_FUNCTION reference operator()(int i) const;
+
+  // Accessor [Host only]
+  KOKKOS_INLINE_FUNCTION reference operator[](int i) const;
+
+// Constructors
+
+  // Construct empty vector
+  vector();
+
+  // Construct vector of size n + 10% and initialize values to `val` 
+  vector(int n, Scalar val = Scalar());
+
+  // Resize vector to size n + 10%
+  void resize(size_t n);
+
+  // Resize vector to size n + 10% and set values to `val`
+  void resize(size_t n, const Scalar& val);
+
+  // Set n values to `val`
+  // will auto synchronize between host and device
+  void assign(size_t n, const Scalar& val); 
+
+  // same as resize (for compatibility)
+  void reserve(size_t n);
+
+  // resize vector to size() + 1 and set last value to val
+  // [Host only, auto synchronize device]
+  void push_back(Scalar val);
+
+  // reduce size() by 1  
+  void pop_back();
+
+  // set size() to 0
+  void clear() ;
+
+  // return number of elements in vector
+  size_type size() const;
+
+  // return maximum possible number of elements
+  size_type max_size() const;
+
+  // return memory used by vector 
+  size_type span() const;
+
+  // returns true if vector is empty
+  bool empty() const;
+
+  // returns pointer to the underlying array
+  // [Host only]
+  pointer data() const;
+
+  // returns iterator starting at the beginning
+  // [Host only]
+  iterator begin() const;
+
+  // returns iterator past the last element
+  // [Host only]
+  iterator end() const;
+
+  // returns reference to the front of the list
+  // [Host only]
+  reference front();
+
+  // returns reference to the last element in the list
+  // [Host only]
+  reference back();
+
+  // returns const reference to the front of the list
+  // [Host only]
+  const_reference front() const;
+
+  // returns const reference to the last element in the list
+  // [Host only]
+  const_reference back() const;
+
+  // Return the index of largest value satisfying val < comp_val within the
+  // range start-theEnd, [Host only]
+  size_t lower_bound(const size_t& start, const size_t& theEnd,
+                     const Scalar& comp_val) const;
+  // Return true if the list is sorted
+  bool is_sorted();
+
+  // return iterator pointing to element matching `val` 
+  iterator find(Scalar val) const;
+  
+  // copy data from device to host
+  void device_to_host();
+
+  // copy data from host to device
+  void host_to_device() const;
+
+  // update/synchronize data in dual view from host perspective
+  void on_host();
+
+  // update/synchronize data in dual view from the device perspective 
+  void on_device(); 
+
+  // set the data buffer available at the end of the vector
+  void set_overallocation(float extra);
+  
+  // returns true if the internal views (host and device) are allocated 
+  // (non-null pointers).
+  constexpr bool is_allocated() const;
+    
+};
+```


### PR DESCRIPTION
### THIS PR:
- removed blank lines and fixed indentation in Bitset.md
- removed blank lines and fixed indentation in DualView.md
- removed blank lines and fixed indentation in DynamicView.md
- removed blank lines, fixed indentation, grammar and changed cpp to c++ code block in DynRankView.md
- fixed indentation and removed blank lines in Offset-View.md
- added missing StaticCrsGraph to API/containers
- added StaticCrsGraph to containers-index.rst
- change title in StaticCrsGraph.md for consistency
- fixed grammar and removed blank lines in API/containers/Unordered-Map
- formatted title in Unordered-Map.md for consistency
- added missing vector to API/containers
- added `ScatterView` and `vector` to API/containers-index
- formatted title in vector.md for consistency