### PR TITLE
use proper format in file know-issues to avoid warnings

### DIFF
--- a/docs/source/known-issues.rst
+++ b/docs/source/known-issues.rst
@@ -1,8 +1,13 @@
-# Known issues
+Known issues
+############
 
-## HIP
+HIP
+===
+
 - Compatibility issue between HIP and gcc 8. You may encounter the following error:
-```
-error: reference to __host__ function 'operator new' in __host__ __device__ function
-```
-gcc 7, 9, and later do not have this issue.
+
+  .. code-block::
+
+     error: reference to __host__ function 'operator new' in __host__ __device__ function
+
+  gcc 7, 9, and later do not have this issue.


### PR DESCRIPTION
the file was previously using md format but the extension was rst so causing a warning: 
```
docs/source/index.rst:124: WARNING: toctree contains reference to document 'known-issues' that doesn't have a title: no link will be generated
....
```
this is fixed now. 