### PR TITLE
#32: Fix Parallel Execution Spaces

### DIFF
--- a/source/API/core-index.rst
+++ b/source/API/core-index.rst
@@ -8,15 +8,20 @@ API: Core
    ./core/parallel_for
    ./core/parallel_reduce
    ./core/parallel_scan
+   ./core/ParallelForTag
+   ./core/ParallelReduceTag
+   ./core/ParallelScanTag
    ./core/atomics
    ./core/builtin_reducers
    ./core/CStyleMemManagement
    ./core/Detection-Idiom
    ./core/Execution-Policies
    ./core/Initialize-and-Finalize
+   ./core/KokkosConcepts
    ./core/Numerics
    ./core/Spaces
    ./core/STL-Compatibility
    ./core/Task-Parallelism
+   ./core/Traits
    ./core/Utilities
    ./core/View

--- a/source/API/core/execution_spaces.md
+++ b/source/API/core/execution_spaces.md
@@ -1,79 +1,196 @@
-
 # Execution Spaces
 
-
+(Cuda)=
 ## `Kokkos::Cuda`
 
 `Kokkos::Cuda` is an [`ExecutionSpace` type](ExecutionSpaceConcept) representing execution on a Cuda device.  Except in rare instances, it should not be used directly, but instead should be used generically as an execution space.  For details, see [the documentation on the `ExecutionSpace` concept](ExecutionSpaceConcept).
 
+(HPX)=
 ## `Kokkos::HPX`
 
 `Kokkos::HPX` is an [`ExecutionSpace` type](ExecutionSpaceConcept) representing execution with the HPX runtime system.  Except in rare instances, it should not be used directly, but instead should be used generically as an execution space.  For details, see [the documentation on the `ExecutionSpace` concept](ExecutionSpaceConcept).
 
+(OpenMP)=
 ## `Kokkos::OpenMP`
 
 `Kokkos::OpenMP` is an [`ExecutionSpace` type](ExecutionSpaceConcept) representing execution with the OpenMP runtime system.  Except in rare instances, it should not be used directly, but instead should be used generically as an execution space.  For details, see [the documentation on the `ExecutionSpace` concept](ExecutionSpaceConcept).
 
+(OpenMPTarget)=
 ## `Kokkos::OpenMPTarget`
 
 `Kokkos::OpenMPTarget` is an [`ExecutionSpace` type](ExecutionSpaceConcept) representing execution using the target offloading feature of the OpenMP runtime system.  Except in rare instances, it should not be used directly, but instead should be used generically as an execution space.  For details, see [the documentation on the `ExecutionSpace` concept](ExecutionSpaceConcept)
 
-
+(Serial)=
 ## `Kokkos::Serial`
 
 `Kokkos::Serial` is an [`ExecutionSpace` type](ExecutionSpaceConcept) representing serial execution the CPU.  Except in rare instances, it should not be used directly, but instead should be used generically as an execution space.  For details, see [the documentation on the `ExecutionSpace` concept](ExecutionSpaceConcept).
 
+(ExecutionSpaceConcept)=
+## `Kokkos::ExecutionSpaceConcept`
 
+The concept of an `ExecutionSpace` is the fundamental abstraction to represent the "where" and the "how" that execution takes place in Kokkos.  Most code that uses Kokkos should be written to the *generic concept* of an `ExecutionSpace` rather than any specific instance.  This page talks practically about how to *use* the common features of execution spaces in Kokkos; for a more formal and theoretical treatment, see [this document](KokkosConcepts).
 
-## Kokkos::ExecutionSpaceConcept
+> *Disclaimer*: There is nothing new about the term "concept" in C++; anyone who has ever used templates in C++ has used concepts whether they knew it or not.  Please do not be confused by the word "concept" itself, which is now more often associated with a shiny new C++20 language feature.  Here, "concept" just means "what you're allowed to do with a type that is a template parameter in certain places".
+
+### Very Simplest Use: Not at all?
+
+When first starting to use Kokkos, the (surprising) answer to where you'll see [`ExecutionSpace`s](ExecutionSpaceConcept) used explicitly is "nowhere".  Many of the first things most users learn are "shortcuts" for "do this thing using the default execution space," which is a type alias (a.k.a., `typedef`) named `Kokkos::DefaultExecutionSpace` defined based on build system flags. For instance,
+
+```c++
+Kokkos::parallel_for(
+  42,
+  KOKKOS_LAMBDA (int n) { /* ... */ }
+);
+```
+
+is a "shortcut" for
+
+```c++
+Kokkos::parallel_for(
+  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(
+    Kokkos::DefaultExecutionSpace(), 0, 42
+  ),
+  KOKKOS_LAMBDA(int n) { /* ... */ }
+);
+```
+
+### Being more generic
+
+For more intermediate and advanced users, however, it is often good practice to write code that is explicitly generic over the execution space, so that calling code can pass in a non-default execution space if needed.  For instance, if the simple version of your function is
+
+```c++
+void my_function(Kokkos::View<double*> data, double scale) {
+  Kokkos::parallel_for(
+    data.extent(0),
+    KOKKOS_LAMBDA (int n) {
+      data(n) *= scale;
+    }
+  );
+}
+```
+
+then a more advanced, more flexible version of your function might look like:
+
+```c++
+template <class ExecSpace, class ViewType>
+void my_function(
+  ExecSpace ex,
+  ViewType data,
+  double scale
+) {
+  static_assert(
+    Kokkos::SpaceAccessibility<ExecSpace, typename ViewType::memory_space>::assignable,
+    "Incompatible ViewType and ExecutionSpace"
+  );
+  Kokkos::parallel_for(
+    Kokkos::RangePolicy<ExecSpace>(ex, 0, data.extent(0)),
+    KOKKOS_LAMBDA (int n) {
+      data(n) *= scale;
+    }
+  );
+}
+```
+
+More advanced users may also prefer the more explicit form simply to avoid the additional mental exercise of translating "shortcuts" when reading the code later.  Being explicit about *where* and *how* Kokkos parallel patterns are executing tends to reduce bugs, even if it is more verbose.
+
+### Functionality
+
+All `ExecutionSpace` types expose a common set of functionality.  In generic code that uses Kokkos (which is pretty much all user code), you should never use any part of an execution space type that isn't common to all execution space types (otherwise, you risk losing portability of your code).  There are a few expressions guaranteed to be valid for any `ExecutionSpace` type.  Given a type `Ex` that is an `ExecutionSpace` type, and an instance of that type `ex`, Kokkos guarantees the following expressions will provide the specified functionality:
+
+```c++
+ex.name();
+```
+
+*Returns:* a value convertible to `const char*` that is guaranteed to be unique to a given `ExecutionSpace` instance type.
+*Note:* the pointer returned by this function may not be accessible from the `ExecutionSpace` itself (for instance, on a device); use with caution.
+
+```c++
+ex.in_parallel();
+```
+
+*Returns:* a value convertible to `bool` indicating whether or not the caller is executing as part of a Kokkos parallel pattern.
+*Note:* as currently implemented, there is no guarantee that `true` means the caller is necessarily executing as part of a pattern on the particular instance `ex`; just *some* instance of `Ex`.  This may be strengthened in the future.
+
+```c++
+ex.fence();
+```
+
+*Effects:* Upon return, all parallel patterns executed on the instance `ex` are guaranteed to have completed, and their effects are guaranteed visible to the calling thread.
+*Returns:* Nothing.
+*Note:* This *cannot* be called from within a parallel pattern.  Doing so will lead to unspecified effects (i.e., it might work, but only for some execution spaces, so be extra careful not to do it).
+
+```c++
+ex.print_configuration(ostr);
+ex.print_configuration(ostr, detail);
+```
+
+where `ostr` is a `std::ostream` (like `std::cout`, for instance) and `detail` is a boolean indicating whether a detailed description should be printed.
+
+*Effects:* Outputs the configuration of `ex` to the given `std::ostream`.
+*Returns:* Nothing.
+*Note:* This *cannot* be called from within a parallel pattern. 
+
+Additionally, the following type aliases (a.k.a. `typedef`s) will be defined by all execution space types:
+
+* `Ex::memory_space`: the default [`MemorySpace`](MemorySpaceConcept) to use when executing with `Ex`.  Kokkos guarantees that `Kokkos::SpaceAccessibility<Ex, Ex::memory_space>::accessible` will be `true` (see [`Kokkos::SpaceAccessibility`](SpaceAccessibility))
+* `Ex::array_layout`: the default `ArrayLayout` recommended for use with `View` types accessed from `Ex`.
+* `Ex::scratch_memory_space`: the `ScratchMemorySpace` that parallel patterns will use for allocation of scratch memory (for instance, as requested by a [`Kokkos::TeamPolicy`](policies/TeamPolicy)).
+
+#### Default Constructibility, Copy Constructibility
+
+In addition to the above functionality, all `ExecutionSpace` types in Kokkos are default constructible (you can construct them as `Ex ex()`) and copy constructible (you can construct them as `Ex ex2(ex1)`).  All default constructible instances of an `ExecutionSpace` type are guaranteed to have equivalent behavior, and all copy constructed instances are guaranteed to have equivalent behavior to the instance they were copied from.
+
+#### Detection
+
+Kokkos provides the convenience type trait `Kokkos::is_execution_space<T>` which has a `value` compile-time accessible value (usable as `Kokkos::is_execution_space<T>::value`) that is `true` if and only if a type `T` meets the requirements of the `ExecutionSpace` concept.  Any `ExecutionSpace` type `T` will also have the expression `Kokkos::is_space<T>::value` evaluate to `true` as a compile-time constant.
 
 ### Synopsis
 
 ```c++
-  // This is not an actual class, it just describes the concept in shorthand
-  class ExecutionSpaceConcept {
-    public: 
-      typedef ExecutionSpaceConcept execution_space;
-      typedef ... memory_space;
-      typedef Device<execution_space, memory_space> device_type;
-      typedef ... scratch_memory_space;
-      typedef ... array_layout;
-      
+// This is not an actual class, it just describes the concept in shorthand
+class ExecutionSpaceConcept {
+public: 
+  typedef ExecutionSpaceConcept execution_space;
+  typedef ... memory_space;
+  typedef Device<execution_space, memory_space> device_type;
+  typedef ... scratch_memory_space;
+  typedef ... array_layout;
+  
 
-      ExecutionSpaceConcept();
-      ExecutionSpaceConcept(const ExecutionSpaceConcept& src);
+  ExecutionSpaceConcept();
+  ExecutionSpaceConcept(const ExecutionSpaceConcept& src);
 
-      const char* name() const;
-      void print_configuration(std::ostream ostr&) const;
-      void print_configuration(std::ostream ostr&, bool details) const;
-      
-      bool in_parallel() const;
-      int concurrency() const;
+  const char* name() const;
+  void print_configuration(std::ostream ostr&) const;
+  void print_configuration(std::ostream ostr&, bool details) const;
+  
+  bool in_parallel() const;
+  int concurrency() const;
 
-      void fence() const;
-  };
+  void fence() const;
+};
 
-  template<class MS>
-  struct is_execution_space {
-    enum { value = false };
-  };
+template<class MS>
+struct is_execution_space {
+enum { value = false };
+};
 
-  template<>
-  struct is_execution_space<ExecutionSpaceConcept> {
-    enum { value = true };
-  };
+template<>
+struct is_execution_space<ExecutionSpaceConcept> {
+enum { value = true };
+};
 ```
 
 ### Typedefs
 
   * `execution_space`: The self type;
-  * `memory_space`: The default [`MemorySpace`](MemorySpaceConcept) to use when executing with `ExecutionSpaceConcept`.  
+  * `memory_space`: The default [`MemorySpace`](MemorySpaceConcept) to use when executing with [`ExecutionSpaceConcept`](ExecutionSpaceConcept).  
                     Kokkos guarantees that `Kokkos::SpaceAccessibility<Ex, Ex::memory_space>::accessible` will be `true` 
-                    (see [`Kokkos::SpaceAccessibility`](Kokkos%3A%3ASpaceAccessibility))
+                    (see [`Kokkos::SpaceAccessibility`](SpaceAccessibility))
   * `device_type`: `DeviceType<execution_space,memory_space>`.
-  * `array_layout`: The default [`ArrayLayout`](ArrayLayoutConcept) recommended for use with `View` types accessed from `ExecutionSpaceConcept`.
-  * `scratch_memory_space`: The [`ScratchMemorySpace`](ScratchMemorySpaceConcept) that parallel patterns will use for allocation of scratch memory 
-                            (for instance, as requested by a [`Kokkos::TeamPolicy`](Kokkos%3A%3ATeamPolicy))
+  * `array_layout`: The default `ArrayLayout` recommended for use with `View` types accessed from [`ExecutionSpaceConcept`](ExecutionSpaceConcept).
+  * `scratch_memory_space`: The `ScratchMemorySpace` that parallel patterns will use for allocation of scratch memory 
+                            (for instance, as requested by a [`Kokkos::TeamPolicy`](policies/TeamPolicy))
 
 ### Constructors
 
@@ -83,11 +200,11 @@
 ### Functions
 
   * `const char* name() const;`: *Returns* the label of the execution space instance.
-  * `bool in_parallel() const;`: *Returns* a value convertible to `bool` indicating whether or not the caller is executing as part of a Kokkos parallel pattern.
+  * `bool in_parallel() const;`: *Returns* a value convertible to `bool` indicating whether the caller is executing as part of a Kokkos parallel pattern.
         *Note:* as currently implemented, there is no guarantee that `true` means the caller is necessarily executing as 
-        part of a pattern on the particular instance `ExecutionSpaceConcept`; just *some* instance of `ExecutionSpaceConcept`.  This may be strengthened in the future.
+        part of a pattern on the particular instance [`ExecutionSpaceConcept`](ExecutionSpaceConcept); just *some* instance of [`ExecutionSpaceConcept`](ExecutionSpaceConcept).  This may be strengthened in the future.
   * `int concurrency() const;` *Returns* the maximum amount of concurrently executing work items in a parallel setting, i.e. the maximum number of threads utilized by an execution space instance.
-  * `void fence() const;` *Effects:* Upon return, all parallel patterns executed on the instance `ExecutionSpaceConcept` are guaranteed to have completed, 
+  * `void fence() const;` *Effects:* Upon return, all parallel patterns executed on the instance [`ExecutionSpaceConcept`](ExecutionSpaceConcept) are guaranteed to have completed, 
                           and their effects are guaranteed visible to the calling thread. 
                           *Note:* This *cannot* be called from within a parallel pattern.  Doing so will lead to unspecified effects 
                           (i.e., it might work, but only for some execution spaces, so be extra careful not to do it).
@@ -98,5 +215,4 @@
 
   * `template<class MS> struct is_execution_space;`: typetrait to check whether a class is a execution space.
   * `template<class S1, class S2> struct SpaceAccessibility;`: typetraits to check whether two spaces are compatible (assignable, deep_copy-able, accessable). 
-          (see [`Kokkos::SpaceAccessibility`](Kokkos%3A%3ASpaceAccessibility))
-
+          (see [`Kokkos::SpaceAccessibility`](SpaceAccessibility))

--- a/source/API/core/memory_spaces.md
+++ b/source/API/core/memory_spaces.md
@@ -1,69 +1,67 @@
-
 # Memory Spaces
 
-
+(CudaSpace)=
 ## `Kokkos::CudaSpace`
 
 `Kokkos::CudaSpace` is a [`MemorySpace` type](MemorySpaceConcept) representing device memory on a Cuda-capable GPU.  Except in rare instances, it should not be used directly, but instead should be used generically as an memory space.  For details, see [the documentation on the `MemorySpace` concept](MemorySpaceConcept).
 
+(CudaHostPinnedSpace)=
 ## `Kokkos::CudaHostPinnedSpace`
 
 `Kokkos::CudaHostPinnedSpace` is a [`MemorySpace` type](MemorySpaceConcept) representing host-side pinned memory on a accessible from a Cuda-capable GPU.  This memory is typically accessible by both host and device execution spaces.  Except in rare instances, it should not be used directly, but instead should be used generically as an memory space.  For details, see [the documentation on the `MemorySpace` concept](MemorySpaceConcept).
 
-
+(CudaUVMSpace)=
 ## `Kokkos::CudaUVMSpace`
 
 `Kokkos::CudaUVMSpace` is a [`MemorySpace` type](MemorySpaceConcept) representing unified virtual memory on a Cuda-capable GPU system.  Unified virtual memory is also accessible from most host execution spaces.  Except in rare instances, it should not be used directly, but instead should be used generically as an memory space.  For details, see [the documentation on the `MemorySpace` concept](MemorySpaceConcept).
 
+(HostSpace)=
 ## `Kokkos::HostSpace`
 
 `Kokkos::HostSpace` is a [`MemorySpace` type](MemorySpaceConcept) representing traditional random access memory accessible from the CPU.  Except in rare instances, it should not be used directly, but instead should be used generically as an memory space.  For details, see [the documentation on the `MemorySpace` concept](MemorySpaceConcept).
 
+(MemorySpaceConcept)=
+## `Kokkos::MemorySpaceConcept`
 
-
-## Kokkos::MemorySpaceConcept
-
-
-The concept of a `MemorySpace` is the fundamental abstraction to represent the "where" and the "how" that memory allocation and access takes place in Kokkos.  Most code that uses Kokkos should be written to the *generic concept* of a `MemorySpace` rather than any specific instance.  This page talks practically about how to *use* the common features of memory spaces in Kokkos; for a more formal and theoretical treatment, see [this document](Kokkos-Concepts).
+The concept of a `MemorySpace` is the fundamental abstraction to represent the "where" and the "how" that memory allocation and access takes place in Kokkos.  Most code that uses Kokkos should be written to the *generic concept* of a `MemorySpace` rather than any specific instance.  This page talks practically about how to *use* the common features of memory spaces in Kokkos; for a more formal and theoretical treatment, see [this document](KokkosConcepts).
 
 > *Disclaimer*: There is nothing new about the term "concept" in C++; anyone who has ever used templates in C++ has used concepts whether they knew it or not.  Please do not be confused by the word "concept" itself, which is now more often associated with a shiny new C++20 language feature.  Here, "concept" just means "what you're allowed to do with a type that is a template parameter in certain places".
-
 
 ### Synopsis
 
 ```c++
-  // This is not an actual class, it just describes the concept in shorthand
-  class MemorySpaceConcept {
-    public: 
-      typedef MemorySpaceConcept memory_space;
-      typedef ... execution_space;
-      typedef Device<execution_space, memory_space> device_type;
+// This is not an actual class, it just describes the concept in shorthand
+class MemorySpaceConcept {
+public: 
+  typedef MemorySpaceConcept memory_space;
+  typedef ... execution_space;
+  typedef Device<execution_space, memory_space> device_type;
 
-      MemorySpaceConcept();
-      MemorySpaceConcept(const MemorySpaceConcept& src);
-      const char* name() const;
-      void * allocate(ptrdiff_t size) const;
-      void deallocate(void* ptr, ptrdiff_t size) const;
-  };
+  MemorySpaceConcept();
+  MemorySpaceConcept(const MemorySpaceConcept& src);
+  const char* name() const;
+  void * allocate(ptrdiff_t size) const;
+  void deallocate(void* ptr, ptrdiff_t size) const;
+};
 
-  template<class MS>
-  struct is_memory_space {
-    enum { value = false };
-  };
+template<class MS>
+struct is_memory_space {
+enum { value = false };
+};
 
-  template<>
-  struct is_memory_space<MemorySpaceConcept> {
-    enum { value = true };
-  };
+template<>
+struct is_memory_space<MemorySpaceConcept> {
+enum { value = true };
+};
 ```
 
 ### Typedefs
 
   * `memory_space`: The self type;
   * `execution_space`: the default [`ExecutionSpace`](ExecutionSpaceConcept) to use when constructing objects in memory provided by an instance of `MemorySpace`, 
-                       or (potentially) when deep copying from or to such memory (see [`deep_copy` documentation](Kokkos%3A%3Adeep_copy) for details). 
+                       or (potentially) when deep copying from or to such memory (see [`deep_copy` documentation](view/deep_copy) for details). 
                        Kokkos guarantees that `Kokkos::SpaceAccessibility<execution_space, memory_space>::accessible` will be `true` 
-                       (see [`Kokkos::SpaceAccessibility`](Kokkos%3A%3ASpaceAccessibility)).
+                       (see [`Kokkos::SpaceAccessibility`](SpaceAccessibility)).
   * `device_type`: `DeviceType<execution_space,memory_space>`.
 
 ### Constructors
@@ -77,10 +75,7 @@ The concept of a `MemorySpace` is the fundamental abstraction to represent the "
   * `void * allocate(ptrdiff_t size) const;`: Allocates a buffer of at least `size` bytes using the memory resource that `MemorySpaceConcept` represents.
   * `void deallocate(void* ptr, ptrdiff_t size) const;`: Frees the buffer starting at `ptr` (of type `void*`) previously allocated with exactly `allocate(size)`.
 
-
 ### Non Member Facilities
 
   * `template<class MS> struct is_memory_space;`: typetrait to check whether a class is a memory space.
-  * `template<class S1, class S2> struct SpaceAccessibility;`: typetraits to check whether two spaces are compatible (assignable, deep_copy-able, accessable). 
-
-
+  * `template<class S1, class S2> struct SpaceAccessibility;`: typetraits to check whether two spaces are compatible (assignable, deep_copy-able, accessible). 

--- a/source/API/core/parallel_for.md
+++ b/source/API/core/parallel_for.md
@@ -8,19 +8,19 @@ Kokkos::parallel_for(name, policy, functor);
 Kokkos::parallel_for(policy, functor);
 ```
 
-Dispatches parallel work defined by `functor` according to the *ExecutionPolicy* `policy`. The optional label `name` is
+Dispatches parallel work defined by `functor` according to the [*ExecutionPolicy*](policies/ExecutionPolicyConcept) `policy`. The optional label `name` is
 used by profiling and debugging tools. This call may be asynchronous and return to the callee immediately. 
 
 ## Interface
 
-```cpp
+```c++
 template <class ExecPolicy, class FunctorType>
 Kokkos::parallel_for(const std::string& name, 
                      const ExecPolicy& policy, 
                      const FunctorType& functor);
 ```
 
-```cpp
+```c++
 template <class ExecPolicy, class FunctorType>
 Kokkos::parallel_for(const ExecPolicy& policy, 
                      const FunctorType& functor);
@@ -31,11 +31,11 @@ Kokkos::parallel_for(const ExecPolicy& policy,
   * `name`: A user provided string which is used in profiling and debugging tools via the Kokkos Profiling Hooks. 
   * ExecPolicy: An *ExecutionPolicy* which defines iteration space and other execution properties. Valid policies are:
     * `IntegerType`: defines a 1D iteration range, starting from 0 and going to a count.
-    * [RangePolicy](Kokkos%3A%3ARangePolicy): defines a 1D iteration range. 
-    * [MDRangePolicy](Kokkos%3A%3AMDRangePolicy): defines a multi-dimensional iteration space.
-    * [TeamPolicy](Kokkos%3A%3ATeamPolicy): defines a 1D iteration range, each of which is assigned to a thread team.
-    * [TeamThreadRange](Kokkos%3A%3ANestedPolicies): defines a 1D iteration range to be executed by a thread-team. Only valid inside a parallel region executed through a `TeamPolicy` or a `TaskTeam`.
-    * [ThreadVectorRange](Kokkos%3A%3ANestedPolicies): defines a 1D iteration range to be executed through vector parallelization dividing the threads within a team.  Only valid inside a parallel region executed through a `TeamPolicy` or a `TaskTeam`.
+    * [RangePolicy](policies/RangePolicy): defines a 1D iteration range. 
+    * [MDRangePolicy](policies/MDRangePolicy): defines a multi-dimensional iteration space.
+    * [TeamPolicy](policies/TeamPolicy): defines a 1D iteration range, each of which is assigned to a thread team.
+    * [TeamThreadRange](policies/TeamVectorRange): defines a 1D iteration range to be executed by a thread-team. Only valid inside a parallel region executed through a `TeamPolicy` or a `TaskTeam`.
+    * [ThreadVectorRange](policies/ThreadVectorRange): defines a 1D iteration range to be executed through vector parallelization dividing the threads within a team.  Only valid inside a parallel region executed through a `TeamPolicy` or a `TaskTeam`.
   * FunctorType: A valid functor having an `operator()` with a matching signature for the `ExecPolicy`.  The functor can be defined using a C++ class/struct or lambda.  See Examples below for more detail.
 
 ### Requirements:

--- a/source/API/core/parallel_reduce.md
+++ b/source/API/core/parallel_reduce.md
@@ -2,7 +2,7 @@
 
 Header File: `Kokkos_Core.hpp`
 
-### Usage 
+## Usage 
 ```c++
 Kokkos::parallel_reduce( name, policy, functor, reducer... );
 Kokkos::parallel_reduce( name, policy, functor, result...);
@@ -16,20 +16,20 @@ Dispatches parallel work defined by `functor` according to the *ExecutionPolicy*
 
 ## Interface
 
-```cpp
+```c++
 template <class ExecPolicy, class FunctorType>
 Kokkos::parallel_reduce(const std::string& name, 
                         const ExecPolicy& policy, 
                         const FunctorType& functor);
 ```
 
-```cpp
+```c++
 template <class ExecPolicy, class FunctorType>
 Kokkos::parallel_reduce(const ExecPolicy& policy, 
                         const FunctorType& functor);
 ```
 
-```cpp
+```c++
 template <class ExecPolicy, class FunctorType, class ReducerArgument>
 Kokkos::parallel_reduce(const std::string& name, 
                         const ExecPolicy& policy, 
@@ -37,14 +37,14 @@ Kokkos::parallel_reduce(const std::string& name,
                         const ReducerArgument& reducer...);
 ```
 
-```cpp
+```c++
 template <class ExecPolicy, class FunctorType, class ReducerArgument>
 Kokkos::parallel_reduce(const ExecPolicy& policy, 
                         const FunctorType& functor, 
                         const ReducerArgument& reducer...);
 ```
 
-```cpp
+```c++
 template <class ExecPolicy, class FunctorType, class ReducerArgumentNonConst>
 Kokkos::parallel_reduce(const std::string& name, 
                         const ExecPolicy& policy, 
@@ -52,14 +52,14 @@ Kokkos::parallel_reduce(const std::string& name,
                         ReducerArgumentNonConst& reducer...);
 ```
 
-```cpp
+```c++
 template <class ExecPolicy, class FunctorType, class ReducerArgumentNonConst>
 Kokkos::parallel_reduce(const ExecPolicy& policy, 
                         const FunctorType& functor, 
                         ReducerArgumentNonConst& reducer...);
 ```
 
-```cpp
+```c++
 template <class ExecPolicy, class FunctorType, class ReducerArgument1, class... ReducerArguments>
 Kokkos::parallel_reduce(const std::string& name, 
                         const ExecPolicy& policy, 
@@ -67,14 +67,14 @@ Kokkos::parallel_reduce(const std::string& name,
                         const ReducerArgument& reducer...);
 ```
 
-```cpp
+```c++
 template <class ExecPolicy, class FunctorType, class ReducerArgument1, class... ReducerArguments>
 Kokkos::parallel_reduce(const ExecPolicy& policy, 
                         const FunctorType& functor, 
                         const ReducerArgument& reducer...);
 ```
 
-```cpp
+```c++
 template <class ExecPolicy, class FunctorType, class ReducerArgumentNonConst1, class... ReducerArgumentNonConsts>
 Kokkos::parallel_reduce(const std::string& name, 
                         const ExecPolicy& policy, 
@@ -82,14 +82,14 @@ Kokkos::parallel_reduce(const std::string& name,
                         ReducerArgumentNonConst& reducer...);
 ```
 
-```cpp
+```c++
 template <class ExecPolicy, class FunctorType, class ReducerArgumentNonConst1, class ReducerArgumentNonConsts>
 Kokkos::parallel_reduce(const ExecPolicy& policy, 
                         const FunctorType& functor, 
                         ReducerArgumentNonConst& reducer...);
 ```
 
-```cpp
+```c++
 template <class ExecPolicy, class FunctorType>
 Kokkos::parallel_reduce(const std::string& name, 
                         const ExecPolicy& policy, 
@@ -97,7 +97,7 @@ Kokkos::parallel_reduce(const std::string& name,
                         const ResultType& result...);
 ```
 
-```cpp
+```c++
 template <class ExecPolicy, class FunctorType>
 Kokkos::parallel_reduce(const ExecPolicy& policy, 
                         const FunctorType& functor, 
@@ -109,11 +109,11 @@ Kokkos::parallel_reduce(const ExecPolicy& policy,
   * `name`: A user provided string which is used in profiling and debugging tools via the Kokkos Profiling Hooks. 
   * ExecPolicy: An *ExecutionPolicy* which defines iteration space and other execution properties. Valid policies are:
     * `IntegerType`: defines a 1D iteration range, starting from 0 and going to a count.
-    * [RangePolicy](Kokkos%3A%3ARangePolicy): defines a 1D iteration range. 
-    * [MDRangePolicy](Kokkos%3A%3AMDRangePolicy): defines a multi-dimensional iteration space.
-    * [TeamPolicy](Kokkos%3A%3ATeamPolicy): defines a 1D iteration range, each of which is assigned to a thread team.
-    * [TeamThreadRange](Kokkos%3A%3ANestedPolicies): defines a 1D iteration range to be executed by a thread-team. Only valid inside a parallel region executed through a `TeamPolicy` or a `TaskTeam`.
-    * [ThreadVectorRange](Kokkos%3A%3ANestedPolicies): defines a 1D iteration range to be executed through vector parallelization dividing the threads within a team.  Only valid inside a parallel region executed through a `TeamPolicy` or a `TaskTeam`.
+    * [RangePolicy](policies/RangePolicy): defines a 1D iteration range. 
+    * [MDRangePolicy](policies/MDRangePolicy): defines a multi-dimensional iteration space.
+    * [TeamPolicy](policies/TeamPolicy): defines a 1D iteration range, each of which is assigned to a thread team.
+    * [TeamThreadRange](policies/TeamThreadRange): defines a 1D iteration range to be executed by a thread-team. Only valid inside a parallel region executed through a `TeamPolicy` or a `TaskTeam`.
+    * [ThreadVectorRange](policies/ThreadVectorRange): defines a 1D iteration range to be executed through vector parallelization dividing the threads within a team.  Only valid inside a parallel region executed through a `TeamPolicy` or a `TaskTeam`.
   * FunctorType: A valid functor with (at minimum) an `operator()` with a matching signature for the `ExecPolicy` combined with the reduced type.
   * ReducerArgument: Either a class fullfilling the "Reducer" concept or a `Kokkos::View`
   * ReducerArgumentNonConst: a class fullfilling the "Reducer" concept, a POD type with `operator +=` and `operator =`, or a `Kokkos::View`.  The ReducerArgumentNonConst can also be an array or a pointer; see below for functor requirements.
@@ -149,7 +149,7 @@ Kokkos::parallel_reduce(const ExecPolicy& policy,
 
 ## Examples
 
-Further examples are provided in the [Custom Reductions](Programming-Guide%3A-Custom-Reductions) and [ExecutionPolicy](Execution-Policies) documentation. 
+Further examples are provided in the [Custom Reductions](../../ProgrammingGuide/Custom-Reductions) and [ExecutionPolicy](policies/ExecutionPolicyConcept) documentation. 
 
 ```c++
 #include<Kokkos_Core.hpp>

--- a/source/API/core/parallel_scan.md
+++ b/source/API/core/parallel_scan.md
@@ -2,7 +2,7 @@
 
 Header File: `Kokkos_Core.hpp`
 
-### Usage 
+## Usage 
 ```c++
 Kokkos::parallel_scan( name, policy, functor, result );
 Kokkos::parallel_scan( name, policy, functor );
@@ -15,20 +15,20 @@ provided by the work items. The optional label `name` is used by profiling and d
 
 ## Interface
 
-```cpp
+```c++
 template <class ExecPolicy, class FunctorType>
 Kokkos::parallel_scan(const std::string& name, 
                       const ExecPolicy& policy, 
                       const FunctorType& functor);
 ```
 
-```cpp
+```c++
 template <class ExecPolicy, class FunctorType>
 Kokkos::parallel_scan(const ExecPolicy&  policy, 
                       const FunctorType& functor);
 ```
 
-```cpp
+```c++
 template <class ExecPolicy, class FunctorType, class ReturnType>
 Kokkos::parallel_scan(const std::string& name, 
                       const ExecPolicy&  policy, 
@@ -36,14 +36,14 @@ Kokkos::parallel_scan(const std::string& name,
                       ReturnType&        return_value);
 ```
 
-```cpp
+```c++
 template <class ExecPolicy, class FunctorType, class ReturnType>
 Kokkos::parallel_scan(const ExecPolicy&  policy, 
                       const FunctorType& functor, 
                       ReturnType&        return_value);
 ```
 
-```cpp
+```c++
 template <class ExecPolicy, class FunctorType, class ReturnType>
 Kokkos::parallel_scan(const std::string& name, 
                       const ExecPolicy&  policy, 
@@ -56,8 +56,8 @@ Kokkos::parallel_scan(const std::string& name,
   * `name`: A user provided string which is used in profiling and debugging tools via the Kokkos Profiling Hooks. 
   * ExecPolicy: An *ExecutionPolicy* which defines iteration space and other execution properties. Valid policies are:
     * `IntegerType`: defines a 1D iteration range, starting from 0 and going to a count.
-    * [RangePolicy](Kokkos%3A%3ARangePolicy): defines a 1D iteration range. 
-    * [ThreadVectorRange](Kokkos%3A%3ANestedPolicies): defines a 1D iteration range to be executed through vector parallelization dividing the threads within a team.  Only valid inside a parallel region executed through a `TeamPolicy` or a `TaskTeam`.
+    * [RangePolicy](policies/RangePolicy): defines a 1D iteration range. 
+    * [ThreadVectorRange](policies/ThreadVectorRange): defines a 1D iteration range to be executed through vector parallelization dividing the threads within a team.  Only valid inside a parallel region executed through a `TeamPolicy` or a `TaskTeam`.
   * FunctorType: A valid functor with (at minimum) an `operator()` with a matching signature for the `ExecPolicy` combined with the reduced type.
   * ReturnType: a POD type with `operator +=` and `operator =`, or a `Kokkos::View`.  
 


### PR DESCRIPTION
### THIS PR:
- fixed links and changed cpp to c++ code block in parallel_for.md
- fixed links, changed cpp to c++ code block, fixed headings in parallel_reduce.md
- fixed links, changed cpp to c++ code block, fixed headings in parallel_scan.md
- added `ExecutionSpaceConcept` and other anchors to API/core/execution-spaces
- fixed links, grammar in execution_spaces.md
- added anchors and formatted to API/core/memory_spaces
- fixed links, grammar in memory_spaces.md
- added ParallelForTag, ParallelReduceTag, ParallelScanTag, KokkosConcepts and Traits to core-index.rst