### PR TITLE
#79: update lectures links in sidebar

### DIFF
--- a/docs/source/videolectures.rst
+++ b/docs/source/videolectures.rst
@@ -1,10 +1,154 @@
 Video lectures
 ##############
 
+.. list-table::
+   :widths: 5 80 15
+   :header-rows: 1
+
+   * - Module
+     - Video lectures
+     - Slides
+   * - 1.
+     - `Intro, Build, Parallel dispatch <https://www.youtube.com/watch?v=rUIcWtFU5qM>`_
+     - `Slides <https://github.com/kokkos/kokkos-tutorials/blob/main/LectureSeries/KokkosTutorial_01_Introduction.pdf>`__
+   * - 1.1.
+     - `Introduction <https://www.youtube.com/watch?v=rUIcWtFU5qM&feature=youtu.be&t=698>`_
+     -
+   * - 1.2.
+     - `Concepts for Data Parallelism <https://www.youtube.com/watch?v=rUIcWtFU5qM&feature=youtu.be&t=2481>`_
+     -
+   * - 1.3.
+     - `Data parallel patterns <https://www.youtube.com/watch?v=rUIcWtFU5qM&feature=youtu.be&t=3000>`_
+     -
+   * - 1.4.
+     - `Building Applications with Kokkos <https://www.youtube.com/watch?v=rUIcWtFU5qM&feature=youtu.be&t=4986>`_
+     -
+   * - 2.
+     - `Views and Spaces <https://www.youtube.com/watch?v=O-asHTtO7O4>`_
+     - `Slides <https://github.com/kokkos/kokkos-tutorials/blob/main/LectureSeries/KokkosTutorial_02_ViewsAndSpaces.pdf>`__
+   * - 2.1.
+     - `Views <https://www.youtube.com/watch?v=O-asHTtO7O4&feature=youtu.be&t=1413>`_
+     -
+   * - 2.2.
+     - `Execution and Memory Spaces <https://www.youtube.com/watch?v=O-asHTtO7O4&feature=youtu.be&t=2390>`_
+     -
+   * - 2.3.
+     - `Managing memory access patterns for performance portability <https://www.youtube.com/watch?v=O-asHTtO7O4&feature=youtu.be&t=4336>`_
+     -
+   * - 2.4.
+     - `Advanced Reductions <https://www.youtube.com/watch?v=O-asHTtO7O4&feature=youtu.be&t=5592>`_
+     -
+   * - 3.
+     - `Multidim loops and Data Structures <https://www.youtube.com/watch?v=nGyJS8u-6GY>`_
+     - `Slides <https://github.com/kokkos/kokkos-tutorials/blob/main/LectureSeries/KokkosTutorial_03_MDRangeMoreViews.pdf>`__
+   * - 3.1.
+     - `Tightly Nested Loops with MDRangePolicy <https://www.youtube.com/watch?v=nGyJS8u-6GY&feature=youtu.be&t=1319>`_
+     -
+   * - 3.2.
+     - `Subviews: Taking slices of Views <https://www.youtube.com/watch?v=nGyJS8u-6GY&feature=youtu.be&t=2185>`_
+     -
+   * - 3.3.
+     - `Unmanaged Views: Dealing with external memory <https://www.youtube.com/watch?v=nGyJS8u-6GY&feature=youtu.be&t=3189>`_
+     -
+   * - 3.4.
+     - `Thread safety and atomic operations <https://www.youtube.com/watch?v=nGyJS8u-6GY&feature=youtu.be&t=3901>`_
+     -
+   * - 3.5.
+     - `ScatterView <https://www.youtube.com/watch?v=nGyJS8u-6GY&t=4884s>`_
+     -
+   * - 3.6.
+     - `DualView <https://www.youtube.com/watch?v=nGyJS8u-6GY&feature=youtu.be&t=5465>`_
+     -
+   * - 4.
+     - `Hierarchical Parallelism <https://www.youtube.com/watch?v=s9ecpeWRePs>`_
+     - `Slides <https://github.com/kokkos/kokkos-tutorials/blob/main/LectureSeries/KokkosTutorial_04_HierarchicalParallelism.pdf>`__
+   * - 4.1.
+     - `Hierarchical parallelism <https://www.youtube.com/watch?v=s9ecpeWRePs&feature=youtu.be&t=2036>`__
+     -
+   * - 4.2.
+     - `Scratch memory <https://www.youtube.com/watch?v=s9ecpeWRePs&feature=youtu.be&t=4333>`_
+     -
+   * - 4.3.
+     - `Unique Token <https://www.youtube.com/watch?v=s9ecpeWRePs&feature=youtu.be&t=5615>`_
+     -
+   * - 5.
+     - `SIMD, Streams, Tasking <https://www.youtube.com/watch?v=xEAyOod57-c>`_
+     - `Slides <https://github.com/kokkos/kokkos-tutorials/blob/main/LectureSeries/KokkosTutorial_05_SIMDStreamsTasking.pdf>`__
+   * - 5.1.
+     - `SIMD <https://www.youtube.com/watch?v=xEAyOod57-c&feature=youtu.be&t=1510>`_
+     -
+   * - 5.2.
+     - `Asynchronicity and Streams <https://www.youtube.com/watch?v=xEAyOod57-c&feature=youtu.be&t=2949>`_
+     -
+   * - 5.3.
+     - `Task parallelism <https://www.youtube.com/watch?v=xEAyOod57-c&feature=youtu.be&t=4541>`_
+     -
+   * - 6.
+     - `Fortran/Python interop, MPI, PGAS <https://www.youtube.com/watch?v=1J3JQ3d3cRc&t=1s>`_
+     - `Slides <https://github.com/kokkos/kokkos-tutorials/blob/main/LectureSeries/KokkosTutorial_06_FortranPythonMPIAndPGAS.pdf>`__
+   * - 6.1.
+     - `Fortran InterOp <https://www.youtube.com/watch?v=1J3JQ3d3cRc&feature=youtu.be&t=1298>`_
+     -
+   * - 6.2.
+     - `Python InterOp <https://www.youtube.com/watch?v=1J3JQ3d3cRc&feature=youtu.be&t=2115>`_
+     -
+   * - 6.3.
+     - `MPI - Kokkos Interoperability <https://www.youtube.com/watch?v=1J3JQ3d3cRc&feature=youtu.be&t=2732>`_
+     -
+   * - 6.4.
+     - `Kokkos Remote Spaces: Support for PGAS in Kokkos <https://www.youtube.com/watch?v=1J3JQ3d3cRc&feature=youtu.be&t=5050>`_
+     -
+   * - 7.
+     - `Kokkos Tools <https://www.youtube.com/watch?v=MH6zFYGw0HU>`_
+     - `Slides <https://github.com/kokkos/kokkos-tutorials/blob/main/LectureSeries/KokkosTutorial_07_Tools.pdf>`__
+   * - 7.1.
+     - `Kokkos Tools <https://www.youtube.com/watch?v=MH6zFYGw0HU&feature=youtu.be&t=1275>`__
+     -
+   * - 7.2.
+     - `Vendor and Independent Profiling GUIs <https://www.youtube.com/watch?v=MH6zFYGw0HU&feature=youtu.be&t=2996>`_
+     -
+   * - 7.3.
+     - `Tuning <https://www.youtube.com/watch?v=MH6zFYGw0HU&feature=youtu.be&t=3705>`_
+     -
+   * - 7.4.
+     - `Custom Tools <https://www.youtube.com/watch?v=MH6zFYGw0HU&feature=youtu.be&t=4960>`_
+     -
+   * - 7.5.
+     - `Clang Based Static Analysis <https://www.youtube.com/watch?v=MH6zFYGw0HU&feature=youtu.be&t=5697>`_
+     -
+   * - 8.
+     - `Kokkos Kernels Math Library <https://www.youtube.com/watch?v=_qD4X66MQF8&t=1s>`_
+     - `Slides <https://github.com/kokkos/kokkos-tutorials/blob/main/LectureSeries/KokkosTutorial_08_KokkosKernels.pdf>`__
+   * - 8.1.
+     - `Kokkos Kernels: Library Based Approach for Performance Portable Sparse/Dense linear algebra and Graph Kernels <https://www.youtube.com/watch?v=_qD4X66MQF8&feature=youtu.be&t=1166>`_
+     -
+   * - 8.2.
+     - `BLAS and LAPACK <https://www.youtube.com/watch?v=_qD4X66MQF8&feature=youtu.be&t=2045>`_
+     -
+   * - 8.3.
+     - `Batched BLAS and LAPACK <https://www.youtube.com/watch?v=_qD4X66MQF8&feature=youtu.be&t=2601>`_
+     -
+   * - 8.4.
+     - `Sparse Linear Algebra <https://www.youtube.com/watch?v=_qD4X66MQF8&feature=youtu.be&t=3490>`_
+     -
+   * - 8.5.
+     - `Graph Kernels <https://www.youtube.com/watch?v=_qD4X66MQF8&feature=youtu.be&t=4387>`_
+     -
+   * - 8.6.
+     - `Sparse Solvers <https://www.youtube.com/watch?v=_qD4X66MQF8&feature=youtu.be&t=4963>`_
+     -
+   * - 8.7.
+     - `Sparse Solvers 2 <https://www.youtube.com/watch?v=_qD4X66MQF8&feature=youtu.be&t=5444>`_
+     -
+   * - 8.8.
+     - `Building Applications with Kokkos Kernels <https://www.youtube.com/watch?v=_qD4X66MQF8&feature=youtu.be&t=6237>`_
+     -
+
 .. toctree::
+   :hidden:
    :maxdepth: 1
 
-   1. Intro, Build, Parallel dispatch <https://www.youtube.com/watch?v=rUIcWtFU5qM> 
+   1. Intro, Build, Parallel dispatch <https://www.youtube.com/watch?v=rUIcWtFU5qM>
    2. Views and Spaces <https://www.youtube.com/watch?v=O-asHTtO7O4>
    3. Multidim loops and Data Structures <https://www.youtube.com/watch?v=nGyJS8u-6GY>
    4. Hierarchical Parallelism <https://www.youtube.com/watch?v=s9ecpeWRePs>

--- a/docs/source/videolectures.rst
+++ b/docs/source/videolectures.rst
@@ -1,5 +1,5 @@
-Video lectures
-##############
+Video lectures and slides
+#########################
 
 .. list-table::
    :widths: 5 80 15


### PR DESCRIPTION
### THIS PR:
- created a table with submodules and slides in `videolectures.rst`

Video lectures is now rendered as follows:
![Zrzut ekranu z 2022-08-17 16-54-54](https://user-images.githubusercontent.com/47597569/185173240-f778b761-6f0a-480f-a72b-fadf91d5747a.png)


closes #79 