### PR TITLE
Update `Kokkos::initialize` API

### DIFF
--- a/docs/source/API/core/initialize_finalize/InitializationSettings.md
+++ b/docs/source/API/core/initialize_finalize/InitializationSettings.md
@@ -1,4 +1,4 @@
-# Kokkos::InitializationSettings
+# InitializationSettings
 
 Defined in header `<KokkosCore.cpp>`
 

--- a/docs/source/API/core/initialize_finalize/ScopeGuard.md
+++ b/docs/source/API/core/initialize_finalize/ScopeGuard.md
@@ -1,4 +1,4 @@
-# Kokkos::ScopeGuard
+# ScopeGuard
 
 Header File: `Kokkos_Core.hpp`
 

--- a/docs/source/API/core/initialize_finalize/ScopeGuard.md
+++ b/docs/source/API/core/initialize_finalize/ScopeGuard.md
@@ -4,54 +4,85 @@ Header File: `Kokkos_Core.hpp`
 
 Usage: 
 ```c++
-Kokkos::ScopeGuard(narg, arg);
-Kokkos::ScopeGuard(args);
+Kokkos::ScopeGuard guard(argc, argv);
+Kokkos::ScopeGuard guard(Kokkos::InitializationSettings()  // (since 3.7)
+                             .set_map_device_id_by("random")
+                             .set_num_threads(1));
 ```
 
-`ScopeGuard` is a class which ensure that `Kokkos::initialize` and
-`Kokkos::finalize` are called correctly even in the presence of unhandled
-exceptions and multiple libraries trying to "own" Kokkos initialization.
-`ScopeGuard` calls `Kokkos::initialize` in its constructor only if
-`Kokkos::is_initialized()` is false, and calls `Kokkos::finalize` in its
-destructor only if it called `Kokkos::initialize` in its constructor.
+`ScopeGuard` is a class which ensure thats [`Kokkos::initialize`](initialize) and
+[`Kokkos::finalize`](finalize) are called correctly even in the presence of unhandled
+exceptions.
+It calls [`Kokkos::intialize`](initialize) with the provided arguments in the
+constructor and [`Kokkos::finalize`](finalize) in the destructor.
+
+
+**WARNING: change of behavior in version 3.7**  
+Since Kokkos version 3.7, `ScopeGuard` unconditionally forwards the provided
+arguments to `Kokkos::initialize`, which means they have the same precondition.
+Until version 3.7, `ScopeGuard` was calling `Kokkos::initialize` in its
+constructor only if `Kokkos::is_initialized()` was `false`, and it was calling
+`Kokkos::finalize` in its destructor only if it called `Kokkos::initialize` in
+its constructor.
+
+We dropped support for the old behavior.  If you think you really need it, you
+may do:
+```C++
+auto guard = std::unique_ptr<Kokkos::ScopeGuard>(
+    Kokkos::is_initialized() ? new Kokkos::ScopeGuard() : nullptr);
+```
+or
+```C++
+auto guard = std::optional<Kokkos::ScopeGuard>(
+    Kokkos::is_initialized() ? Kokkos::ScopeGuard() : std::nullopt);
+```
+with C++17.  This will work regardless of the Kokkos version.
 
 ## Interface
 
 ```c++
-Kokkos::ScopeGuard(int& narg, char* arg[]);
-```
+class ScopeGuard {
+public:
+  ScopeGuard(ScopeGuard const&) = delete;
+  ScopeGuard(ScopeGuard&&) = delete;
+  ScopeGuard& operator=(ScopeGuard const&) = delete;
+  ScopeGuard& operator=(ScopeGuard&&) = delete;
 
-```c++
-Kokkos::ScopeGuard(const InitArguments& args);
-```
+  ScopeGuard(int& argc, char* argv[]);                           // (until 3.7)
+  ScopeGuard(InitArguments const& arguments = InitArguments());  // (until 3.7)
 
-```c++
-~ScopeGuard();
+  template <class... Args>
+  ScopeGuard(Args&&... args) {                                   // (since 3.7)
+    // possible implementation
+    initialize(std::forward<Args>(args)...);
+  }
+
+  ~ScopeGuard() {
+    // possible implementation
+    finalize();
+  }
 ```
 
 ### Parameters:
 
-  * narg:  number of command line arguments
-  * arg: array of command line arguments, valid arguments are listed below.
-  * args: structure of valid Kokkos arguments
+* `argc`: number of command line arguments
+* `argv`: array of character pointers to null-terminated strings storing the command line arguments
+* `arguments`: `struct` object with valid initialization arguments
+* `args`: arguments to pass to [`Kokkos::initialize`](initialize)
 
 Note that all of the parameters above are passed to the `Kokkos::initialize` called internally.  See [Kokkos::initialize](initialize) for more details.
- 
-### Requirements
-  * `Kokkos::ScopeGuard` object should be constructed before user initiated Kokkos objects 
-
-### Semantics
-  * Calls `Kokkos::initialize` only if `Kokkos::is_initialized()` is false.
-  * Arguments are passed directly to `Kokkos::initialize` if it is called.
-  * Kokkos::ScopeGuard::~ScopeGuard calls `Kokkos::finalize` only if the constructor of this object called `Kokkos::initialize`.
 
 ### Example
 
 ```c++
-int main(int argc, char** argv) {
-  Kokkos::ScopeGuard kokkos(argc, argv);
+int main(int argc, char* argv[]) {
+  Kokkos::ScopeGuard guard(argc, argv);
   Kokkos::View<double*> my_view("my_view", 10);
   // my_view destructor called before Kokkos::finalize
   // ScopeGuard destructor called, calls Kokkos::finalize
 }
 ```
+
+### See also
+* [Kokkos::initialize](initialize)
+* [Kokkos::finalize](finalize)

--- a/docs/source/API/core/initialize_finalize/finalize.md
+++ b/docs/source/API/core/initialize_finalize/finalize.md
@@ -1,4 +1,4 @@
-# Kokkos::finalize
+# finalize
 
 Header File: `Kokkos_Core.hpp`
 

--- a/docs/source/API/core/initialize_finalize/initialize.md
+++ b/docs/source/API/core/initialize_finalize/initialize.md
@@ -1,4 +1,4 @@
-# Kokkos::initialize
+# initialize
 
 Defined in header `<Kokkos_Core.hpp>`
 


### PR DESCRIPTION
Attempted to use reStructuredText instead of Markdown just to give it a try.
I updated every section but `Requirements` and `Semantics`