### PR TITLE
#57: Fixed usecases

### DIFF
--- a/source/usecases/Average-To-Nodes.md
+++ b/source/usecases/Average-To-Nodes.md
@@ -1,6 +1,6 @@
 # ScatterView averaging elements to nodes
 
-In order to demonstrate a typical use case for `Kokkos::ScatterView`, we can think of
+In order to demonstrate a typical use case for [`Kokkos::ScatterView`](../API/containers/ScatterView), we can think of
 a finite element program where the only information available is a mapping from elements
 to nodes, and we would like to average some quantity from the elements to the nodes.
 This average is the ratio of two sums, namely the sum of the adjacent element quantities
@@ -9,11 +9,11 @@ divided by the sum of adjacent elements.
 ## Computing the number of adjacent elements
 
 Even just computing the number of elements adjacent to a node will already demonstrate most
-of the necessary workflow around `Kokkos::ScatterView`.
+of the necessary workflow around [`Kokkos::ScatterView`](../API/containers/ScatterView).
 The algorithm is as follows: we will iterate over mesh elements, in parallel, and each mesh
 element will identify its nodes and add one to an array entry specific to that node.
-Those entries are ultimately stored in a `Kokkos::View` with one entry per node, but
-during the algorithm they will be accessed through a `Kokkos::ScatterView` in order to
+Those entries are ultimately stored in a [`Kokkos::View`](../API/core/view/view) with one entry per node, but
+during the algorithm they will be accessed through a [`Kokkos::ScatterView`](../API/containers/ScatterView) in order to
 prevent data races.
 
 ```c++

--- a/source/usecases/Kokkos-Fortran-Interoperability.md
+++ b/source/usecases/Kokkos-Fortran-Interoperability.md
@@ -1,24 +1,22 @@
 # Fortran Interop Use Case
 
-## Operations on multi-dimensional fortran allocated arrays using Kokkos 
+## Operations on multidimensional fortran allocated arrays using Kokkos 
 
 This example demonstrates usage of the `Fortran Language Compatibility Layer (FLCL)` in the context of performing a DAXPY (double precision A * X + Y) using Kokkos from a simple fortran program. Such a use case occurs when using Kokkos for performance portability within a Fortran application. 
 
 ## Program structure 
 This example uses the Kokkos fortran interop utilities in [FLCL](https://github.com/kokkos/kokkos-fortran-interop). 
-This includes a set of fortran routines for converting fortran allocated arrays into an ndarray and a set of C++ functions for converting an ndarray into a Kokkos unmanaged view. 
+This includes a set of fortran routines for converting fortran allocated arrays into a ndarray and a set of C++ functions for converting a ndarray into a Kokkos unmanaged view. 
 
 The ndarray type (flcl_ndarray_t) is a simple struct that captures the rank, dimensions, strides (equivalent to a dope vector) along with the flattened data. This is defined and implemented in [flcl-cxx.hpp](https://github.com/kokkos/kokkos-fortran-interop/blob/master/src/flcl-cxx.hpp)
 
 ```c++ 
-
 typedef struct _flcl_nd_array_t {
     size_t rank;
     size_t dims[FLCL_NDARRAY_MAX_RANK];
     size_t strides[FLCL_NDARRAY_MAX_RANK];
     void *data;
 } flcl_ndarray_t;
-
 ```
 This has a fortran equivalent type located in [flcl-f.f90](https://github.com/kokkos/kokkos-fortran-interop/blob/master/src/flcl-f.f90)
 
@@ -31,10 +29,9 @@ type, bind(C) :: nd_array_t
   end type nd_array_t
 ```
 
-To convert a fortran allocated array into an ndarray we use a set of procedures (behind an interface) defined in [flcl-f.f90](https://github.com/kokkos/kokkos-fortran-interop/blob/master/src/flcl-f.f90)
+To convert a fortran allocated array into a ndarray we use a set of procedures (behind an interface) defined in [flcl-f.f90](https://github.com/kokkos/kokkos-fortran-interop/blob/master/src/flcl-f.f90)
 
 ```fortran
-
 interface to_nd_array
     ! 1D specializations
     module procedure to_nd_array_l_1d
@@ -58,7 +55,7 @@ interface to_nd_array
     module procedure to_nd_array_r64_3d
 ```
 
-To convert an ndarray to a Kokkos::View we use view_from_ndarray defined in [flcl-cxx.hpp](https://github.com/kokkos/kokkos-fortran-interop/blob/master/src/flcl-cxx.hpp)
+To convert a ndarray to a Kokkos::View we use view_from_ndarray defined in [flcl-cxx.hpp](https://github.com/kokkos/kokkos-fortran-interop/blob/master/src/flcl-cxx.hpp)
 ``` c++ 
 template <typename DataType>
   Kokkos::View<DataType, Kokkos::LayoutStride, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>
@@ -82,7 +79,6 @@ We then define our arrays including two 'Y' arrays, one will be used for calcula
 ``` 
 Performing the DAXPY in fortran is simply: 
 ``` fortran 
-
 do ii = 1, mm
     f_y(ii) = f_y(ii) + alpha * x(ii)
   end do
@@ -138,9 +134,8 @@ void c_axpy( flcl_ndarray_t *nd_array_y, flcl_ndarray_t *nd_array_x, double *alp
   
     return;
   }
-
 ```
 
-In this function we first convert our two nd_array to Kokkos::View and then use Kokkos::parallel_for with a simply DAXPY lambda.  
+In this function we first convert our two nd_array to [`Kokkos::View`](../API/core/view/view) and then use [`Kokkos::parallel_for`](../API/core/parallel-dispatch/parallel_for) with a simply DAXPY lambda.  
 
-This use case illustrates the ability to use Kokkos in fortran applications with interoperability of fortran arrays and Kokkos::View via the ndarray type and conversion routines provided in FLCL. 
+This use case illustrates the ability to use Kokkos in fortran applications with interoperability of fortran arrays and [`Kokkos::View`](../API/core/view/view) via the ndarray type and conversion routines provided in FLCL. 

--- a/source/usecases/MDRangePolicy.md
+++ b/source/usecases/MDRangePolicy.md
@@ -1,9 +1,9 @@
 # MDRangePolicy Use Case
 
-## Operations on multi-dimenstional arrays
+## Operations on multi-dimensional arrays
 
-This example demonstrates usage of the `MDRangePolicy` in the context of performing operations on multi-dimensional arrays or tensor data.
-Such a use case occurs for example when working on numerical solution to PDEs such as finite element methods, where discretization of the space may result in `C` cells (elements), and definition of basis functions that take `P` evalutation points as input arguments and return output whose rank and dimensions `D` depend on the field rank `F` of the basis function.
+This example demonstrates usage of the [`MDRangePolicy`](../API/core/policies/MDRangePolicy) in the context of performing operations on multidimensional arrays or tensor data.
+Such a use case occurs for example when working on numerical solution to PDEs such as finite element methods, where discretization of the space may result in `C` cells (elements), and definition of basis functions that take `P` evaluation points as input arguments and return output whose rank and dimensions `D` depend on the field rank `F` of the basis function.
 
 
 ## Problem formulation
@@ -21,11 +21,10 @@ Such a use case occurs for example when working on numerical solution to PDEs su
   For each triple in `C,F,P` compute an output field from the two input views:
   
 ``` c++
-  for each (c,f,p) in (C,F,P)
-    compute the product inputData(c,p,:,:) * inputField(c,f,p,:)
-    store result in outputField(c,f,p,:)
+for each (c,f,p) in (C,F,P)
+  compute the product inputData(c,p,:,:) * inputField(c,f,p,:)
+  store result in outputField(c,f,p,:)
 ```
-
 
 ## Serial implementation
 
@@ -53,13 +52,11 @@ for (int p = 0; p < P; ++p)
 
 ```
 
-
 ## Parallelization with Kokkos
 
 ### Initial implementation - `RangePolicy`
 
-The most straightforward way to parallize the serial code above is to convert the outer `for` loop over cells with the sequential iteration pattern into a parallel for loop using a `RangePolicy`
-
+The most straightforward way to parallize the serial code above is to convert the outer `for` loop over cells with the sequential iteration pattern into a parallel for loop using a [`RangePolicy`](../API/core/policies/RangePolicy)
 
 ``` c++
 
@@ -91,15 +88,13 @@ Kokkos::parallel_for("for_all_cells",
 
 If the number of cells is large enough to merit parallelization, that is the overhead for parallel dispatch plus computation time is less than total serial execution time, then the simple implementation above will result in improved performance.
 
-There is more parallelism to exploit, particularly within the for loops over fields `F` and points `P`. One way to accomplish this would involve taking the product of the three iteration ranges, `C*F*P`, and performing a `parallel_for` over that product. However, this would require extraction routines to map between indices from the flattened iteration range, `C*F*P`, and the multidimensional indices required by data structures in this example. In addition, to achieve performance portability the mapping between the 1-D product iteration range and multi-dimensional 3-D indices would require architecture-awareness, akin to the notion of `LayoutLeft` and `LayoutRight` used in Kokkos to establish data access patterns.
+There is more parallelism to exploit, particularly within the for loops over fields `F` and points `P`. One way to accomplish this would involve taking the product of the three iteration ranges, `C*F*P`, and performing a [`parallel_for`](../API/core/parallel-dispatch/parallel_for) over that product. However, this would require extraction routines to map between indices from the flattened iteration range, `C*F*P`, and the multidimensional indices required by data structures in this example. In addition, to achieve performance portability the mapping between the 1-D product iteration range and multidimensional 3-D indices would require architecture-awareness, akin to the notion of [`LayoutLeft`](../API/core/view/layoutLeft.md) and [`LayoutRight`](../API/core/view/layoutRight) used in Kokkos to establish data access patterns.
 
-The `MDRangePolicy` provides a natural way to accomplish the goal of parallelizing over all three iteration ranges without requiring manually computing the product of the iteration ranges and mapping between 1-D and 3-D multidimensional indices. The `MDRangePolicy` is suitable for use with tightly-nested for loops and provides a method to expose additional parallelism in computations beyond simply parallelizing in a single dimension, as was shown in the first implementation using the `RangePolicy`.
-
+The [`MDRangePolicy`](../API/core/policies/MDRangePolicy) provides a natural way to accomplish the goal of parallelize over all three iteration ranges without requiring manually computing the product of the iteration ranges and mapping between 1-D and 3-D multidimensional indices. The [`MDRangePolicy`](../API/core/policies/MDRangePolicy) is suitable for use with tightly-nested for loops and provides a method to expose additional parallelism in computations beyond simply parallelize in a single dimension, as was shown in the first implementation using the [`RangePolicy`](../API/core/policies/RangePolicy).
 
 ### Implementation - `MDRangePolicy`
 
 ``` c++
-
 Kokkos::parallel_for("mdr_for_all_cells", 
   Kokkos::MDRangePolicy< Kokkos::Rank<3> > ({0,0,0}, {C,F,P}),
    KOKKOS_LAMBDA (const int c, const int f, const int p) {
@@ -117,28 +112,26 @@ Kokkos::parallel_for("mdr_for_all_cells",
       result(i) = tmp;
     }
   });
-
 ```
-
 
 ## MDRangePolicy usage
 
-The `MDRangePolicy` accepts the same template parameters as the `RangePolicy`, but also requires an additional type - the `Kokkos::Rank<R>` parameter, where `R` is the rank, that is the number of nested for-loops, and must be provided at compile-time.
+The [`MDRangePolicy`](../API/core/policies/MDRangePolicy) accepts the same template parameters as the [`RangePolicy`](../API/core/policies/RangePolicy), but also requires an additional type - the `Kokkos::Rank<R>` parameter, where `R` is the rank, that is the number of nested for-loops, and must be provided at compile-time.
 
 The policy requires two arguments:
   1) An initializer list, or `Kokkos::Array`, of "begin" indices
   2) An initializer list, or `Kokkos::Array`, of "end" indices
 
-Internally the `MDRangePolicy` uses tiling over the multi-dimensional iteration space. For customization an optional third argument may be passed to the policy - an initializer list of tile dimension sizes. This argument might become important when performance tuning, as simple default sizes can be problem-dependent and difficult to determine automatically.
+Internally the [`MDRangePolicy`](../API/core/policies/MDRangePolicy) uses tiling over the multidimensional iteration space. For customization an optional third argument may be passed to the policy - an initializer list of tile dimension sizes. This argument might become important when performance tuning, as simple default sizes can be problem-dependent and difficult to determine automatically.
 
 The signature of the lambda (or access operator of the functor) requires an argument for each rank.
 
-The `MDRangePolicy` can be used with both the `parallel_for` and `parallel_reduce` patterns in Kokkos.
+The [`MDRangePolicy`](../API/core/policies/MDRangePolicy) can be used with both the [`parallel_for`](../API/core/parallel-dispatch/parallel_for) and [`parallel_reduce`](../API/core/parallel-dispatch/parallel_reduce) patterns in Kokkos.
 
 
 ## References
 
-The API reference for the `MDRangePolicy` is available on the Kokkos wiki:
+The API reference for the [`MDRangePolicy`](../API/core/policies/MDRangePolicy) is available on the Kokkos wiki:
   [wiki link](https://github.com/kokkos/kokkos/wiki/Kokkos%3A%3AMDRangePolicy)
  
 The use case that this example is based on comes from the Intrepid2 package of Trilinos. For more examples, check out code in Trilinos in files at: `Trilinos/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDef*.hpp`.

--- a/source/usecases/MPI-Halo-Exchange.md
+++ b/source/usecases/MPI-Halo-Exchange.md
@@ -62,7 +62,7 @@ to that element must be done by the MPI rank that owns it.
 Suppose further that on each MPI rank there exists an array that maps each element, whether owned
 or redudantly copied, to the (possibly different) MPI rank which owns that element.
 We can filter out the subset of these elements that are associated with a given owner using
-`Kokkos::parallel_scan` and subsequently pack messages using `Kokkos::parallel_for`.
+[`Kokkos::parallel_scan`](../API/core/parallel-dispatch/parallel_scan) and subsequently pack messages using [`Kokkos::parallel_for`](../API/core/parallel-dispatch/parallel_for).
 
 ## Identifying subset indices
 
@@ -121,7 +121,7 @@ Kokkos::View<int*> find_subset(Kokkos::View<int*> keys, int desired_key) {
 
 Once we are able to produce a list of subset indices (those indices of elements which will be transmitted in one message),
 we can use that list of indices to extract a subset of the simulation data to send.
-Here, let us assume that we have a `Kokkos::View` which stores one floating-point value per element, and we want
+Here, let us assume that we have a [`Kokkos::View`](../API/core/view/view) which stores one floating-point value per element, and we want
 to extract a message containing only the floating-point values for the relevant subset.
 
 ```c++

--- a/source/usecases/OverlappingHostAndDeviceWork.md
+++ b/source/usecases/OverlappingHostAndDeviceWork.md
@@ -2,14 +2,14 @@
 
 When using architectures that allow host execution to concur with device execution Kokkos supports 
 overlapping host operations with device operations which can produce significant speedup depending 
-on the algorithm.  This use case describes the conditions and the design of algorithms that take advange of
+on the algorithm.  This use case describes the conditions and the design of algorithms that take advantage of
 overlapping device execution with host execution.
 
 ## Actors
  - Algorithm with different set of kernels where some are best executed on the host and some 
 are better executed on an accelerator device
  - Algorithm where communication or serialization operations can be staggered with computational kernels
- - Algorithm where work can be divied between host and device without contention to resources
+ - Algorithm where work can be divided between host and device without contention to resources
  
 ## Subjects
  - Kokkos Execution Spaces
@@ -25,21 +25,19 @@ are better executed on an accelerator device
 ## Preconditions
  - Execution "kernel" implemented in the form of C++ functor
     
-## Usage Pattern 1 - overapping computational kernels
+## Usage Pattern 1 - overlapping computational kernels
 
 ```
-
-  |--- Allocate Device and Host Memory
-  |--- Initialize Host and Device Memory
-  |------------------------------------------------
-  |- Perform host operation 0
-  |--- iteration loop -----------------------------
+|--- Allocate Device and Host Memory
+|--- Initialize Host and Device Memory
+|------------------------------------------------
+|- Perform host operation 0
+|--- iteration loop -----------------------------
     |->----------- global barrier -----------------
     |  |- Synchronize host and device data
     |  |- Perform device operation N \
     |  |- Perform host operation N+1 / asynchronous
     |-<--------------------------------------------
-       
 ```
 
 ## Example Code
@@ -47,70 +45,68 @@ Perform setup of host data needed for iteration n+1 while device is performing
 operation on iteration n
 
 ```c++
-  typedef double value_type;
-  typedef Kokkos::OpenMP   HostExecSpace;
-  typedef Kokkos::Cuda     DeviceExecSpace;
-  typedef Kokkos::RangePolicy<DeviceExecSpace>  device_range_policy;
-  typedef Kokkos::RangePolicy<HostExecSpace>    host_range_policy;
-  typedef Kokkos::View<double*, Kokkos::CudaSpace>   ViewVectorType;
-  typedef Kokkos::View<double**, Kokkos::CudaSpace>  ViewMatrixType;
+typedef double value_type;
+typedef Kokkos::OpenMP   HostExecSpace;
+typedef Kokkos::Cuda     DeviceExecSpace;
+typedef Kokkos::RangePolicy<DeviceExecSpace>  device_range_policy;
+typedef Kokkos::RangePolicy<HostExecSpace>    host_range_policy;
+typedef Kokkos::View<double*, Kokkos::CudaSpace>   ViewVectorType;
+typedef Kokkos::View<double**, Kokkos::CudaSpace>  ViewMatrixType;
 
-  // Setup data on host  
-  // use parameter xVal to demonstrate variability between iterations
-  void init_src_views(ViewVectorType::HostMirror p_x,
-                      ViewMatrixType::HostMirror p_A,
-                      const value_type xVal ) {
+// Setup data on host  
+// use parameter xVal to demonstrate variability between iterations
+void init_src_views(ViewVectorType::HostMirror p_x,
+                  ViewMatrixType::HostMirror p_A,
+                  const value_type xVal ) {
     
-    Kokkos::parallel_for( "init_A", host_range_policy(0,N), [=] ( int i ) {
-      for ( int j = 0; j < M; ++j ) {
-        h_A( i, j ) = 1;
-      }
-    });
+  Kokkos::parallel_for( "init_A", host_range_policy(0,N), [=] ( int i ) {
+    for ( int j = 0; j < M; ++j ) {
+      h_A( i, j ) = 1;
+    }
+  });
 
-    Kokkos::parallel_for( "init_x", host_range_policy(0,M), [=] ( int i ) {
-      h_x( i ) = xVal;
-    });
-  }
+  Kokkos::parallel_for( "init_x", host_range_policy(0,M), [=] ( int i ) {
+    h_x( i ) = xVal;
+  });
+}
   
-  ViewVectorType y( "y", N );
-  ViewVectorType x( "x", M );
-  ViewMatrixType A( "A", N, M );
+ViewVectorType y( "y", N );
+ViewVectorType x( "x", M );
+ViewMatrixType A( "A", N, M );
+
+ViewVectorType::HostMirror h_y = Kokkos::create_mirror_view( y );
+ViewVectorType::HostMirror h_x = Kokkos::create_mirror_view( x );
+ViewMatrixType::HostMirror h_A = Kokkos::create_mirror_view( A );
   
-  ViewVectorType::HostMirror h_y = Kokkos::create_mirror_view( y );
-  ViewVectorType::HostMirror h_x = Kokkos::create_mirror_view( x );
-  ViewMatrixType::HostMirror h_A = Kokkos::create_mirror_view( A );
+for ( int repeat = 0; repeat < nrepeat; repeat++ ) {
+  init_src_views( h_x, h_A, repeat+1);  // setup data for next device launch
   
-  for ( int repeat = 0; repeat < nrepeat; repeat++ ) {
-    init_src_views( h_x, h_A, repeat+1);  // setup data for next device launch
-  
-    Kokkos::fence(); // barrier used to synch between device and host before copying data
+  Kokkos::fence(); // barrier used to synch between device and host before copying data
     
-    // Deep copy host data needed for this iteration to device.
-    Kokkos::deep_copy( h_y, h );
-    Kokkos::deep_copy( x, h_x );
-    Kokkos::deep_copy( A, h_A );  // implicit barrier
+  // Deep copy host data needed for this iteration to device.
+  Kokkos::deep_copy( h_y, h );
+  Kokkos::deep_copy( x, h_x );
+  Kokkos::deep_copy( A, h_A );  // implicit barrier
 
-    // Application: y=Ax
-    Kokkos::parallel_for( "yAx", device_range_policy( 0, N ), 
-                                KOKKOS_LAMBDA ( int j ) {
-      double temp2 = 0;
-      for ( int i = 0; i < M; ++i ) {
-        temp2 += A( j, i ) * x( i );
-      }
+  // Application: y=Ax
+  Kokkos::parallel_for( "yAx", device_range_policy( 0, N ), 
+                              KOKKOS_LAMBDA ( int j ) {
+    double temp2 = 0;
+    for ( int i = 0; i < M; ++i ) {
+      temp2 += A( j, i ) * x( i );
+    }
 
-      y( j ) = temp2;
-    } );
+    y( j ) = temp2;
+  } );
     
-    // note that there is no barrier here, so the host thread will loop
-    // back around and call ini_src_views while the kernel is still running
-   }
-
-  
+  // note that there is no barrier here, so the host thread will loop
+  // back around and call ini_src_views while the kernel is still running
+}
 ```
 
-<b>Important note</b>:  In theory, the order in which the host kernel and the device kernel are
+**Important note**:  In theory, the order in which the host kernel and the device kernel are
 launched is not important, but in practice the device kernel must be launched first.  Most 
-host backends do not leave a "main" thread free while the kernel is running.  Once the 
+host backends do not leave a "main" thread free while the kernel is running. Once the 
 host parallel kernel is launched, the main thread is occupied until that thread's 
 contribution to the kernel is complete.  Because the device execution is in a different context, 
 the host thread is free immediately after the kernel is launched.  Attention must 
@@ -119,21 +115,19 @@ requires a synchronization prior to completion (such as a reduction), then there
 overlap host and device operations.  Thus, taking advantage of a host/device
 overlapping pattern may require modifications to the overall algorithm.
 
-
 ## Usage pattern 2 - perform serialized operation on host while device is executing kernel
 
 ```
-  |--- Allocate Device and Host Memory
-  |--- Initialize Host and Device Memory
-  |---------- global barrier ------------------------------
-  |- Synchronize host and device data
-  |--------------------------------------------------------
+|--- Allocate Device and Host Memory
+|--- Initialize Host and Device Memory
+|---------- global barrier ------------------------------
+|- Synchronize host and device data
+|--------------------------------------------------------
     |->|- Perform device operation N         \ asynchronous
     |  |- Serialize host data from N to disk /
     |  |------------ global barrier -----------------------
     |  |- Synchronize host and device data for start of N+1
     |-<----------------------------------------------------
-
 ```
 
 Data serialized to disk is behind by 1 iteration, but it can be performed 
@@ -143,31 +137,31 @@ iteration N which is why the barrier is need before the synchronization
 ## example code
 
 ```c++
-  typedef Kokkos::RangePolicy<>    range_policy;
-  typedef Kokkos::View<double*>    ViewVectorType;
+typedef Kokkos::RangePolicy<>    range_policy;
+typedef Kokkos::View<double*>    ViewVectorType;
 
-  ViewVectorType V_r;
-  ViewVectorType V_r1;
-  ViewVectorType::HostMirror h_V = Kokkos::create_mirror_view( y );
+ViewVectorType V_r;
+ViewVectorType V_r1;
+ViewVectorType::HostMirror h_V = Kokkos::create_mirror_view( y );
 
-  get_initial_state(h_V); // function to initialize V on host
+get_initial_state(h_V); // function to initialize V on host
+
+Kokkos::deep_copy(V_r, h_V);
+Kokkos::deep_copy(V_r1, h_V)
+
+for (int r = 0; r < R; r++) {
   
+  Kokkos::parallel_for(range_policy(0,N), KOKKOS_LAMBDA (int i) {
+     V_r1(i) = get_RHS_func(V_r);  //return V_r1(i) for RHS from V_r
+  });
+
+  serialize_state(h_V); // serialize data still in host view_r
+ 
+  Kokkos::fence();  // synchronize between host and device
+ 
+  Kokkos::deep_copy(h_V, V_r1);  // update for next iteration
   Kokkos::deep_copy(V_r, h_V);
-  Kokkos::deep_copy(V_r1, h_V)
-
-  for (int r = 0; r < R; r++) {
-  
-     Kokkos::parallel_for(range_policy(0,N), KOKKOS_LAMBDA (int i) {
-        V_r1(i) = get_RHS_func(V_r);  //return V_r1(i) for RHS from V_r
-     });
-  
-     serialize_state(h_V); // serialize data still in host view_r
      
-     Kokkos::fence();  // synchronize between host and device
-     
-     Kokkos::deep_copy(h_V, V_r1);  // update for next iteration
-     Kokkos::deep_copy(V_r, h_V);
-     
-  }
+}
 ```
 

--- a/source/usecases/SoA-and-AoSoA-with-Cabana.md
+++ b/source/usecases/SoA-and-AoSoA-with-Cabana.md
@@ -19,7 +19,6 @@ Conceptually `Cabana::SoA<Cabana::MemberTypes<float[3], char>, 8>` is equivalent
 
 The data structure keeps a separate, homogeneous data array for each particle field, each having the same number of elements.  The motivation is easier vectorization for the compiler.
 
-
 #### Template parameters
 `DataTypes`
 : The types of the elements that the SoA stores as fixed size arrays.

--- a/source/usecases/TaggedOperators.md
+++ b/source/usecases/TaggedOperators.md
@@ -2,13 +2,13 @@
 
 ## Dealing with pre-C++17
 
-Many applications and libraries in HPC are written using an Object Oriented design.
+Many applications and libraries in HPC are written using an Object-Oriented design.
 This has numerous advantages in terms of code organization and potentially reuse.
-Unfortunately it comes with a significant draw back as far as using Kokkos is concerned,
+Unfortunately it comes with a significant drawback as far as using Kokkos is concerned,
 if C++17 is not an option.
 
 Consider an application for simulating the time evolution of a particle system.
-In an Object Oriented design, it would likely contain something like a class `ParticleInteractions`,
+In an Object-Oriented design, it would likely contain something like a class `ParticleInteractions`,
 which holds references to data structures for particles and interaction potentials.
 It would also contain some member function `compute`, which would loop over the particles
 and calculate the interactions:
@@ -31,7 +31,7 @@ public:
 };
 ```
 
-A simple way of parallelising this is to add a `parallel_for` inside the member function `compute`.
+A simple way of parallelising this is to add a [`parallel_for`](../API/core/parallel-dispatch/parallel_for) inside the member function `compute`.
 
 ```c++
 class ParticleInteractions {
@@ -46,14 +46,14 @@ class ParticleInteractions {
 };
 ```
 
-And indeed on non-accelerator based systems this would work. But on systems where the `parallel_for`
+And indeed on non-accelerator based systems this would work. But on systems where the [`parallel_for`](../API/core/parallel-dispatch/parallel_for)
 dispatches work to an accelerator, this approach would likely fail with an access error.
 
-The reason for that is, that lambdas inside of a class member function do not capture other
+The reason for that is, that lambdas inside a class member function do not capture other
 class members individually, they capture the entire class as a whole.
 More precisely, in pre-C++17 they capture the `this` pointer at the scope of `compute`.
 
-In effect it is as if one would have written:
+In effect, it is as if one had written:
 ```c++
 class ParticleInteractions {
   ...
@@ -89,11 +89,11 @@ class ParticleInteractions {
 ```
 
 In fact this may even have clarity enhancing qualities, since it separates the work items of the parallel operation,
-from the dispatch itself and its associated pre and post launch work.
+from the dispatch itself and its associated pre- and post-launch work.
 
 But what if you have more than one parallel operation in a class?
 This is where Kokkos's tagged dispatch comes into play.
-In order for a class to have multiple operators, Kokkos allows these operators to have an unsued additional parameter
+In order for a class to have multiple operators, Kokkos allows these operators to have an unused additional parameter
 which is used in overload resolution.
 This parameter is given as an additional template parameter to the execution policy during dispatch.
 A good practice is to create `Tag-Classes` as nested definitions inside the original object:

--- a/source/usecases/VirtualFunctions.md
+++ b/source/usecases/VirtualFunctions.md
@@ -7,7 +7,6 @@ Due to oddities of GPU programming, the use of virtual functions in Kokkos paral
 In GPU programming, you might have run into the bug of calling a host function from the device. A similar thing can happen for subtle reasons in code using virtual functions. Consider the following code
 
 ```c++
-
 class ClassWithVirtualFunctions : public SomeBase {
   /** fields */
   public:
@@ -42,13 +41,13 @@ Remember that we have one VTable shared amongst all instances of a type. Each in
 
 Now that we know what the compiler is doing to implement virtual functions, we'll look at why it doesn't work with GPU's
 
-Credit: the content of this section is adapted from Pablo Arias here (https://pabloariasal.github.io/2017/06/10/understanding-virtual-tables/ )
+Credit: the content of this section is adapted from Pablo Arias [here](https://pabloariasal.github.io/2017/06/10/understanding-virtual-tables/ )
 
 ## Then why doesn't my code work?
 
 The reason the intro code might break is that when dealing with GPU-compatible classes with virtual functions, there isn't one VTable, but two. The first has the host versions of the virtual functions, while the second has the device functions. We're initializing the class on the host, so it points to the host VTable.
 
-Our cudaMemcpy faithfully copied all of the members of the class, including the VPointer merrily pointing at host functions, which we then call on the device.
+Our cudaMemcpy faithfully copied all the members of the class, including the VPointer merrily pointing at host functions, which we then call on the device.
 
 ## How to fix this
 
@@ -114,4 +113,4 @@ This is the solution that the code teams we have talked to have said is the most
 
 ## Questions/Follow-up
 
-This is intended to be an educational resource for our users. If something doesn't make sense, or you have further questions, you'd be doing us a favor by letting us know on [Slack](https://kokkosteam.slack.com) or [GitHub](https://github.com/kokkos/kokkos.com)
+This is intended to be an educational resource for our users. If something doesn't make sense, or you have further questions, you'd be doing us a favor by letting us know on [Slack](https://kokkosteam.slack.com) or [GitHub](https://github.com/kokkos/kokkos)


### PR DESCRIPTION
- added links in usecases/Average-To-Nodes.md
- fixed grammar, fixed formatting, removed blank lines added links in usecases/Kokkos-Fortran-Interoperability.md
- fixed grammar, fixed formatting, removed blank lines and added links in usecases/MDRangePolicy.md
- added links to usecases/MPI-Halo-Exchange.md
- fixed grammar, fixed formatting and removed blank lines in usecases/OverlappingHostAndDeviceWork.md
- removed blank lines in usecases/SoA-and-AoSoA-with-Cabana.md
- fixed grammar and fixed links in usecases/TaggedOperators.md
- fixed grammar, fixed links and formatting in usecases/Tasking.md
- removed blank lines, fixed links and fixed grammar in usecases/VirtualFunctions.md