### PR TITLE
#120: API containers Offset-View transition

### DIFF
--- a/docs/source/API/containers/Offset-View.rst
+++ b/docs/source/API/containers/Offset-View.rst
@@ -68,7 +68,7 @@ Note that
 
    OffsetView::end(const size_t i)
 
-returns a value that is not a legal index:  It is exactly one more than the maximum allowable index for the given dimenion i.
+returns a value that is not a legal index:  It is exactly one more than the maximum allowable index for the given dimension i.
 
 Subviews are supported, and the result of taking a subview of an OffsetView is another OffsetView. If ALL() is passed to the subview function, then the offsets for that rank are preserved, otherwise they are dropped.
 

--- a/docs/source/API/containers/Offset-View.rst
+++ b/docs/source/API/containers/Offset-View.rst
@@ -1,36 +1,39 @@
 ``OffsetView``
 ==============
 
+An ``OffsetView`` can be used when the indices of an array begin at something other than zero.
+
 .. role:: cppkokkos(code)
-	:language: cppkokkos
+	  :language: cppkokkos
 
-The OffsetView is in the Experimental namespace.
+.. warning::
 
-Sometimes, it is advantageous to have the indices of an array begin at something other than zero. In this case, an OffsetView may be used.
+   The OffsetView is in the Experimental namespace.
+
 
 Construction
 ------------
 
-An OffsetView must have a label, and at least one dimension. Only runtime extents are supported, but otherwise the semantics of an OffsetView are similar to those of a View.  
+An OffsetView must have a label, and at least one dimension. Only runtime extents are supported, but otherwise the semantics of an OffsetView are similar to those of a View.
 
 .. code-block:: cpp
 
-   const size_t min0 = ...; 
-   const size_t max0 = ...; 
-   const size_t min1 = ...; 
-   const size_t max1 = ...; 
-   const size_t min2 = ...; 
-   const size_t max2 = ...; 
+   const size_t min0 = ...;
+   const size_t max0 = ...;
+   const size_t min1 = ...;
+   const size_t max1 = ...;
+   const size_t min2 = ...;
+   const size_t max2 = ...;
 
    OffsetView<int***> a("someLabel", {min0, max0}, {min1, max1},{min2, max2});
 
-Construction from a layout is also allowed.  
+Construction from a layout is also allowed.
 
 .. code-block:: cpp
-    
+
     OffsetView<int***> a("someLabel", LayoutLeft, {min0, min1, min2});
 
-An OffsetView may also be created from a View that has the same underlying type. Since the View already has extents, the beginning indices must be passed to the constructor.  
+An OffsetView may also be created from a View that has the same underlying type. Since the View already has extents, the beginning indices must be passed to the constructor.
 
 .. code-block:: cpp
 
@@ -38,12 +41,12 @@ An OffsetView may also be created from a View that has the same underlying type.
    Array<int64_t, 2> begins = {-10, -20};
    OffsetView<double**> ov(b, begins);
 
-The OffsetView ov has the same extents as b and must be indexed from [-10,-1] and [-20,-11].  
+The OffsetView ov has the same extents as b and must be indexed from [-10,-1] and [-20,-11].
 
 A std::initializer_list may also be used instead of an Array.
 
 .. code-block:: cpp
-    
+
     OffsetView<double**> ov(b, {-10, -20});
 
 Interface
@@ -59,9 +62,11 @@ The beginning indices may be obtained as an array. The begin and end of iteratio
    const int64_t begin0 = ov.begin(0);
    const int64_t end0= ov.end(0);
 
-Note that 
+Note that
 
-.. cppkokkos:function:: OffsetView::end(const size_t i)
+.. code-block:: cpp
+
+   OffsetView::end(const size_t i)
 
 returns a value that is not a legal index:  It is exactly one more than the maximum allowable index for the given dimenion i.
 

--- a/docs/source/API/containers/Offset-View.rst
+++ b/docs/source/API/containers/Offset-View.rst
@@ -1,17 +1,17 @@
 ``OffsetView``
 ==============
 
-.. role:: cpp(code)
-   :language: cpp
+.. role:: cppkokkos(code)
+	:language: cppkokkos
 
 The OffsetView is in the Experimental namespace.
 
-Sometimes, it is advantageous to have the indices of an array begin at something other than zero.  In this case, an OffsetView may be used.
+Sometimes, it is advantageous to have the indices of an array begin at something other than zero. In this case, an OffsetView may be used.
 
 Construction
 ------------
 
-An OffsetView must have a label, and at least one dimension.  Only runtime extents are supported, but otherwise the semantics of an OffsetView are similar to those of a View.  
+An OffsetView must have a label, and at least one dimension. Only runtime extents are supported, but otherwise the semantics of an OffsetView are similar to those of a View.  
 
 .. code-block:: cpp
 
@@ -27,10 +27,10 @@ An OffsetView must have a label, and at least one dimension.  Only runtime exten
 Construction from a layout is also allowed.  
 
 .. code-block:: cpp
+    
+    OffsetView<int***> a("someLabel", LayoutLeft, {min0, min1, min2});
 
-   OffsetView<int***> a("someLabel", LayoutLeft, {min0, min1, min2});
-
-An OffsetView may also be created from a View that has the same underlying type.  Since the View already has extents, the beginning indices must be passed to the constructor.  
+An OffsetView may also be created from a View that has the same underlying type. Since the View already has extents, the beginning indices must be passed to the constructor.  
 
 .. code-block:: cpp
 
@@ -43,8 +43,8 @@ The OffsetView ov has the same extents as b and must be indexed from [-10,-1] an
 A std::initializer_list may also be used instead of an Array.
 
 .. code-block:: cpp
-
-   OffsetView<double**> ov(b, {-10, -20});
+    
+    OffsetView<double**> ov(b, {-10, -20});
 
 Interface
 ---------
@@ -61,13 +61,11 @@ The beginning indices may be obtained as an array. The begin and end of iteratio
 
 Note that 
 
-.. code-block:: cpp
-
-   OffsetView::end(const size_t i)
+.. cppkokkos:function:: OffsetView::end(const size_t i)
 
 returns a value that is not a legal index:  It is exactly one more than the maximum allowable index for the given dimenion i.
 
-Subviews are supported, and the result of taking a subview of an OffsetView is another OffsetView.  If ALL() is passed to the subview  function, then the offsets for that rank are preserved, otherwise they are dropped.
+Subviews are supported, and the result of taking a subview of an OffsetView is another OffsetView. If ALL() is passed to the subview function, then the offsets for that rank are preserved, otherwise they are dropped.
 
 .. code-block:: cpp
 
@@ -91,6 +89,6 @@ A compatible View with the same label is obtained from the view() method.
 
 A copy constructor and an assignment operator from a View to an OffsetView are also provided.
 
-Equivalence operators "==" and "!=" are defined.  Given an OffsetView and a View, they are equivalent in the same sense that two Views are equivalent.  Similarly, two OffsetViews are equivalent in the same sense if their begins also match.
+Equivalence operators "==" and "!=" are defined. Given an OffsetView and a View, they are equivalent in the same sense that two Views are equivalent. Similarly, two OffsetViews are equivalent in the same sense if their begins also match.
 
 Mirrors are also supported.

--- a/docs/source/API/containers/Offset-View.rst
+++ b/docs/source/API/containers/Offset-View.rst
@@ -1,83 +1,93 @@
-# `OffsetView`
+``OffsetView``
+==============
+
+.. role:: cpp(code)
+   :language: cpp
 
 The OffsetView is in the Experimental namespace.
 
 Sometimes, it is advantageous to have the indices of an array begin at something other than zero.  In this case, an OffsetView may be used.
 
-----------
-## Construction
+Construction
+------------
 
 An OffsetView must have a label, and at least one dimension.  Only runtime extents are supported, but otherwise the semantics of an OffsetView are similar to those of a View.  
 
-```c++
-const size_t min0 = ...; 
-const size_t max0 = ...; 
-const size_t min1 = ...; 
-const size_t max1 = ...; 
-const size_t min2 = ...; 
-const size_t max2 = ...; 
+.. code-block:: cpp
 
-OffsetView<int***> a("someLabel", {min0, max0}, {min1, max1},{min2, max2});
-```
+   const size_t min0 = ...; 
+   const size_t max0 = ...; 
+   const size_t min1 = ...; 
+   const size_t max1 = ...; 
+   const size_t min2 = ...; 
+   const size_t max2 = ...; 
+
+   OffsetView<int***> a("someLabel", {min0, max0}, {min1, max1},{min2, max2});
+
 Construction from a layout is also allowed.  
 
-```c++
-OffsetView<int***> a("someLabel", LayoutLeft, {min0, min1, min2});
-```
+.. code-block:: cpp
+
+   OffsetView<int***> a("someLabel", LayoutLeft, {min0, min1, min2});
+
 An OffsetView may also be created from a View that has the same underlying type.  Since the View already has extents, the beginning indices must be passed to the constructor.  
 
-```c++
-View<double**> b("somelabel", 10, 20);
-Array<int64_t, 2> begins = {-10, -20};
-OffsetView<double**> ov(b, begins);
-```
+.. code-block:: cpp
+
+   View<double**> b("somelabel", 10, 20);
+   Array<int64_t, 2> begins = {-10, -20};
+   OffsetView<double**> ov(b, begins);
+
 The OffsetView ov has the same extents as b and must be indexed from [-10,-1] and [-20,-11].  
 
 A std::initializer_list may also be used instead of an Array.
 
-```c++
-OffsetView<double**> ov(b, {-10, -20});
-```
+.. code-block:: cpp
+
+   OffsetView<double**> ov(b, {-10, -20});
+
+Interface
 ---------
-## Interface
 
 The beginning indices may be obtained as an array. The begin and end of iteration may be found for each rank.
 
-```c++
-OffsetView<int***> ov("someLabel", {-1,1}, {-2,2}, {-3,3});
- Array<int64_t, 3> a = ov.begins();
+.. code-block:: cpp
 
-const int64_t begin0 = ov.begin(0);
-const int64_t end0= ov.end(0);
-```
+   OffsetView<int***> ov("someLabel", {-1,1}, {-2,2}, {-3,3});
+    Array<int64_t, 3> a = ov.begins();
+
+   const int64_t begin0 = ov.begin(0);
+   const int64_t end0= ov.end(0);
 
 Note that 
-```c++
-OffsetView::end(const size_t i) 
-```
+
+.. code-block:: cpp
+
+   OffsetView::end(const size_t i)
+
 returns a value that is not a legal index:  It is exactly one more than the maximum allowable index for the given dimenion i.
 
 Subviews are supported, and the result of taking a subview of an OffsetView is another OffsetView.  If ALL() is passed to the subview  function, then the offsets for that rank are preserved, otherwise they are dropped.
 
-```c++
-OffsetView<Scalar***> sliceMe("offsetToSlice", {-10,20}, {-20,30}, {-30,40});
-auto offsetSubview = subview(sliceMe,0, Kokkos::ALL(), std::make_pair(-30, -21));
- 
-ASSERT_EQ(offsetSubview.Rank, 2);
-ASSERT_EQ(offsetSubview.begin(0) , -20);
-ASSERT_EQ(offsetSubview.end(0) , 31);
-ASSERT_EQ(offsetSubview.begin(1) , 0);
-ASSERT_EQ(offsetSubview.end(1) , 9);
-```
+.. code-block:: cpp
+
+   OffsetView<Scalar***> sliceMe("offsetToSlice", {-10,20}, {-20,30}, {-30,40});
+   auto offsetSubview = subview(sliceMe,0, Kokkos::ALL(), std::make_pair(-30, -21));
+
+   ASSERT_EQ(offsetSubview.Rank, 2);
+   ASSERT_EQ(offsetSubview.begin(0) , -20);
+   ASSERT_EQ(offsetSubview.end(0) , 31);
+   ASSERT_EQ(offsetSubview.begin(1) , 0);
+   ASSERT_EQ(offsetSubview.end(1) , 9);
 
 The following deep copies are also supported: from a constant value to an OffsetView; from a compatible OffsetView to another OffsetView; from a compatible View to an OffsetView; from a compatible OffsetView to a View.
 
 A compatible View with the same label is obtained from the view() method.
 
-```c++
-OffsetView<int***> ov("someLabel", {-1,1}, {-2,2}, {-3,3});
-View<int***> v = ov.view();
-```
+.. code-block:: cpp
+
+   OffsetView<int***> ov("someLabel", {-1,1}, {-2,2}, {-3,3});
+   View<int***> v = ov.view();
 
 A copy constructor and an assignment operator from a View to an OffsetView are also provided.
 


### PR DESCRIPTION
* API/containers/Offset-View.rst transition from .md to .rst

before (.md) | after (.rst)
:----------------: | :-------------:
![image](https://user-images.githubusercontent.com/62652182/219057428-4becef78-ebe3-4a5a-8763-a57a6cbe1f56.png) | <img width="818" alt="image" src="https://user-images.githubusercontent.com/18708772/220057645-a85cf700-e103-43ee-9c4f-909b05b4e5d7.png">
<img width="708" alt="image" src="https://user-images.githubusercontent.com/18708772/220057831-506fdd8f-a104-473f-984c-d2c213a13327.png"> | <img width="754" alt="image" src="https://user-images.githubusercontent.com/18708772/220057772-e9fe6eca-7ea8-4d85-b556-715e460e7423.png">
