### PR TITLE
#95: Fixed some rst files rendering

### DIFF
--- a/docs/source/API/core/Initialize-and-Finalize.rst
+++ b/docs/source/API/core/Initialize-and-Finalize.rst
@@ -20,11 +20,11 @@ See `Kokkos::finalize <initialize_finalize/finalize.html>`_ for details.
 Kokkos::ScopeGuard
 ------------------
 
-`Kokkos::ScopeGuard` is a class which aggregates the resources managed by Kokkos. ScopeGuard will call `Kokkos::initialize` when constructed and `Kokkos::finalize` when destructed, thus the Kokkos context is automatically managed via the scope of the ScopeGuard object.
+``Kokkos::ScopeGuard`` is a class which aggregates the resources managed by Kokkos. ScopeGuard will call ``Kokkos::initialize`` when constructed and ``Kokkos::finalize`` when destructed, thus the Kokkos context is automatically managed via the scope of the ScopeGuard object.
 
 See `Kokkos::ScopeGuard <initialize_finalize/ScopeGuard.html>`_ for details.
 
-ScopeGuard aids in the following common mistake which is allowing Kokkos objects to live past `Kokkos::finalize`:
+ScopeGuard aids in the following common mistake which is allowing Kokkos objects to live past ``Kokkos::finalize``:
 
 .. code-block:: cpp
 
@@ -35,7 +35,7 @@ ScopeGuard aids in the following common mistake which is allowing Kokkos objects
     // my_view destructor called after Kokkos::finalize !
   }
 
-Switching to `Kokkos::ScopeGuard` fixes it:
+Switching to ``Kokkos::ScopeGuard`` fixes it:
 
 .. code-block:: cpp
 
@@ -46,11 +46,10 @@ Switching to `Kokkos::ScopeGuard` fixes it:
     // ScopeGuard destructor called, calls Kokkos::finalize
   }
 
-In the above example, `my_view` will not go out of scope until the end of the main() function.  Without `ScopeGuard`, `Kokkos::finalize` will be called before `my_view` is out of scope.  With `ScopeGuard`, `ScopeGuard` will be dereferenced (subsequently calling `Kokkos::finalize`) after `my_view` is dereferenced, which ensures the proper order during shutdown.
-
-|
+In the above example, ``my_view`` will not go out of scope until the end of the main() function.  Without ``ScopeGuard``, ``Kokkos::finalize`` will be called before ``my_view`` is out of scope.  With ``ScopeGuard``, ``ScopeGuard`` will be dereferenced (subsequently calling ``Kokkos::finalize``) after ``my_view`` is dereferenced, which ensures the proper order during shutdown.
 
 .. toctree::
+   :hidden:
    :maxdepth: 1
 
    ./initialize_finalize/initialize

--- a/docs/source/API/core/ParallelDispatch.rst
+++ b/docs/source/API/core/ParallelDispatch.rst
@@ -1,9 +1,47 @@
-
 Parallel Execution/Dispatch
 ===========================
 
+Parallel patterns
+-----------------
+
+Parallel execution patterns for composing algorithms.
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Function
+     - Description
+   * - `parallel_for <parallel-dispatch/parallel_for.html>`__
+     - Executes user code in parallel
+   * - `parallel_reduce <parallel-dispatch/parallel_reduce.html>`__
+     - Executes user code to perform a reduction in parallel
+   * - `parallel_scan <parallel-dispatch/parallel_scan.html>`__
+     - Executes user code to generate a prefix sum in parallel
+   * - `fence <parallel-dispatch/fence.html>`__
+     - Fences execution spaces
+
+Tags for Team Policy Calculations
+---------------------------------
+
+The following parallel pattern tags are used to call the correct overload for team size calculations (team_size_max,team_size_recommended):
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Tag
+     - Pattern
+   * - `ParallelForTag <parallel-dispatch/ParallelForTag.html>`__
+     - parallel_for
+   * - `ParallelReduceTag <parallel-dispatch/ParallelReduceTag.html>`__
+     - parallel_reduce
+   * - `ParallelScanTag <parallel-dispatch/ParallelScanTag.html>`__
+     - parallel_scan
+
 .. toctree::
-   :maxdepth: 2
+   :hidden:
+   :maxdepth: 1
 
    ./parallel-dispatch/parallel_for
    ./parallel-dispatch/parallel_reduce

--- a/docs/source/API/core/View.rst
+++ b/docs/source/API/core/View.rst
@@ -1,7 +1,40 @@
 View and related
 ================
 
+Data management is a critical part of any program. The main facility in Kokkos is the ``Kokkos::View``.
+The following facilities are available:
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Class
+     - Description
+   * - `create_mirror[_view] <view/create_mirror.html>`__
+     - Creating a copy of a ``Kokkos::View`` in a different memory space.
+   * - `deep_copy() <view/deep_copy.html>`__
+     - Copying data between views and scalars.
+   * - `LayoutLeft <view/layoutLeft.html>`__
+     - Memory Layout matching Fortran.
+   * - `LayoutRight <view/layoutRight.html>`__
+     - Memory Layout matching C.
+   * - `LayoutStride <view/layoutStride.html>`__
+     - Memory Layout for arbitrary strides.
+   * - `realloc <view/realloc.html>`__
+     - Reallocating a ``Kokkos::View``.
+   * - `resize <view/resize.html>`__
+     - Resizing a ``Kokkos::View``.
+   * - `subview <view/subview.html>`__
+     - Getting slices from a ``Kokkos::View``.
+   * - `View <view/view.html>`__
+     - The main Kokkos data structure, a multidimensional memory space and layout aware array.
+   * - `view_alloc() <view/view_alloc.html>`__
+     - Create View allocation parameter bundle from argument list.
+   * - `View-like Types <view/view_like.html>`__
+     - Loosely defined as the set of class templates that behave like ``Kokkos::View``.
+
 .. toctree::
+   :hidden:
    :maxdepth: 1
 
    ./view/create_mirror

--- a/docs/source/API/core/builtin_reducers.rst
+++ b/docs/source/API/core/builtin_reducers.rst
@@ -1,7 +1,45 @@
 Built-in Reducers
-#################
+=================
+
+`ReducerConcept <builtinreducers/ReducerConcept.html>`__ provides the concept for Reducers.
+
+Reducer objects used in conjunction with `parallel_reduce <parallel-dispatch/parallel_reduce.html>`__
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Reducer
+     - Description
+   * - `BAnd <builtinreducers/BAnd.html>`__
+     - Binary 'And' reduction
+   * - `BOr <builtinreducers/BOr.html>`__
+     - Binary 'Or' reduction
+   * - `LAnd <builtinreducers/LAnd.html>`__
+     - Logical 'And' reduction
+   * - `LOr <builtinreducers/LOr.html>`__
+     - Logical 'Or' reduction
+   * - `Max <builtinreducers/Max.html>`__
+     - Maximum reduction
+   * - `MaxLoc <builtinreducers/MaxLoc.html>`__
+     - Reduction providing maximum and an associated index
+   * - `Min <builtinreducers/Min.html>`__
+     - Minimum reduction
+   * - `MinLoc <builtinreducers/MinLoc.html>`__
+     - Reduction providing minimum and an associated index
+   * - `MinMax <builtinreducers/MinMax.html>`__
+     - Reduction providing both minimum and maximum
+   * - `MinMaxLoc <builtinreducers/MinMaxLoc.html>`__
+     - Reduction providing both minimum and maximum and associated indices
+   * - `Prod <builtinreducers/Prod.html>`__
+     - Multiplicative reduction
+   * - `Sum <builtinreducers/Sum.html>`__
+     - Sum reduction
+
+`Reduction Scalar Types <builtinreducers/ReductionScalarTypes.html>`__ are template classes for storage for reducers.
 
 .. toctree::
+   :hidden:
    :maxdepth: 1
 
    ./builtinreducers/ReducerConcept

--- a/docs/source/API/core/builtinreducers/ReductionScalarTypes.rst
+++ b/docs/source/API/core/builtinreducers/ReductionScalarTypes.rst
@@ -1,7 +1,21 @@
 Reduction Scalar Types
 ######################
 
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Class
+     - Description
+   * - `MinMaxLocScalar <MinMaxLocScalar.html>`__
+     - Template class for storing the min and max values with indices for min/max location reducers.
+   * - `MinMaxScalar <MinMaxScalar.html>`__
+     - Template class for storing the min and max values for min/max reducers.
+   * - `ValLocScalar <ValLocScalar.html>`__
+     - Template class for storing a value plus index for min/max location reducers.
+
 .. toctree::
+   :hidden:
    :maxdepth: 1
 
    MinMaxLocScalar


### PR DESCRIPTION
### THIS PR:
- hid toctree for builtin_reducers.rst and added a table
- fixed formatting and hid toctree in Initialize-and-Finalize.rst
- reduced depth and hid toctree in ParallelDispatch.rst
- Added tables to ParallelDispatch.rst
- hid toctree and add table in ReductionScalarTypes.rst
- hid toctree and add table in View.rst

Below rendered docs, after improvements.

![Zrzut ekranu z 2022-07-04 13-24-20](https://user-images.githubusercontent.com/47597569/177145312-162c1369-ceea-4046-838e-c5bfe0575d3e.png)
![Zrzut ekranu z 2022-07-04 13-24-07](https://user-images.githubusercontent.com/47597569/177145318-a18cd5ae-2a58-4b06-b34f-4e263b816b07.png)
![Zrzut ekranu z 2022-07-04 13-23-56](https://user-images.githubusercontent.com/47597569/177145321-90305766-516a-464f-8b02-4f8214c8ce97.png)
![Zrzut ekranu z 2022-07-04 13-23-46](https://user-images.githubusercontent.com/47597569/177145325-bd515948-a767-4c39-b8b9-8109f221c6fa.png)
![Zrzut ekranu z 2022-07-04 13-23-32](https://user-images.githubusercontent.com/47597569/177145327-d51e98c8-cfe7-414a-9074-245e1cd59db6.png)
