### PR TITLE
#106: Fix links in ProgrammingGuide/Interoperability

### DIFF
--- a/docs/source/ProgrammingGuide/Interoperability.md
+++ b/docs/source/ProgrammingGuide/Interoperability.md
@@ -59,7 +59,7 @@ In both cases, it is mandatory to fix the Layout of the Kokkos view to the actua
 
 ## 12.3 Raw allocations through Kokkos
 
-A simple way to add support for multiple memory spaces to a legacy app is to use [`kokkos_malloc`](kokkos_malloc), [`kokkos_free`](kokkos_free) and [`kokkos_realloc`](kokkos_realloc). The functions are templated on the memory space and thus allow targeted placement of data structures:
+A simple way to add support for multiple memory spaces to a legacy app is to use [`kokkos_malloc`](../API/core/c_style_memory_management/malloc), [`kokkos_free`](../API/core/c_style_memory_management/free) and [`kokkos_realloc`](../API/core/c_style_memory_management/realloc). The functions are templated on the memory space and thus allow targeted placement of data structures:
 
 ```c++
 // Allocate an array of 100 doubles in the default memory space


### PR DESCRIPTION
### THIS PR:
- fixed links in ProgrammingGuide/Interoperability.md

closes #106 