### PR TITLE
ScatterView.md: improve readability, link to View, add TODO

### DIFF
--- a/docs/source/API/containers/ScatterView.md
+++ b/docs/source/API/containers/ScatterView.md
@@ -3,6 +3,11 @@
 Header File: `Kokkos_ScatterView.hpp`
 
 Usage: 
+
+`ScatterView` can tranparently switch between **Atomic** and **Data Replication** - based scatter algorithms.  Recall, **Atomics** are thread-scalable, and depend on atomic performance.  In **Data Replication** implementations, every thread owns a copy of the output, are not thread-scalable, but are good for low (< 16) thread-count architectures.  `ScatterView` is a compile-time choice with backend-specific defaults and has a limited number of supported operations.  Typically, `ScatterView` wraps an existing [`View`](../core/view/view), allowing the **atomic** variant to work *without* additional allocation -- remember to contribute back to the original `View`!  If possible, reuse a `ScatterView`, as creating and destroying data duplicates are costly.
+
+## Interface
+
 ```c++
 KOKKOS_INLINE_FUNCTION int foo(int i) { return i; }
 KOKKOS_INLINE_FUNCTION double bar(int i) { return i*i; }
@@ -23,7 +28,7 @@ Kokkos::Experimental::contribute(results, scatter);
 ```c++
 
 template <typename DataType
-        ,int Op
+        ,int Operation
         ,typename ExecSpace
         ,typename Layout
         ,int contribution
@@ -31,7 +36,7 @@ template <typename DataType
 class ScatterView<DataType
                   ,Layout
                   ,ExecSpace
-                  ,Op
+                  ,Operation
                   ,{ScatterNonDuplicated,ScatterDuplicated}
                   ,contribution>
 {
@@ -39,37 +44,39 @@ public:
  typedef Kokkos::View<DataType, Layout, ExecSpace> original_view_type;
  typedef typename original_view_type::value_type original_value_type;
  typedef typename original_view_type::reference_type original_reference_type;
- friend class ScatterAccess<DataType, Op, ExecSpace, Layout, {ScatterNonDuplicated,ScatterDuplicated}, contribution, ScatterNonAtomic>;
- friend class ScatterAccess<DataType, Op, ExecSpace, Layout, {ScatterNonDuplicated,ScatterDuplicated}, contribution, ScatterAtomic>;
+ friend class ScatterAccess<DataType, Operation, ExecSpace, Layout, {ScatterNonDuplicated,ScatterDuplicated}, contribution, ScatterNonAtomic>;
+ friend class ScatterAccess<DataType, Operation, ExecSpace, Layout, {ScatterNonDuplicated,ScatterDuplicated}, contribution, ScatterAtomic>;
+ []:# (TODO: Deprecate types requiring `Kokkos::Impl..` )
  typedef typename Kokkos::Impl::Experimental::DuplicatedDataType<DataType, {Kokkos::LayoutRight,Kokkos::LayoutLeft}> data_type_info; // ScatterDuplicated only
  typedef typename data_type_info::value_type internal_data_type; // ScatterDuplicated only
  typedef Kokkos::View<internal_data_type, {Kokkos::LayoutRight,Kokkos::LayoutLeft}, ExecSpace> internal_view_type; // ScatterDuplicated only
  
  ScatterView();
 
- template <typename RT, typename ... RP>
- ScatterView(View<RT, RP...> const& );
+ template <typename ReferenceType, typename ... Properties>
+ ScatterView(View<ReferenceType, Properties...> const& );
 
- template <typename ... Dims>
- ScatterView(std::string const& name, Dims ... dims);
+ template <typename ... Dimensions>
+ ScatterView(std::string const& name, Dimensions ... dims);
 
- template <typename... P, typename... Dims>
- ScatterView(::Kokkos::Impl::ViewCtorProp<P...> const& arg_prop, Dims... dims);
+ []: # (TODO: Deprecate types requiring `Kokkos::Impl..` )
+ template <typename... Properties, typename... Dimensions>
+ ScatterView(::Kokkos::Impl::ViewCtorProp<Properties...> const& arg_prop, Dimensions... dims);
 
  template <int override_contrib = contribution>
  KOKKOS_FORCEINLINE_FUNCTION
- ScatterAccess<DataType, Op, ExecSpace, Layout, ScatterNonDuplicated, contribution, override_contrib>
+ ScatterAccess<DataType, Operation, ExecSpace, Layout, ScatterNonDuplicated, contribution, override_contrib>
  access() const;
 
  original_view_type subview() const;
 
- template <typename DT, typename ... RP>
- void contribute_into(View<DT, RP...> const& dest) const;
+ template <typename DataType, typename ... Properties>
+ void contribute_into(View<DataType, Properties...> const& dest) const;
 
  void reset();
  
- template <typename DT, typename ... RP>
- void reset_except(View<DT, RP...> const& view);
+ template <typename DataType, typename ... Properties>
+ void reset_except(View<DataType, Properties...> const& view);
 
  void resize(const size_t n0 = 0,
           const size_t n1 = 0,
@@ -103,13 +110,13 @@ private:
 ## Public Class Members
 
 ### Typedefs
-* `original_view_type`: Type of View passed to ScatterView constructor.
-* `original_value_type`: Value type of the original_view_type.
-* `original_reference_type`: Reference type of the original_view_type.
-// ScatterDuplicated only
-* `data_type_info`: DuplicatedDataType, a newly created DataType that has a new runtime dimension which becomes the largest-stride dimension, from the given View DataType.
-* `internal_data_type`: Value type of data_type_info.
-* `internal_view_type`: A View type created from the internal_data_type.
+* `original_view_type`: Type of `View` passed to ScatterView constructor.
+* `original_value_type`: Value type of the `original_view_type`.
+* `original_reference_type`: Reference type of the `original_view_type`.
+[]: # (ScatterDuplicated only)
+* `data_type_info`: DuplicatedDataType, a newly created DataType that has a new runtime dimension which becomes the largest-stride dimension, from the given `View` DataType.
+* `internal_data_type`: Value type of `data_type_info`.
+* `internal_view_type`: A `View` type created from the `internal_data_type`.
 
 ### Constructors
 
@@ -119,21 +126,22 @@ private:
    Default constructor. Default constructs members.
 
  * ```c++
-    ScatterView(View<RT, RP...> const& );
+    ScatterView(View<ReferenceType, Properties...> const& );
    ```
    Constructor from a `Kokkos::View`. `internal_view` member is copy constructed from this input view.
 
  * ```c++
-    ScatterView(std::string const& name, Dims ... dims);
+    ScatterView(std::string const& name, Dimensions ... dims);
    ```
    Constructor from variadic pack of dimension arguments. Constructs `internal_view` member.
 
+ []: # (TODO: Deprecate types requiring `Kokkos::Impl..` )
  * ```c++
-    ScatterView(::Kokkos::Impl::ViewCtorProp<P...> const& arg_prop, Dims... dims);
+    ScatterView(::Kokkos::Impl::ViewCtorProp<Properties...> const& arg_prop, Dimensions ... dims);
    ```
-   Constructor from variadic pack of dimension arguments. Constructs `internal_view` member.
+   Constructor from variadic pack of properties and dimension arguments. Constructs `internal_view` member.
    This constructor allows specifying an execution space instance to be used by passing, e.g., 
-   Kokkos::view_alloc(exec_space, "label") as first argument.
+   `Kokkos::view_alloc(exec_space, "label")` as first argument.
 
 ### Functions
   * ```c++
@@ -152,7 +160,7 @@ private:
    Return a subview of a `ScatterView`.
 
  * ```c++
-    contribute_into(View<DT, RP...> const& dest) const;
+    contribute_into(View<DataType, Properties...> const& dest) const;
    ```
    Contribute `ScatterView` array's results into the input View `dest`.
 
@@ -162,7 +170,7 @@ private:
    Performs reset on destination array.
 
  * ```c++
-    reset_except(View<DT, RP...> const& view);
+    reset_except(View<DataType, Properties...> const& view);
    ```
 
  * ```c++
@@ -177,6 +185,6 @@ private:
 
 ### Free Functions
  * ```c++
-   contribute(View<DT1, VP...>& dest, Kokkos::Experimental::ScatterView<DT2, LY, ES, OP, CT, DP> const& src)
+   contribute(View<DataType1, Properties...>& dest, Kokkos::Experimental::ScatterView<DataType2, Layout, ExecSpace, Operation, Contribution, Duplicated> const& src)
    ```
    Convenience function to perform final reduction of ScatterView results into a resultant View; may be called following [`parallel_reduce()`](../core/parallel-dispatch/parallel_reduce).


### PR DESCRIPTION
This PR aims to improve readability by spelling out concepts represented by terse, non-standard acronyms and linking to `View` documentation.  Additionally, a brief usage explanation is provided, as are deprecation `TODO` around `Kokkos::Impl` statements.