### PR TITLE
Document new create_mirror[_view] overloads taking Kokkos::view_alloc() return type

### DIFF
--- a/docs/source/API/core/view/create_mirror.md
+++ b/docs/source/API/core/view/create_mirror.md
@@ -154,8 +154,8 @@ auto create_mirror_view_and_copy(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_
   auto create_mirror_view(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
                           ViewType const& src);
   ```
-  If the [`View`](view) constructor arguments `arg_prop` include a memory space and the memory space doesn't match the memory space of `src`, creates a new [`View`](view) in the specified memory_space.
-  If the `arg_prop` don't include a memory space and the memory space of `src` is not host-accessible, creates a new host-accessible [`View`](view).
+  If the [`View`](view) constructor arguments `arg_prop` include a memory space and the memory space doesn't match the memory space of `src`, a new [`View`](view) in the specified memory_space is created.
+  If the `arg_prop` don't include a memory space and the memory space of `src` is not host-accessible, a new host-accessible [`View`](view) is created.
   Otherwise, `src` is returned.
   If a new [`View`](view) is created, the implicitly called constructor respects `arg_prop` and uses the same layout and padding as `src`.
   * `src`: a `Kokkos::View`.
@@ -180,7 +180,7 @@ auto create_mirror_view_and_copy(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_
   ImplMirrorType create_mirror_view_and_copy(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
                                              ViewType const& src);
   ```
-  If the  memory space included in the [`View`](view) constructor arguments `arg_prop` matches the memory space of `src`, creates a new [`View`](view) in the specified memory space using `arg_prop` and the same layout andf padding as `src`. Additionally, a `deep_copy` from `src` to the new view is executed (using the execution space contained in `arg_prop` if provided).
+  If the  memory space included in the [`View`](view) constructor arguments `arg_prop` matches the memory space of `src`, a new [`View`](view) in the specified memory space is created using `arg_prop` and the same layout andf padding as `src`. Additionally, a `deep_copy` from `src` to the new view is executed (using the execution space contained in `arg_prop` if provided).
 Otherwise returns `src`.
   * `src`: a `Kokkos::View`.
   * `arg_prop`: [`View`](view) constructor properties, e.g., `Kokkos::view_alloc(Kokkos::HostSpace{}, Kokkos::WithoutInitializing)`.

--- a/docs/source/API/core/view/create_mirror.md
+++ b/docs/source/API/core/view/create_mirror.md
@@ -31,8 +31,7 @@ ImplMirrorType create_mirror(decltype(Kokkos::ViewAllocateWithoutInitializing())
                              Space const& space, ViewType const&);
 
 template <class ViewType, class... ViewCtorArgs>
-auto create_mirror(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
-                   ViewType const& v);
+auto create_mirror(/* is-alloc-prop */ const& arg_prop, ViewType const& v);
 
 template <class ViewType>
 typename ViewType::HostMirror create_mirror_view(ViewType const&);
@@ -49,15 +48,13 @@ ImplMirrorType create_mirror_view(decltype(Kokkos::ViewAllocateWithoutInitializi
                                   Space const& space, ViewType const&);
 
 template <class ViewType, class... ViewCtorArgs>
-auto create_mirror_view(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
-                        ViewType const& v);
+auto create_mirror_view(/* is-alloc-prop */ const& arg_prop, ViewType const& v);
 
 template <class Space, class ViewType>
 ImplMirrorType create_mirror_view_and_copy(Space const& space, ViewType const&);
 
 template <class ViewType, class... ViewCtorArgs>
-auto create_mirror_view_and_copy(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
-                                 ViewType const& v);
+auto create_mirror_view_and_copy(/* is-alloc-prop */ const& arg_prop, ViewType const& v);
 ```
 
 
@@ -99,8 +96,7 @@ auto create_mirror_view_and_copy(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_
 
 * ```c++
   template <class ViewType, class... ViewCtorArgs>
-  auto create_mirror(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
-                     ViewType const& v);
+  auto create_mirror(/* is-alloc-prop */ const& arg_prop, ViewType const& v);
   ```
   Creates a new [`View`](view) with the same layout and padding as `src` using the [`View`](view) constructor properties `arg_prop`, e.g., `Kokkos::view_alloc(Kokkos::WithoutInitializing)`. If `arg_prop` contains a memory space, a [`View`](view) in that space is created. Otherwise, a [`View`](view) in host-accessible memory is returned.
   * `src`: a `Kokkos::View`.
@@ -151,8 +147,7 @@ auto create_mirror_view_and_copy(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_
 
 * ```c++
   template <class ViewType, class... ViewCtorArgs>
-  auto create_mirror_view(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
-                          ViewType const& src);
+  auto create_mirror_view(/* is-alloc-prop */ const& arg_prop, ViewType const& src);
   ```
   If the [`View`](view) constructor arguments `arg_prop` include a memory space and the memory space doesn't match the memory space of `src`, a new [`View`](view) in the specified memory_space is created.
   If the `arg_prop` don't include a memory space and the memory space of `src` is not host-accessible, a new host-accessible [`View`](view) is created.
@@ -177,8 +172,7 @@ auto create_mirror_view_and_copy(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_
 
 * ```c++
   template <class ViewType, class... ViewCtorArgs>
-  ImplMirrorType create_mirror_view_and_copy(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
-                                             ViewType const& src);
+  ImplMirrorType create_mirror_view_and_copy(/* is-alloc-prop */ const& arg_prop, ViewType const& src);
   ```
   If the  memory space included in the [`View`](view) constructor arguments `arg_prop` matches the memory space of `src`, a new [`View`](view) in the specified memory space is created using `arg_prop` and the same layout andf padding as `src`. Additionally, a `deep_copy` from `src` to the new view is executed (using the execution space contained in `arg_prop` if provided).
 Otherwise returns `src`.

--- a/docs/source/API/core/view/create_mirror.md
+++ b/docs/source/API/core/view/create_mirror.md
@@ -30,6 +30,10 @@ template <class Space, class ViewType>
 ImplMirrorType create_mirror(decltype(Kokkos::ViewAllocateWithoutInitializing()),
                              Space const& space, ViewType const&);
 
+template <class ViewType, class... ViewCtorArgs>
+auto create_mirror(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
+                   ViewType const& v);
+
 template <class ViewType>
 typename ViewType::HostMirror create_mirror_view(ViewType const&);
 
@@ -44,8 +48,16 @@ template <class Space, class ViewType>
 ImplMirrorType create_mirror_view(decltype(Kokkos::ViewAllocateWithoutInitializing()),
                                   Space const& space, ViewType const&);
 
+template <class ViewType, class... ViewCtorArgs>
+auto create_mirror_view(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
+                        ViewType const& v);
+
 template <class Space, class ViewType>
 ImplMirrorType create_mirror_view_and_copy(Space const& space, ViewType const&);
+
+template <class ViewType, class... ViewCtorArgs>
+auto create_mirror_view_and_copy(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
+                                 ViewType const& v);
 ```
 
 
@@ -86,6 +98,18 @@ ImplMirrorType create_mirror_view_and_copy(Space const& space, ViewType const&);
   * `ImplMirrorType`: an implementation defined specialization of `Kokkos::View`.
 
 * ```c++
+  template <class ViewType, class... ViewCtorArgs>
+  auto create_mirror(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
+                     ViewType const& v);
+  ```
+  Creates a new [`View`](view) with the same layout and padding as `src` using the [`View`](view) constructor properties `arg_prop`, e.g., `Kokkos::view_alloc(Kokkos::WithoutInitializing)`. If `arg_prop` contains a memory space, a [`View`](view) in that space is created. Otherwise, a [`View`](view) in host-accessible memory is returned.
+  * `src`: a `Kokkos::View`.
+  * `arg_prop`: [`View`](view) constructor properties, e.g., `Kokkos::view_alloc(Kokkos::WithoutInitializing)`.
+
+ Restrictions:
+  * `arg_prop` must not include a pointer to memory, or a label, or allow padding.
+
+* ```c++
   template <class ViewType>
   typename ViewType::HostMirror create_mirror_view(ViewType const& src);
   ```
@@ -116,7 +140,7 @@ ImplMirrorType create_mirror_view_and_copy(Space const& space, ViewType const&);
 * ```c++
   template <class Space, class ViewType>
   ImplMirrorType create_mirror_view(decltype(Kokkos::ViewAllocateWithoutInitializing()),
-                                    Space const& space, ViewType const&);
+                                    Space const& space, ViewType const& src);
   ```
   If `std::is_same<typename Space::memory_space, typename ViewType::memory_space>::value` is `false`,
   creates a new [`View`](view) with the same layout and padding as `src` but with a device type of `Space::device_type`. The new view will have uninitialized data.
@@ -124,6 +148,21 @@ ImplMirrorType create_mirror_view_and_copy(Space const& space, ViewType const&);
   * `src`: a `Kokkos::View`.
   * `Space`: a class meeting the requirements of [`ExecutionSpaceConcept`](ExecutionSpaceConcept) or [`MemorySpaceConcept`](MemorySpaceConcept)
   * `ImplMirrorType`: an implementation defined specialization of `Kokkos::View`.
+
+* ```c++
+  template <class ViewType, class... ViewCtorArgs>
+  auto create_mirror_view(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
+                          ViewType const& src);
+  ```
+  If the [`View`](view) constructor arguments `arg_prop` include a memory space and the memory space doesn't match the memory space of `src`, creates a new [`View`](view) in the specified memory_space.
+  If the `arg_prop` don't include a memory space and the memory space of `src` is not host-accessible, creates a new host-accessible [`View`](view).
+  Otherwise, `src` is returned.
+  If a new [`View`](view) is created, the implicitly called constructor respects `arg_prop` and uses the same layout and padding as `src`.
+  * `src`: a `Kokkos::View`.
+  * `arg_prop`: [`View`](view) constructor properties, e.g., `Kokkos::view_alloc(Kokkos::WithoutInitializing)`.
+
+ Restrictions:
+  * `arg_prop` must not include a pointer to memory, or a label, or allow padding.
 
 * ```c++
   template <class Space, class ViewType>
@@ -135,3 +174,17 @@ ImplMirrorType create_mirror_view_and_copy(Space const& space, ViewType const&);
   * `src`: a `Kokkos::View`.
   * `Space`: a class meeting the requirements of [`ExecutionSpaceConcept`](ExecutionSpaceConcept) or [`MemorySpaceConcept`](MemorySpaceConcept)
   * `ImplMirrorType`: an implementation defined specialization of `Kokkos::View`.
+
+* ```c++
+  template <class ViewType, class... ViewCtorArgs>
+  ImplMirrorType create_mirror_view_and_copy(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
+                                             ViewType const& src);
+  ```
+  If the  memory space included in the [`View`](view) constructor arguments `arg_prop` matches the memory space of `src`, creates a new [`View`](view) in the specified memory space using `arg_prop` and the same layout andf padding as `src`. Additionally, a `deep_copy` from `src` to the new view is executed (using the execution space contained in `arg_prop` if provided).
+Otherwise returns `src`.
+  * `src`: a `Kokkos::View`.
+  * `arg_prop`: [`View`](view) constructor properties, e.g., `Kokkos::view_alloc(Kokkos::HostSpace{}, Kokkos::WithoutInitializing)`.
+
+ Restrictions:
+  * `arg_prop` must not include a pointer to memory, or a label, or allow padding.
+  * `arg_prop` must include a memory space.


### PR DESCRIPTION
Corresponding to https://github.com/kokkos/kokkos/pull/5095 and https://github.com/kokkos/kokkos/pull/5125.