### PR TITLE
#151: Clear out references to obviated volatile-qualified overloads

### DIFF
--- a/docs/source/API/algorithms/std-algorithms/StdMinMaxElement.md
+++ b/docs/source/API/algorithms/std-algorithms/StdMinMaxElement.md
@@ -101,18 +101,8 @@ auto min_element(const std::string& label,                              (8)
      bool operator()(const value_type & a, const value_type & b) const {
 	   return /* true if a is less than b, based on your logic of "less than" */;
      }
-
-     KOKKOS_INLINE_FUNCTION
-     bool operator()(const volatile value_type a, const volatile value_type b) const {
-     return /* true if a is less than b, based on your logic of "less than" */;
-     }
   };
   ```
-  - the volatile overload is needed because the algorithm is
-  currently implemented as a reduction, where the `comp` functor is used
-  as the ``joiner'' to join two values. The current Kokkos implementation
-  of reductions requires any custom joiner to have
-  a volatile overload: see [Custom Reductions](../../../../ProgrammingGuide/Custom-Reductions) for more info on reductions.
 
 ### Return
 
@@ -145,13 +135,6 @@ struct CustomLessThanComparator {
   bool operator()(const ValueType1& a,
                   const ValueType2& b) const {
    // here we use < but one can put any custom logic to return true if a is less than b
-    return a < b;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  bool operator()(const volatile ValueType1& a,
-                  const volatile ValueType1& b) const {
-    // here we use < but one can put any custom logic to return true if a is less than b
     return a < b;
   }
 
@@ -263,13 +246,6 @@ struct CustomLessThanComparator {
   KOKKOS_INLINE_FUNCTION
   bool operator()(const ValueType1& a,
                   const ValueType2& b) const {
-    // here we use < but one can put any custom logic to return true if a is less than b
-    return a < b;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  bool operator()(const volatile ValueType1& a,
-                  const volatile ValueType1& b) const {
     // here we use < but one can put any custom logic to return true if a is less than b
     return a < b;
   }
@@ -387,13 +363,6 @@ struct CustomLessThanComparator {
   KOKKOS_INLINE_FUNCTION
   bool operator()(const ValueType1& a,
                   const ValueType2& b) const {
-    // here we use < but one can put any custom logic to return true if a is less than b
-    return a < b;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  bool operator()(const volatile ValueType1& a,
-                  const volatile ValueType1& b) const {
     // here we use < but one can put any custom logic to return true if a is less than b
     return a < b;
   }

--- a/docs/source/API/algorithms/std-algorithms/StdNumeric.md
+++ b/docs/source/API/algorithms/std-algorithms/StdNumeric.md
@@ -146,12 +146,6 @@ ValueType reduce(const std::string& label, const ExecutionSpace& exespace,      
 	constexpr ValueType operator()(const ValueType& a, const ValueType& b) const {
 	  return /* ... */
 	}
-
-	KOKKOS_FUNCTION
-	constexpr ValueType operator()(const volatile ValueType& a,
-								   const volatile ValueType& b) const {
-	  return /* ... */
-	}
   };
   ```
   - The behavior is non-deterministic if the `joiner` operation
@@ -372,12 +366,6 @@ ValueType transform_reduce(const std::string& label,                            
                                  const ValueType& b) const {
 	  return /* ... */
 	}
-
-	KOKKOS_FUNCTION
-	constexpr ValueType operator()(const volatile ValueType& a,
-								   const volatile ValueType& b) const {
-	  return /* ... */
-	}
   };
   ```
   - The behavior is non-deterministic if the `joiner` operation
@@ -557,20 +545,11 @@ Exclusive means that the i-th input element is not included in the i-th sum.
 	                        const value_type & b) const {
        return /* ... */;
      }
-
-     return_type operator()(const volatile value_type & a,
-	                  	    const volatile value_type & b) const {
-       return /* ... */;
-     }
   };
   ```
   The return type `return_type` must be such that an object of type `OutputIteratorType`
   for (1,2,5,6) or an object of type `value_type` where `value_type` is the
   value type of `view_dest` for (3,4,7,8) can be dereferenced and assigned a value of type `return_type`.
-
-  - the volatile overload is needed for correctness by the current Kokkos
-  implementation of prefix scan operations
-
 
 ### Return
 

--- a/docs/source/API/algorithms/std-algorithms/StdSorting.md
+++ b/docs/source/API/algorithms/std-algorithms/StdSorting.md
@@ -100,19 +100,8 @@ bool is_sorted(const std::string& label, const ExecutionSpace& exespace,    (8)
      bool operator()(const value_type & a, const value_type & b) const {
 	   return /* true if a is less than b, based on your logic of "less than" */;
      }
-
-     KOKKOS_INLINE_FUNCTION
-     bool operator()(const volatile value_type a, const volatile value_type b) const {
-     return /* true if a is less than b, based on your logic of "less than" */;
-     }
   };
   ```
-  - the volatile overload is needed because the algorithm is
-  currently implemented as a reduction, where the `comp` functor is used
-  as the ``joiner'' to join two values. The current Kokkos implementation
-  of reductions requires any custom joiner to have
-  a volatile overload: see [this wiki page](https://github.com/kokkos/kokkos/wiki/Programming-Guide%3A-Custom-Reductions) for more info on reductions.
-
 
 ### Return
 

--- a/docs/source/API/core/builtinreducers/BAnd.md
+++ b/docs/source/API/core/builtinreducers/BAnd.md
@@ -23,9 +23,6 @@ class BAnd{
    void join(value_type& dest, const value_type& src)  const
 
    KOKKOS_INLINE_FUNCTION
-   void join(volatile value_type& dest, const volatile value_type& src) const;
-
-   KOKKOS_INLINE_FUNCTION
    void init( value_type& val)  const;
 
    KOKKOS_INLINE_FUNCTION
@@ -66,11 +63,6 @@ class BAnd{
 
  * ```c++
    void join(value_type& dest, const value_type& src)  const;
-   ```
-   Store bitwise `and` of `src` and `dest` into `dest`:  `dest = src & dest;`. 
-
- * ```c++
-   void join(volatile value_type& dest, const volatile value_type& src) const;
    ```
    Store bitwise `and` of `src` and `dest` into `dest`:  `dest = src & dest;`. 
 

--- a/docs/source/API/core/builtinreducers/BOr.md
+++ b/docs/source/API/core/builtinreducers/BOr.md
@@ -23,9 +23,6 @@ class BOr{
    void join(value_type& dest, const value_type& src)  const
 
    KOKKOS_INLINE_FUNCTION
-   void join(volatile value_type& dest, const volatile value_type& src) const;
-
-   KOKKOS_INLINE_FUNCTION
    void init( value_type& val)  const;
 
    KOKKOS_INLINE_FUNCTION
@@ -66,11 +63,6 @@ class BOr{
 
  * ```c++
    void join(value_type& dest, const value_type& src)  const;
-   ```
-   Store logical `or` of `src` and `dest` into `dest`:  `dest = src | dest;`. 
-
- * ```c++
-   void join(volatile value_type& dest, const volatile value_type& src) const;
    ```
    Store logical `or` of `src` and `dest` into `dest`:  `dest = src | dest;`. 
 

--- a/docs/source/API/core/builtinreducers/LAnd.md
+++ b/docs/source/API/core/builtinreducers/LAnd.md
@@ -23,9 +23,6 @@ class LAnd{
    void join(value_type& dest, const value_type& src)  const
 
    KOKKOS_INLINE_FUNCTION
-   void join(volatile value_type& dest, const volatile value_type& src) const;
-
-   KOKKOS_INLINE_FUNCTION
    void init( value_type& val)  const;
 
    KOKKOS_INLINE_FUNCTION
@@ -66,11 +63,6 @@ class LAnd{
 
  * ```c++
    void join(value_type& dest, const value_type& src)  const;
-   ```
-   Store logical `and` of `src` and `dest` into `dest`:  `dest = src && dest;`. 
-
- * ```c++
-   void join(volatile value_type& dest, const volatile value_type& src) const;
    ```
    Store logical `and` of `src` and `dest` into `dest`:  `dest = src && dest;`. 
 

--- a/docs/source/API/core/builtinreducers/LOr.md
+++ b/docs/source/API/core/builtinreducers/LOr.md
@@ -23,9 +23,6 @@ class LOr{
    void join(value_type& dest, const value_type& src)  const
 
    KOKKOS_INLINE_FUNCTION
-   void join(volatile value_type& dest, const volatile value_type& src) const;
-
-   KOKKOS_INLINE_FUNCTION
    void init( value_type& val)  const;
 
    KOKKOS_INLINE_FUNCTION
@@ -66,11 +63,6 @@ class LOr{
 
  * ```c++
    void join(value_type& dest, const value_type& src)  const;
-   ```
-   Store logical `or` of `src` and `dest` into `dest`:  `dest = src || dest;`. 
-
- * ```c++
-   void join(volatile value_type& dest, const volatile value_type& src) const;
    ```
    Store logical `or` of `src` and `dest` into `dest`:  `dest = src || dest;`. 
 

--- a/docs/source/API/core/builtinreducers/Max.md
+++ b/docs/source/API/core/builtinreducers/Max.md
@@ -23,9 +23,6 @@ class Max{
    void join(value_type& dest, const value_type& src)  const
 
    KOKKOS_INLINE_FUNCTION
-   void join(volatile value_type& dest, const volatile value_type& src) const;
-
-   KOKKOS_INLINE_FUNCTION
    void init( value_type& val)  const;
 
    KOKKOS_INLINE_FUNCTION
@@ -66,11 +63,6 @@ class Max{
 
  * ```c++
    void join(value_type& dest, const value_type& src)  const;
-   ```
-   Store maximum of `src` and `dest` into `dest`:  `dest = (src > dest) ? src : dest;`. 
-
- * ```c++
-   void join(volatile value_type& dest, const volatile value_type& src) const;
    ```
    Store maximum of `src` and `dest` into `dest`:  `dest = (src > dest) ? src : dest;`. 
 

--- a/docs/source/API/core/builtinreducers/MaxLoc.md
+++ b/docs/source/API/core/builtinreducers/MaxLoc.md
@@ -24,9 +24,6 @@ class MaxLoc{
    void join(value_type& dest, const value_type& src)  const
 
    KOKKOS_INLINE_FUNCTION
-   void join(volatile value_type& dest, const volatile value_type& src) const;
-
-   KOKKOS_INLINE_FUNCTION
    void init( value_type& val)  const;
 
    KOKKOS_INLINE_FUNCTION
@@ -67,11 +64,6 @@ class MaxLoc{
 
  * ```c++
    void join(value_type& dest, const value_type& src)  const;
-   ```
-   Store maximum with index of `src` and `dest` into `dest`:  `dest = (src.val > dest.val) ? src : dest;`. 
-
- * ```c++
-   void join(volatile value_type& dest, const volatile value_type& src) const;
    ```
    Store maximum with index of `src` and `dest` into `dest`:  `dest = (src.val > dest.val) ? src : dest;`. 
 

--- a/docs/source/API/core/builtinreducers/Min.md
+++ b/docs/source/API/core/builtinreducers/Min.md
@@ -23,9 +23,6 @@ class Min{
    void join(value_type& dest, const value_type& src)  const
 
    KOKKOS_INLINE_FUNCTION
-   void join(volatile value_type& dest, const volatile value_type& src) const;
-
-   KOKKOS_INLINE_FUNCTION
    void init( value_type& val)  const;
 
    KOKKOS_INLINE_FUNCTION
@@ -66,11 +63,6 @@ class Min{
 
  * ```c++
    void join(value_type& dest, const value_type& src)  const;
-   ```
-   Store minimum of `src` and `dest` into `dest`:  `dest = (src < dest) ? src : dest;`. 
-
- * ```c++
-   void join(volatile value_type& dest, const volatile value_type& src) const;
    ```
    Store minimum of `src` and `dest` into `dest`:  `dest = (src < dest) ? src : dest;`. 
 

--- a/docs/source/API/core/builtinreducers/MinLoc.md
+++ b/docs/source/API/core/builtinreducers/MinLoc.md
@@ -24,9 +24,6 @@ class MinLoc{
    void join(value_type& dest, const value_type& src)  const
 
    KOKKOS_INLINE_FUNCTION
-   void join(volatile value_type& dest, const volatile value_type& src) const;
-
-   KOKKOS_INLINE_FUNCTION
    void init( value_type& val)  const;
 
    KOKKOS_INLINE_FUNCTION
@@ -67,11 +64,6 @@ class MinLoc{
 
  * ```c++
    void join(value_type& dest, const value_type& src)  const;
-   ```
-   Store minimum with index of `src` and `dest` into `dest`:  `dest = (src.val < dest.val) ? src : dest;`. 
-
- * ```c++
-   void join(volatile value_type& dest, const volatile value_type& src) const;
    ```
    Store minimum with index of `src` and `dest` into `dest`:  `dest = (src.val < dest.val) ? src : dest;`. 
 

--- a/docs/source/API/core/builtinreducers/MinMax.md
+++ b/docs/source/API/core/builtinreducers/MinMax.md
@@ -23,9 +23,6 @@ class MinMax{
    void join(value_type& dest, const value_type& src)  const
 
    KOKKOS_INLINE_FUNCTION
-   void join(volatile value_type& dest, const volatile value_type& src) const;
-
-   KOKKOS_INLINE_FUNCTION
    void init( value_type& val)  const;
 
    KOKKOS_INLINE_FUNCTION
@@ -69,12 +66,6 @@ class MinMax{
    ```
    - Store minimum of `src` and `dest` into `dest`:  `dest.min_val = (src.min_val < dest.min_val) ? src.min_val : dest.min_val;`.
    - Store maximum of `src` and `dest` into `dest`:  `dest.max_val = (src.max_val < dest.max_val) ? src.max_val : dest.max_val;`.
- * ```c++
-   void join(volatile value_type& dest, const volatile value_type& src) const;
-   ```
-    - Store minimum of `src` and `dest` into `dest`:  `dest.min_val = (src.min_val < dest.min_val) ? src.min_val : dest.min_val;`.
-   - Store maximum of `src` and `dest` into `dest`:  `dest.max_val = (src.max_val < dest.max_val) ? src.max_val : dest.max_val;`. 
-
  * ```c++
    void init( value_type& val)  const;
    ```

--- a/docs/source/API/core/builtinreducers/MinMaxLoc.md
+++ b/docs/source/API/core/builtinreducers/MinMaxLoc.md
@@ -24,9 +24,6 @@ class MinMaxLoc{
    void join(value_type& dest, const value_type& src)  const
 
    KOKKOS_INLINE_FUNCTION
-   void join(volatile value_type& dest, const volatile value_type& src) const;
-
-   KOKKOS_INLINE_FUNCTION
    void init( value_type& val)  const;
 
    KOKKOS_INLINE_FUNCTION
@@ -70,11 +67,6 @@ class MinMaxLoc{
    ```
    - Store minimum with location of `src` and `dest` into `dest`.
    - Store maximum with location of `src` and `dest` into `dest`.
- * ```c++
-   void join(volatile value_type& dest, const volatile value_type& src) const;
-   ```
-    - Store minimum with location of `src` and `dest` into `dest`.
-   - Store maximum with location of `src` and `dest` into `dest`. 
 
  * ```c++
    void init( value_type& val)  const;

--- a/docs/source/API/core/builtinreducers/MinMaxLocScalar.md
+++ b/docs/source/API/core/builtinreducers/MinMaxLocScalar.md
@@ -26,7 +26,6 @@ struct MinMaxLocScalar{
   Index max_loc;
 
   void operator = (const MinMaxLocScalar& rhs);
-  void operator = (const volatile MinMaxLocScalar& rhs);
 };
 ```
 
@@ -42,7 +41,4 @@ struct MinMaxLocScalar{
 ### Assignment operators
 
  * `void operator = (const MinMaxLocScalar& rhs);` 
-      assign `min_val`, `max_val`, `min_loc` and `max_loc` from `rhs`;
-
- * `void operator = (const volatile MinMaxLocScalar& rhs);` 
       assign `min_val`, `max_val`, `min_loc` and `max_loc` from `rhs`;

--- a/docs/source/API/core/builtinreducers/MinMaxScalar.md
+++ b/docs/source/API/core/builtinreducers/MinMaxScalar.md
@@ -21,7 +21,6 @@ struct MinMaxScalar{
   Scalar max_val;
 
   void operator = (const MinMaxScalar& rhs);
-  void operator = (const volatile MinMaxScalar& rhs);
 };
 ```
 
@@ -35,7 +34,4 @@ struct MinMaxScalar{
 ### Assignment operators
 
  * `void operator = (const MinMaxScalar& rhs);` 
-      assign `min_val` and `max_val` from `rhs`;
-
- * `void operator = (const volatile MinMaxScalar& rhs);` 
       assign `min_val` and `max_val` from `rhs`;

--- a/docs/source/API/core/builtinreducers/Prod.md
+++ b/docs/source/API/core/builtinreducers/Prod.md
@@ -23,9 +23,6 @@ class Prod{
    void join(value_type& dest, const value_type& src)  const
 
    KOKKOS_INLINE_FUNCTION
-   void join(volatile value_type& dest, const volatile value_type& src) const;
-
-   KOKKOS_INLINE_FUNCTION
    void init( value_type& val)  const;
 
    KOKKOS_INLINE_FUNCTION
@@ -68,11 +65,6 @@ class Prod{
    void join(value_type& dest, const value_type& src)  const;
    ```
    Multiply `src` and `dest` and store in `dest`:  `dest*=src;`. 
-
- * ```c++
-   void join(volatile value_type& dest, const volatile value_type& src) const;
-   ```
-   Multiply `src` and `dest` and store in `dest`: `dest*=src;`. 
 
  * ```c++
    void init( value_type& val)  const;

--- a/docs/source/API/core/builtinreducers/ReducerConcept.md
+++ b/docs/source/API/core/builtinreducers/ReducerConcept.md
@@ -23,9 +23,6 @@ class Reducer {
    void join(value_type& dest, const value_type& src)  const
 
    KOKKOS_INLINE_FUNCTION
-   void join(volatile value_type& dest, const volatile value_type& src) const;
-
-   KOKKOS_INLINE_FUNCTION
    void init( value_type& val)  const;
 
    KOKKOS_INLINE_FUNCTION
@@ -68,11 +65,6 @@ class Reducer {
 
  * ```c++
    void join(value_type& dest, const value_type& src)  const;
-   ```
-   Combine `src` into `dest`. For example, `Add` performs `dest+=src;`. 
-
- * ```c++
-   void join(volatile value_type& dest, const volatile value_type& src) const;
    ```
    Combine `src` into `dest`. For example, `Add` performs `dest+=src;`. 
 

--- a/docs/source/API/core/builtinreducers/Sum.md
+++ b/docs/source/API/core/builtinreducers/Sum.md
@@ -23,9 +23,6 @@ class Sum{
    void join(value_type& dest, const value_type& src)  const
 
    KOKKOS_INLINE_FUNCTION
-   void join(volatile value_type& dest, const volatile value_type& src) const;
-
-   KOKKOS_INLINE_FUNCTION
    void init( value_type& val)  const;
 
    KOKKOS_INLINE_FUNCTION
@@ -68,11 +65,6 @@ class Sum{
    void join(value_type& dest, const value_type& src)  const;
    ```
    Add `src` into `dest`:  `dest+=src;`. 
-
- * ```c++
-   void join(volatile value_type& dest, const volatile value_type& src) const;
-   ```
-   Add `src` into `dest`: `dest+=src;`. 
 
  * ```c++
    void init( value_type& val)  const;

--- a/docs/source/API/core/builtinreducers/ValLocScalar.md
+++ b/docs/source/API/core/builtinreducers/ValLocScalar.md
@@ -21,7 +21,6 @@ struct ValLocScalar{
   Index loc;
 
   void operator = (const ValLocScalar& rhs);
-  void operator = (const volatile ValLocScalar& rhs);
 };
 ```
 
@@ -35,7 +34,4 @@ struct ValLocScalar{
 ### Assignment operators
 
  * `void operator = (const ValLocScalar& rhs);` 
-      assign `val` and `loc` from `rhs`;
-
- * `void operator = (const volatile ValLocScalar& rhs);` 
       assign `val` and `loc` from `rhs`;

--- a/docs/source/API/core/stl-compat/pair.md
+++ b/docs/source/API/core/stl-compat/pair.md
@@ -29,15 +29,9 @@ struct pair {
   
     template <class U, class V>
     KOKKOS_FORCEINLINE_FUNCTION constexpr pair(const pair<U, V>& p);
-  
-    template <class U, class V>
-    KOKKOS_FORCEINLINE_FUNCTION constexpr pair(const volatile pair<U, V>& p);
-  
+
     template <class U, class V>
     KOKKOS_FORCEINLINE_FUNCTION pair<T1, T2>& operator=(const pair<U, V>& p);
-  
-    template <class U, class V>
-    KOKKOS_FORCEINLINE_FUNCTION void operator=(const volatile pair<U, V>& p) volatile;
   
     template <class U, class V>
     pair(const std::pair<U, V>& p);
@@ -81,14 +75,6 @@ struct pair {
       
   Conversion from `std::pair`. Assigns each element of the pair to its corresponding element in the `p`
 
-  * 
-  ```c++
-  template <class U, class V>
-  KOKKOS_FORCEINLINE_FUNCTION constexpr pair(const volatile pair<U, V>& p);
-  ```
-     
-  Copy constructor from a volatile pair. Copies each element from `p` 
-
 ### Assignment and conversion
 
   * 
@@ -97,16 +83,8 @@ struct pair {
   KOKKOS_FORCEINLINE_FUNCTION pair<T1, T2>& operator=(const pair<U, V>& p);
   ```
 
-Sets `first` to `p.first` and `second` to `p.second` 
- 
-  * 
-  ```c++ 
-  template <class U, class V>
-  KOKKOS_FORCEINLINE_FUNCTION void operator=(const volatile pair<U, V>& p) volatile;
-  ```
-  
   Sets `first` to `p.first` and `second` to `p.second` 
-
+ 
   ### Functions
 
   * 

--- a/docs/source/API/core/stl-compat/pair.md
+++ b/docs/source/API/core/stl-compat/pair.md
@@ -84,7 +84,6 @@ struct pair {
   ```
 
   Sets `first` to `p.first` and `second` to `p.second` 
- 
   ### Functions
 
   * 

--- a/docs/source/API/core/utilities/complex.md
+++ b/docs/source/API/core/utilities/complex.md
@@ -25,7 +25,6 @@ class complex {
 
    KOKKOS_INLINE_FUNCTION complex();
    KOKKOS_INLINE_FUNCTION complex(const complex& src);
-   KOKKOS_INLINE_FUNCTION complex(const volatile complex& src);
 
    template<class T>
    KOKKOS_INLINE_FUNCTION complex(const T& re);
@@ -38,17 +37,9 @@ class complex {
 
    template<class T>
    KOKKOS_INLINE_FUNCTION complex<Scalar>& operator= (const complex<T>& src);
-   template<class T>
-   KOKKOS_INLINE_FUNCTION complex<Scalar>& operator= (const volatile complex<T>& src);
-   template<class T>
-   KOKKOS_INLINE_FUNCTION complex<Scalar>& operator= (const complex<T>& src) volatile;
-   template<class T>
-   KOKKOS_INLINE_FUNCTION complex<Scalar>& operator= (const volatile complex<T>& src) volatile;
 
    template<class T>
    KOKKOS_INLINE_FUNCTION complex<Scalar>& operator= (const T& re);
-   template<class T>
-   KOKKOS_INLINE_FUNCTION complex<Scalar>& operator= (const T& re) volatile;
 
    template<class T>
    KOKKOS_INLINE_FUNCTION complex<Scalar>& operator= (const std::complex<T>& src);
@@ -60,23 +51,15 @@ class complex {
    KOKKOS_INLINE_FUNCTION RealType& real();
    KOKKOS_INLINE_FUNCTION const RealType imag() const;
    KOKKOS_INLINE_FUNCTION const RealType real() const;
-   KOKKOS_INLINE_FUNCTION volatile RealType& imag() volatile;
-   KOKKOS_INLINE_FUNCTION volatile RealType& real() volatile;
-   KOKKOS_INLINE_FUNCTION const RealType imag() const volatile;
-   KOKKOS_INLINE_FUNCTION const RealType real() const volatile;
    KOKKOS_INLINE_FUNCTION void imag(RealType v);
    KOKKOS_INLINE_FUNCTION void real(RealType v);
 
    template<class T>
    KOKKOS_INLINE_FUNCTION complex& operator += (const complex<T>& src);
    template<class T>
-   KOKKOS_INLINE_FUNCTION complex& operator += (const volatile complex<T>& src) volatile;
-   template<class T>
    complex& operator += (const std::complex<T>& src);
    template<class T>
    KOKKOS_INLINE_FUNCTION complex& operator += (const T& real);
-   template<class T>
-   KOKKOS_INLINE_FUNCTION complex& operator += (const volatile T& real) real;
 
    template<class T>
    KOKKOS_INLINE_FUNCTION complex& operator -= (const complex<T>& src);
@@ -88,13 +71,9 @@ class complex {
    template<class T>
    KOKKOS_INLINE_FUNCTION complex& operator *= (const complex<T>& src);
    template<class T>
-   KOKKOS_INLINE_FUNCTION complex& operator *= (const volatile complex<T>& src) volatile;
-   template<class T>
    complex& operator *= (const std::complex<T>& src);
    template<class T>
    KOKKOS_INLINE_FUNCTION complex& operator *= (const T& real);
-   template<class T>
-   KOKKOS_INLINE_FUNCTION complex& operator *= (const volatile T& real) real;
 
    template<class T>
    KOKKOS_INLINE_FUNCTION complex& operator /= (const complex<T>& src);
@@ -139,11 +118,6 @@ class complex {
    
 
  * ```c++
-      KOKKOS_INLINE_FUNCTION complex(const volatile complex& src);
-   ```
-   Copy constructor. Sets `re = src.real()` and `im = src.imag()`.
-
- * ```c++
       template<class T>
       KOKKOS_INLINE_FUNCTION complex(const T& real);
    ```
@@ -171,29 +145,7 @@ class complex {
 
  * ```c++
       template<class T>
-      KOKKOS_INLINE_FUNCTION complex<Scalar>& operator= (const volatile complex<T>& src);
-   ```
-   Sets `re = src.real()` and `im = src.imag()`.
- * ```c++
-      template<class T>
-      KOKKOS_INLINE_FUNCTION complex<Scalar>& operator= (const complex<T>& src) volatile;
-   ```
-   Sets `re = src.real()` and `im = src.imag()`.
- * ```c++
-      template<class T>
-      KOKKOS_INLINE_FUNCTION complex<Scalar>& operator= (const volatile complex<T>& src) volatile;
-   ```
-   Sets `re = src.real()` and `im = src.imag()`.
-
- * ```c++
-      template<class T>
       KOKKOS_INLINE_FUNCTION complex<Scalar>& operator= (const T& re);
-   ```
-   Sets `re = src.real()` and `im = value_type()`.
-
- * ```c++
-      template<class T>
-      KOKKOS_INLINE_FUNCTION complex<Scalar>& operator= (const T& re) volatile;
    ```
    Sets `re = src.real()` and `im = value_type()`.
 
@@ -228,22 +180,6 @@ class complex {
    ```
    Return `re`.
  * ```c++
-      KOKKOS_INLINE_FUNCTION volatile RealType& imag() volatile;
-   ```
-   Return `im`.
- * ```c++
-      KOKKOS_INLINE_FUNCTION volatile RealType& real() volatile;
-   ```
-   Return `re`.
- * ```c++
-      KOKKOS_INLINE_FUNCTION const RealType imag() const volatile;
-   ```
-   Return `im`.
- * ```c++
-      KOKKOS_INLINE_FUNCTION const RealType real() const volatile;
-   ```
-   Return `re`.
- * ```c++
       KOKKOS_INLINE_FUNCTION void imag(RealType v);
    ```
    Sets `im = v`.
@@ -260,22 +196,12 @@ class complex {
 
  * ```c++
       template<class T>
-      KOKKOS_INLINE_FUNCTION complex& operator += (const volatile complex<T>& src) volatile;
-   ```
-   Executes `re += src.real(); im += src.imag(); return *this;`
- * ```c++
-      template<class T>
       complex& operator += (const std::complex<T>& src);
    ```
    Executes `re += src.real(); im += src.imag(); return *this;`
  * ```c++
       template<class T>
       KOKKOS_INLINE_FUNCTION complex& operator += (const T& real);
-   ```
-   Executes `re += real; return *this;`
- * ```c++
-      template<class T>
-      KOKKOS_INLINE_FUNCTION complex& operator += (const volatile T& real) real;
    ```
    Executes `re += real; return *this;`
  
@@ -302,22 +228,12 @@ class complex {
    Multiplies the current complex number with the complex number src.
  * ```c++
       template<class T>
-      KOKKOS_INLINE_FUNCTION complex& operator *= (const volatile complex<T>& src) volatile;
-   ```
-   Multiplies the current complex number with the complex number `src`.
- * ```c++
-      template<class T>
       complex& operator *= (const std::complex<T>& src);
    ```
    Multiplies the current complex number with the complex number `src`.
  * ```c++
       template<class T>
       KOKKOS_INLINE_FUNCTION complex& operator *= (const T& real);
-   ```
-   Executes `re *= real; im *= real; return *this;`
- * ```c++
-      template<class T>
-      KOKKOS_INLINE_FUNCTION complex& operator *= (const volatile T& real) real;
    ```
    Executes `re *= real; im *= real; return *this;`
  * ```c++

--- a/docs/source/ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.md
+++ b/docs/source/ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.md
@@ -33,12 +33,6 @@ namespace sample {  // namespace helps with name resolution in reduction identit
           the_array[i]+=src.the_array[i];
        }
        return *this;
-     } 
-     KOKKOS_INLINE_FUNCTION   // volatile add operator 
-     void operator += (const volatile array_type& src) volatile {
-       for ( int i = 0; i < N; i++ ) {
-         the_array[i]+=src.the_array[i];
-       }
      }
    };
    typedef array_type<int,4> ValueType;  // used to simplify code below

--- a/docs/source/ProgrammingGuide/Custom-Reductions-Custom-Reducers.md
+++ b/docs/source/ProgrammingGuide/Custom-Reductions-Custom-Reducers.md
@@ -56,7 +56,7 @@ struct array_type {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator+=(const volatile array_type& src) volatile {
+  void operator+=(const array_type& src) {
     for (int i = 0; i < N; i++) {
       myArray[i] += src.myArray[i];
     }
@@ -84,7 +84,7 @@ struct SumMyArray {
   void join(value_type& dest, const value_type& src) const { dest += src; }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
+  void join(value_type& dest, const value_type& src) const {
     dest += src;
   }
 

--- a/docs/source/ProgrammingGuide/ParallelDispatch.md
+++ b/docs/source/ProgrammingGuide/ParallelDispatch.md
@@ -119,11 +119,10 @@ public:
 
   // "Join" intermediate results from different threads.
   // This should normally implement the same reduction
-  // operation as operator() above. Note that both input
-  // arguments MUST be declared volatile.
+  // operation as operator() above.
   KOKKOS_INLINE_FUNCTION void
-  join (volatile value_type& dst,
-        const volatile value_type& src) const
+  join (value_type& dst,
+        const value_type& src) const
   { // max-plus semiring equivalent of "plus"
     if (dst < src) {
       dst = src;
@@ -195,8 +194,8 @@ struct ColumnSums {
   // value_type here is already a "reference" type,
   // so we don't pass it in by reference here.
   KOKKOS_INLINE_FUNCTION void
-  join (volatile value_type dst,
-        const volatile value_type src) const {
+  join (value_type dst,
+        const value_type src) const {
     for (size_type j = 0; j < value_count; ++j) {
       dst[j] += src[j];
     }

--- a/docs/source/usecases/MPI-Halo-Exchange.md
+++ b/docs/source/usecases/MPI-Halo-Exchange.md
@@ -97,7 +97,7 @@ public:
   KOKKOS_INLINE_FUNCTION void init(int& update) const {
     update = 0;
   }
-  KOKKOS_INLINE_FUNCTION void join(volatile int& update, volatile const int& input) const {
+  KOKKOS_INLINE_FUNCTION void join(int& update, const int& input) const {
     update += input;
   }
 private:


### PR DESCRIPTION
From 3.7 onwards, these are no longer necessary, and they are being deleted in the code base.