### PR TITLE
Remove duplicated parallel_scan with result overload

### DIFF
--- a/docs/source/API/core/parallel-dispatch/parallel_scan.md
+++ b/docs/source/API/core/parallel-dispatch/parallel_scan.md
@@ -43,14 +43,6 @@ Kokkos::parallel_scan(const ExecPolicy&  policy,
                       ReturnType&        return_value);
 ```
 
-```c++
-template <class ExecPolicy, class FunctorType, class ReturnType>
-Kokkos::parallel_scan(const std::string& name, 
-                      const ExecPolicy&  policy, 
-                      const FunctorType& functor, 
-                      ReturnType&        return_value);
-```
-
 ### Parameters:
 
   * `name`: A user provided string which is used in profiling and debugging tools via the Kokkos Profiling Hooks. 


### PR DESCRIPTION
Duplicate of https://github.com/kokkos/kokkos-core-wiki/blob/fdbb4eade33363b65e8086e14f98c020aaac6ae3/docs/source/API/core/parallel-dispatch/parallel_scan.md?plain=1#L31-L37