### PR TITLE
Fixup deducing `Kokkos::Impl::ALL_t` in `Kokkos::Subview` doc

### DIFF
--- a/docs/source/API/core/view/subview.md
+++ b/docs/source/API/core/view/subview.md
@@ -44,7 +44,7 @@ IMPL_DETAIL subview(const ViewType& v, Args ... args);
     * `std::pair<iType,iType>` with `std::is_integral<iType>::value` being true.
     * `Kokkos::pair<iType,iType>` with `std::is_integral<iType>::value` being true.
     * `iType` with `std::is_integral<iType>::value` being true.
-    * `decltype(`[`Kokkos::ALL`](KokkosALL)`)`
+    * `std::remove_const_t<decltype(`[`Kokkos::ALL`](KokkosALL)`)>`
   * If the `r`th argument `arg_r` is of type `std::pair<iType,iType>` or `Kokkos::pair<iType,iType>` it must meet:
     * `arg_r.first >= 0`
     * `arg_r.second <= v.extent(r)`

--- a/docs/source/ProgrammingGuide/Subviews.md
+++ b/docs/source/ProgrammingGuide/Subviews.md
@@ -79,10 +79,10 @@ For some applications, it is useful to know the type of a subview, given the arg
 ```c++
 using my_view_type = Kokkos::View<double **>;
 using my_subview_type = Kokkos::Subview<my_view_type,
-                                        decltype(Kokkos::ALL),
+                                        std::remove_const_t<decltype(Kokkos::ALL)>,
                                         Kokkos::pair<unsigned, unsigned>>;
 
-using my_subview_type_deduced = decltype(subview(std::declval<my_view_type>(), Kokkos::ALL, std::make_pair(1u, 1u));
+using my_subview_type_deduced = decltype(subview(std::declval<my_view_type>(), Kokkos::ALL, std::make_pair(1u, 1u)));
 
 static_assert(std::is_same<my_subview_type, my_subview_type_deduced>::value);
 ```


### PR DESCRIPTION
Code snippets do not compile.  Reported on Slack.

Opening just a base for discussion as we could probably update the definition of the subview and make it work instead.