### PR TITLE
Adding Hip spaces ... already without `Experimental`

### DIFF
--- a/docs/source/API/core/Utilities.rst
+++ b/docs/source/API/core/Utilities.rst
@@ -7,3 +7,4 @@ Utilities
    ./utilities/abort
    ./utilities/complex
    ./utilities/timer
+   ./utilities/experimental

--- a/docs/source/API/core/execution_spaces.md
+++ b/docs/source/API/core/execution_spaces.md
@@ -5,6 +5,11 @@
 
 `Kokkos::Cuda` is an [`ExecutionSpace` type](ExecutionSpaceConcept) representing execution on a Cuda device.  Except in rare instances, it should not be used directly, but instead should be used generically as an execution space.  For details, see [the documentation on the `ExecutionSpace` concept](ExecutionSpaceConcept).
 
+(HIP)=
+## `Kokkos::HIP`
+
+`Kokkos::HIP` is an [`ExecutionSpace` type](ExecutionSpaceConcept) representing execution on a device supported by HIP.  Except in rare instances, it should not be used directly, but instead should be used generically as an execution space.  For details, see [the documentation on the `ExecutionSpace` concept](ExecutionSpaceConcept).
+
 (HPX)=
 ## `Kokkos::HPX`
 

--- a/docs/source/API/core/execution_spaces.md
+++ b/docs/source/API/core/execution_spaces.md
@@ -8,7 +8,7 @@
 (HIP)=
 ## `Kokkos::HIP`
 
-`Kokkos::HIP` is an [`ExecutionSpace` type](ExecutionSpaceConcept) representing execution on a device supported by HIP.  Except in rare instances, it should not be used directly, but instead should be used generically as an execution space.  For details, see [the documentation on the `ExecutionSpace` concept](ExecutionSpaceConcept).
+`Kokkos::HIP` <sup>promoted from [Experimental](ExperimentalNamespace) since 4.0</sup> is an [`ExecutionSpace` type](ExecutionSpaceConcept) representing execution on a device supported by HIP.  Except in rare instances, it should not be used directly, but instead should be used generically as an execution space.  For details, see [the documentation on the `ExecutionSpace` concept](ExecutionSpaceConcept).
 
 (HPX)=
 ## `Kokkos::HPX`

--- a/docs/source/API/core/memory_spaces.md
+++ b/docs/source/API/core/memory_spaces.md
@@ -15,6 +15,21 @@
 
 `Kokkos::CudaUVMSpace` is a [`MemorySpace` type](MemorySpaceConcept) representing unified virtual memory on a Cuda-capable GPU system.  Unified virtual memory is also accessible from most host execution spaces.  Except in rare instances, it should not be used directly, but instead should be used generically as an memory space.  For details, see [the documentation on the `MemorySpace` concept](MemorySpaceConcept).
 
+(HIPSpace)=
+## `Kokkos::HIPSpace`
+
+`Kokkos::HIPSpace` is a [`MemorySpace` type](MemorySpaceConcept) representing device memory on a GPU in the `HIP` GPU programming environment.  Except in rare instances, it should not be used directly, but instead should be used generically as an memory space.  For details, see [the documentation on the `MemorySpace` concept](MemorySpaceConcept).
+
+(HIPHostPinnedSpace)=
+## `Kokkos::HIPHostPinnedSpace`
+
+`Kokkos::HIPHostPinnedSpace` is a [`MemorySpace` type](MemorySpaceConcept) representing host-side pinned memory accessible from a GPU in the `HIP` GPU programming environment.  This memory is accessible by both host and device execution spaces.  Except in rare instances, it should not be used directly, but instead should be used generically as an memory space.  For details, see [the documentation on the `MemorySpace` concept](MemorySpaceConcept).
+
+(HIPManagedSpace)=
+## `Kokkos::HIPManagedSpace`
+
+`Kokkos::HIPManagedSpace` is a [`MemorySpace` type](MemorySpaceConcept) representing page-migratint memory on a GPU in the `HIP` GPU programming environment.  Page-migrating memory is accessible from most host execution spaces. Even though available with all combinations of operting system and `HIP`-supported hardware, it requires both operating system and hardware to support and enable the `xnack` feature. Except in rare instances, it should not be used directly, but instead should be used generically as an memory space.  For details, see [the documentation on the `MemorySpace` concept](MemorySpaceConcept).
+
 (HostSpace)=
 ## `Kokkos::HostSpace`
 

--- a/docs/source/API/core/memory_spaces.md
+++ b/docs/source/API/core/memory_spaces.md
@@ -18,17 +18,17 @@
 (HIPSpace)=
 ## `Kokkos::HIPSpace`
 
-`Kokkos::HIPSpace` is a [`MemorySpace` type](MemorySpaceConcept) representing device memory on a GPU in the HIP GPU programming environment.  Except in rare instances, it should not be used directly, but instead should be used generically as an memory space.  For details, see [the documentation on the `MemorySpace` concept](MemorySpaceConcept).
+`Kokkos::HIPSpace` <sup>promoted from [Experimental](ExperimentalNamespace) since 4.0</sup> is a [`MemorySpace` type](MemorySpaceConcept) representing device memory on a GPU in the HIP GPU programming environment.  Except in rare instances, it should not be used directly, but instead should be used generically as an memory space.  For details, see [the documentation on the `MemorySpace` concept](MemorySpaceConcept).
 
 (HIPHostPinnedSpace)=
 ## `Kokkos::HIPHostPinnedSpace`
 
-`Kokkos::HIPHostPinnedSpace` is a [`MemorySpace` type](MemorySpaceConcept) representing host-side pinned memory accessible from a GPU in the HIP GPU programming environment.  This memory is accessible by both host and device execution spaces.  Except in rare instances, it should not be used directly, but instead should be used generically as an memory space.  For details, see [the documentation on the `MemorySpace` concept](MemorySpaceConcept).
+`Kokkos::HIPHostPinnedSpace` <sup>promoted from [Experimental](ExperimentalNamespace) since 4.0</sup> is a [`MemorySpace` type](MemorySpaceConcept) representing host-side pinned memory accessible from a GPU in the HIP GPU programming environment.  This memory is accessible by both host and device execution spaces.  Except in rare instances, it should not be used directly, but instead should be used generically as an memory space.  For details, see [the documentation on the `MemorySpace` concept](MemorySpaceConcept).
 
 (HIPManagedSpace)=
 ## `Kokkos::HIPManagedSpace`
 
-`Kokkos::HIPManagedSpace` is a [`MemorySpace` type](MemorySpaceConcept) representing page-migrating memory on a GPU in the HIP GPU programming environment.  Page-migrating memory is accessible from most host execution spaces. Even though available with all combinations of operating system and HIP-supported hardware, it requires both operating system and hardware to support and enable the `xnack` feature. Except in rare instances, it should not be used directly, but instead should be used generically as an memory space.  For details, see [the documentation on the `MemorySpace` concept](MemorySpaceConcept).
+`Kokkos::HIPManagedSpace` <sup>promoted from [Experimental](ExperimentalNamespace) since 4.0</sup>  is a [`MemorySpace` type](MemorySpaceConcept) representing page-migrating memory on a GPU in the HIP GPU programming environment.  Page-migrating memory is accessible from most host execution spaces. Even though available with all combinations of operating system and HIP-supported hardware, it requires both operating system and hardware to support and enable the `xnack` feature. Except in rare instances, it should not be used directly, but instead should be used generically as an memory space.  For details, see [the documentation on the `MemorySpace` concept](MemorySpaceConcept).
 
 (HostSpace)=
 ## `Kokkos::HostSpace`

--- a/docs/source/API/core/memory_spaces.md
+++ b/docs/source/API/core/memory_spaces.md
@@ -18,17 +18,17 @@
 (HIPSpace)=
 ## `Kokkos::HIPSpace`
 
-`Kokkos::HIPSpace` is a [`MemorySpace` type](MemorySpaceConcept) representing device memory on a GPU in the `HIP` GPU programming environment.  Except in rare instances, it should not be used directly, but instead should be used generically as an memory space.  For details, see [the documentation on the `MemorySpace` concept](MemorySpaceConcept).
+`Kokkos::HIPSpace` is a [`MemorySpace` type](MemorySpaceConcept) representing device memory on a GPU in the HIP GPU programming environment.  Except in rare instances, it should not be used directly, but instead should be used generically as an memory space.  For details, see [the documentation on the `MemorySpace` concept](MemorySpaceConcept).
 
 (HIPHostPinnedSpace)=
 ## `Kokkos::HIPHostPinnedSpace`
 
-`Kokkos::HIPHostPinnedSpace` is a [`MemorySpace` type](MemorySpaceConcept) representing host-side pinned memory accessible from a GPU in the `HIP` GPU programming environment.  This memory is accessible by both host and device execution spaces.  Except in rare instances, it should not be used directly, but instead should be used generically as an memory space.  For details, see [the documentation on the `MemorySpace` concept](MemorySpaceConcept).
+`Kokkos::HIPHostPinnedSpace` is a [`MemorySpace` type](MemorySpaceConcept) representing host-side pinned memory accessible from a GPU in the HIP GPU programming environment.  This memory is accessible by both host and device execution spaces.  Except in rare instances, it should not be used directly, but instead should be used generically as an memory space.  For details, see [the documentation on the `MemorySpace` concept](MemorySpaceConcept).
 
 (HIPManagedSpace)=
 ## `Kokkos::HIPManagedSpace`
 
-`Kokkos::HIPManagedSpace` is a [`MemorySpace` type](MemorySpaceConcept) representing page-migratint memory on a GPU in the `HIP` GPU programming environment.  Page-migrating memory is accessible from most host execution spaces. Even though available with all combinations of operting system and `HIP`-supported hardware, it requires both operating system and hardware to support and enable the `xnack` feature. Except in rare instances, it should not be used directly, but instead should be used generically as an memory space.  For details, see [the documentation on the `MemorySpace` concept](MemorySpaceConcept).
+`Kokkos::HIPManagedSpace` is a [`MemorySpace` type](MemorySpaceConcept) representing page-migrating memory on a GPU in the HIP GPU programming environment.  Page-migrating memory is accessible from most host execution spaces. Even though available with all combinations of operating system and HIP-supported hardware, it requires both operating system and hardware to support and enable the `xnack` feature. Except in rare instances, it should not be used directly, but instead should be used generically as an memory space.  For details, see [the documentation on the `MemorySpace` concept](MemorySpaceConcept).
 
 (HostSpace)=
 ## `Kokkos::HostSpace`

--- a/docs/source/API/core/utilities/experimental.md
+++ b/docs/source/API/core/utilities/experimental.md
@@ -1,0 +1,14 @@
+(ExperimentalNamespace)=
+# `Kokkos::Experimental`
+
+Defined in header `<Kokkos_Core.hpp>`
+
+```c++
+namespace Kokkos {
+  namespace Experimental {
+    ...
+  }
+}
+```
+
+Namespace inside main `Kokkos` namespace that contains features that are not yet part of the public API. Anything contained might be subject to any change, removal, or extension without anouncement. No guarantees are given.


### PR DESCRIPTION
It contains only a minimal hint on the `xnack` rabbithole 