### PR TITLE
warn in view that pointer manipulation might end in undefined behavior

### DIFF
--- a/docs/source/API/core/c_style_memory_management/malloc.md
+++ b/docs/source/API/core/c_style_memory_management/malloc.md
@@ -18,6 +18,8 @@ If allocation succeeds, returns a pointer to the lowest (first) byte in the allo
 
 If allocation fails, an exception of type `Kokkos::Experimental::RawMemoryAllocationFailure` is thrown.
 
+WARNING: calling any function that manipulates the behavior of the memory (e.g. `memAdvise`) on memory managed by `Kokkos` results in undefined behavior. You are on your own with this.
+
 ## Parameters
 
 `label`: A user provided string which is used in profiling and debugging tools via the KokkosP Profiling Tools.  

--- a/docs/source/API/core/c_style_memory_management/malloc.md
+++ b/docs/source/API/core/c_style_memory_management/malloc.md
@@ -18,7 +18,7 @@ If allocation succeeds, returns a pointer to the lowest (first) byte in the allo
 
 If allocation fails, an exception of type `Kokkos::Experimental::RawMemoryAllocationFailure` is thrown.
 
-WARNING: calling any function that manipulates the behavior of the memory (e.g. `memAdvise`) on memory managed by `Kokkos` results in undefined behavior. You are on your own with this.
+WARNING: calling any function that manipulates the behavior of the memory (e.g. `memAdvise`) on memory managed by `Kokkos` results in undefined behavior.
 
 ## Parameters
 

--- a/docs/source/API/core/c_style_memory_management/realloc.md
+++ b/docs/source/API/core/c_style_memory_management/realloc.md
@@ -9,6 +9,8 @@ void* kokkos_realloc(void* ptr, size_t new_size);
 
 Reallocates the given area of memory. It must be previously allocated by [`Kokkos::kokkos_malloc()`](malloc) or [`Kokkos::kokkos_realloc()`](realloc) on the same memory space [`MemorySpace`](../memory_spaces) and not yet freed with [`Kokkos::kokkos_free()`](free), otherwise, the results are undefined.
 
+WARNING: calling any function that manipulates the behavior of the memory (e.g. `memAdvise`) on memory managed by `Kokkos` results in undefined behavior. You are on your own with this.
+
 ## Parameters
 
 `ptr`: The pointer to the memory area to be reallocated.  

--- a/docs/source/API/core/c_style_memory_management/realloc.md
+++ b/docs/source/API/core/c_style_memory_management/realloc.md
@@ -9,7 +9,7 @@ void* kokkos_realloc(void* ptr, size_t new_size);
 
 Reallocates the given area of memory. It must be previously allocated by [`Kokkos::kokkos_malloc()`](malloc) or [`Kokkos::kokkos_realloc()`](realloc) on the same memory space [`MemorySpace`](../memory_spaces) and not yet freed with [`Kokkos::kokkos_free()`](free), otherwise, the results are undefined.
 
-WARNING: calling any function that manipulates the behavior of the memory (e.g. `memAdvise`) on memory managed by `Kokkos` results in undefined behavior. You are on your own with this.
+WARNING: calling any function that manipulates the behavior of the memory (e.g. `memAdvise`) on memory managed by `Kokkos` results in undefined behavior.
 
 ## Parameters
 

--- a/docs/source/API/core/view/view.md
+++ b/docs/source/API/core/view/view.md
@@ -212,7 +212,7 @@ Template parameters other than `DataType` are optional, but ordering is enforced
   * ```c++
     constexpr pointer_type data() const
     ```
-    Return the pointer to the underlying data allocation. WARNING: calling any function that manipulates the behavior of the memory (e.g. `memAdvise`) on memory managed by `Kokkos` results in undefined behavior. You are on your own with this.
+    Return the pointer to the underlying data allocation. WARNING: calling any function that manipulates the behavior of the memory (e.g. `memAdvise`) on memory managed by `Kokkos` results in undefined behavior.
   * ```c++
     bool span_is_contiguous() const
     ```

--- a/docs/source/API/core/view/view.md
+++ b/docs/source/API/core/view/view.md
@@ -212,7 +212,7 @@ Template parameters other than `DataType` are optional, but ordering is enforced
   * ```c++
     constexpr pointer_type data() const
     ```
-    Return the pointer to the underlying data allocation. WARNING: calling any function that manipulates the behavior of the memory (e.g. `memAdvise`) on memory managed by `Kokkos` might result in undefined behavior. You are on your own with this.
+    Return the pointer to the underlying data allocation. WARNING: calling any function that manipulates the behavior of the memory (e.g. `memAdvise`) on memory managed by `Kokkos` results in undefined behavior. You are on your own with this.
   * ```c++
     bool span_is_contiguous() const
     ```

--- a/docs/source/API/core/view/view.md
+++ b/docs/source/API/core/view/view.md
@@ -212,7 +212,7 @@ Template parameters other than `DataType` are optional, but ordering is enforced
   * ```c++
     constexpr pointer_type data() const
     ```
-    Return the pointer to the underlying data allocation.
+    Return the pointer to the underlying data allocation. WARNING: calling any function that manipulates the behavior of the memory (e.g. `memAdvise`) on memory managed by `Kokkos` might result in undefined behavior. You are on your own with this.
   * ```c++
     bool span_is_contiguous() const
     ```


### PR DESCRIPTION
This is part of the general discussion of making all user facing memory coarse grained and what happens if the user gets the pointer and changes how the os handles the underlying memory. 

I am not sure about the wording though...maybe it is better to say:
WARNING: calling any function that manipulates the behavior of the memory (e.g. `memAdvise`) on memory managed by `Kokkos` is illegal.