### PR TITLE
Fixup subview doc `decltype(Kokkos::ALL)`

### DIFF
--- a/docs/source/API/core/view/Subview_type.md
+++ b/docs/source/API/core/view/Subview_type.md
@@ -30,7 +30,8 @@ struct subViewHolder {
 Kokkos::Subview<view_type,
                 std::pair<int,int>,
                 int,
-                Kokkos::ALL,int> s;
+                decltype(Kokkos::ALL),
+                int> s;
 } subViewHolder;
 
 subViewHolder.s  = Kokkos::subview(a,


### PR DESCRIPTION
`Kokkos::Impl::ALL_t` is private so must us `decltype`