### PR TITLE
Add link to the actual docmentation website in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # kokkos-core-documentation-website
+Welcome to the Kokkos Documentation repository.  This is the source for https://kokkos.github.io/kokkos-core-wiki/.
 
 ## Requirements to build html page locally
 


### PR DESCRIPTION
I've found myself having to manually enter the URL or browse back to the Core repo too many times already