### PR TITLE
#193: Remove type word before type definition in cppkokkos

### DIFF
--- a/docs/source/_ext/cppkokkos.py
+++ b/docs/source/_ext/cppkokkos.py
@@ -7164,10 +7164,6 @@ class CPPKokkosTypeObject(CPPKokkosObject):
 class CPPKokkosDeprecatedTypeObject(CPPKokkosObject):
     object_type = 'deprecated-type'
 
-class CPPKokkosDeprecatedTypeObject(CPPKokkosObject):
-    object_type = 'deprecated-type'
-
-
 class CPPKokkosConceptObject(CPPKokkosObject):
     object_type = 'concept'
 

--- a/docs/source/_ext/cppkokkos.py
+++ b/docs/source/_ext/cppkokkos.py
@@ -7080,7 +7080,6 @@ class CPPKokkosObject(ObjectDescription[ASTDeclaration]):
                     deprecated_version = ''
             except ValueError as e:
                 sig = sig
-
         # @@@@@!
 
         parser = DefinitionParser(sig, location=signode, config=self.env.config)
@@ -7162,6 +7161,10 @@ class CPPKokkosTypeObject(CPPKokkosObject):
 
 class CPPKokkosDeprecatedTypeObject(CPPKokkosObject):
     object_type = 'deprecated-type'
+
+class CPPKokkosDeprecatedTypeObject(CPPKokkosObject):
+    object_type = 'deprecated-type'
+
 
 class CPPKokkosConceptObject(CPPKokkosObject):
     object_type = 'concept'

--- a/docs/source/_ext/cppkokkos.py
+++ b/docs/source/_ext/cppkokkos.py
@@ -2912,6 +2912,8 @@ class ASTType(ASTBase):
             if self.deprecated_version is None:
                 return '[DEPRECATED]'
             return f'[DEPRECATED since {self.deprecated_version}]'
+        elif self.declSpecs.outer == 'type':
+            return ''
         else:
             return 'type'
 


### PR DESCRIPTION
## MUST BE MERGED AFTER #190 and #192 

### THIS PR:
- removed word `type` before type definition in `cppkokkos` extension

#### Below an input:
```rst
``Kokkos::TestView``
====================

.. role:: cppkokkos(code)
   :language: cppkokkos

Header File: ``Kokkos_Core.hpp``

Class Interface
---------------

.. cppkokkos:class:: template <class DataType, class... Traits> TestView

  A potentially reference counted multi dimensional array with compile time layouts and memory space.
  Its semantics are similar to that of :cppkokkos:`std::shared_ptr`.

  .. rubric:: Public Member Variables

  .. cppkokkos:member:: static constexpr unsigned rank

    the rank of the view (i.e. the dimensionality).

  .. cppkokkos:type:: const_data_type

    The const version of ``DataType``, same as ``data_type`` if that is already const.

  .. cppkokkos:type:: uniform_runtime_type

    :cppkokkos:`uniform_type` but without compile time extents

  .. cppkokkos:deprecated-type:: 3.6.01 some_deprecated_data_type

    The const version of some_deprecated_data_type.

  .. cppkokkos:deprecated-type:: other_deprecated_data_type

    The const version of other_deprecated_data_type.

  .. cppkokkos:deprecated-type:: 3.7.0 some_deprecated_data_type_1

    The const version of some_deprecated_data_type_1.

  .. cppkokkos:function:: View( const ScratchSpace& space, const IntType& ... indices)

    *Requires:* :cppkokkos:`sizeof(IntType...)==rank_dynamic()` *and*  :cppkokkos:`array_layout::is_regular == true`.

    A constructor which acquires memory from a Scratch Memory handle.

    :param space: a scratch memory handle. Typically returned from :cppkokkos:`team_handles` in :cppkokkos:`TeamPolicy` kernels.
    :param indices: the runtime dimensions of the view.
```

#### Below the output:
![Zrzut ekranu z 2022-10-20 16-43-11](https://user-images.githubusercontent.com/47597569/196980744-9b85a8b1-fe9b-4e39-8a00-def2fb7a9cc0.png)
![Zrzut ekranu z 2022-10-20 16-43-18](https://user-images.githubusercontent.com/47597569/196980756-8abf2214-b87c-4c5b-9585-625336f38a3e.png)

closes #193 