### PR TITLE
#120: API-core-utilities-abort from md to rst

### DIFF
--- a/docs/source/API/core/utilities/abort.md
+++ b/docs/source/API/core/utilities/abort.md
@@ -1,9 +1,0 @@
-# `Kokkos::abort`
-
-Defined in header `<Kokkos_Core.hpp>`
-
-```c++
-KOKKOS_FUNCTION void abort(const char *const msg);
-```
-
-Causes abnormal program termination with error explanatory string being printed.

--- a/docs/source/API/core/utilities/abort.rst
+++ b/docs/source/API/core/utilities/abort.rst
@@ -1,0 +1,13 @@
+``Kokkos::abort``
+=================
+
+.. role:: cppkokkos(code)
+    :language: cppkokkos
+
+Defined in header ``<Kokkos_Core.hpp>``
+
+.. code-block:: cpp
+
+    KOKKOS_FUNCTION void abort(const char *const msg);
+
+Causes abnormal program termination with error explanatory string being printed.


### PR DESCRIPTION
### THIS PR:
* API/core/utilities/abort transition from .md to .rst

- [x] uses cppkokkos
- [x] rebased on latest main
- [x] screenshots

before (.md) | after (.rst)
:----------------: | :-------------:
![image](https://user-images.githubusercontent.com/62652182/220761074-8177d56c-953c-4a99-b245-6c27736b90cd.png) | ![image](https://user-images.githubusercontent.com/62652182/220761193-bbccf1f6-ca10-41e0-8b48-76e1840c3c53.png)
