### PR TITLE
Remove duplicate function definition

### DIFF
--- a/docs/source/ProgrammingGuide/Custom-Reductions-Custom-Reducers.md
+++ b/docs/source/ProgrammingGuide/Custom-Reductions-Custom-Reducers.md
@@ -81,9 +81,6 @@ struct SumMyArray {
 
   // Required
   KOKKOS_INLINE_FUNCTION
-  void join(value_type& dest, const value_type& src) const { dest += src; }
-
-  KOKKOS_INLINE_FUNCTION
   void join(value_type& dest, const value_type& src) const {
     dest += src;
   }


### PR DESCRIPTION
Looks like a duplicate function is defined immediately below (maybe used to be `volatile`-qualified before those were removed?)