### PR TITLE
#120: API-algorithms-std_algorithms-StdModSeq from rst to new rst

### DIFF
--- a/docs/source/API/algorithms/std-algorithms/StdModSeq.rst
+++ b/docs/source/API/algorithms/std-algorithms/StdModSeq.rst
@@ -1,35 +1,170 @@
-
 Modifying Sequence
-##################
+==================
 
-.. toctree::
-   :maxdepth: 1
+.. _StdCopy: ./all/StdCopy.html
 
-   ./all/StdCopy
-   ./all/StdCopyIf
-   ./all/StdCopy_n
-   ./all/StdCopyBackward
-   ./all/StdMove
-   ./all/StdMoveBackward
-   ./all/StdFill
-   ./all/StdFill_n
-   ./all/StdTransform
-   ./all/StdGenerate
-   ./all/StdGenerate_n
-   ./all/StdRemove
-   ./all/StdRemoveIf
-   ./all/StdRemoveCopy
-   ./all/StdRemoveCopyIf
-   ./all/StdReplace
-   ./all/StdReplaceIf
-   ./all/StdReplaceCopy
-   ./all/StdReplaceCopyIf
-   ./all/StdSwapRanges
-   ./all/StdReverse
-   ./all/StdReverseCopy
-   ./all/StdRotate
-   ./all/StdRotateCopy
-   ./all/StdShiftLeft
-   ./all/StdShiftRight
-   ./all/StdUnique
-   ./all/StdUniqueCopy
+.. |StdCopy| replace:: ``copy``
+
+* |StdCopy|_
+
+.. _StdCopyIf: ./all/StdCopyIf.html
+
+.. |StdCopyIf| replace:: ``copy_if``
+
+* |StdCopyIf|_
+
+.. _StdCopyN: ./all/StdCopy_n.html
+
+.. |StdCopyN| replace:: ``copy_n``
+
+* |StdCopyN|_
+
+.. _StdCopyBackward: ./all/StdCopyBackward.html
+
+.. |StdCopyBackward| replace:: ``copy_backward``
+
+* |StdCopyBackward|_
+
+.. _StdMove: ./all/StdMove.html
+
+.. |StdMove| replace:: ``move``
+
+* |StdMove|_  
+
+.. _StdMoveBackward: ./all/StdMoveBackward.html
+
+.. |StdMoveBackward| replace:: ``move_backward``
+
+* |StdMoveBackward|_
+
+.. _StdFill: ./all/StdFill.html
+
+.. |StdFill| replace:: ``fill``
+
+* |StdFill|_
+
+.. _StdFillN: ./all/StdFill_n.html
+
+.. |StdFillN| replace:: ``fill_n``
+
+* |StdFillN|_
+
+.. _StdTransform: ./all/StdTransform.html
+
+.. |StdTransform| replace:: ``transform``
+
+* |StdTransform|_
+
+.. _StdGenerate: ./all/StdGenerate.html
+
+.. |StdGenerate| replace:: ``generate``
+
+* |StdGenerate|_
+
+.. _StdGenerateN: ./all/StdGenerate_n.html
+
+.. |StdGenerateN| replace:: ``generate_n``
+
+* |StdGenerateN|_
+
+.. _StdRemove: ./all/StdRemove.html
+
+.. |StdRemove| replace:: ``remove``
+
+* |StdRemove|_
+
+.. _StdRemoveIf: ./all/StdRemoveIf.html
+
+.. |StdRemoveIf| replace:: ``remove_if``
+
+* |StdRemoveIf|_
+
+.. _StdRemoveCopy: ./all/StdRemoveCopy.html
+
+.. |StdRemoveCopy| replace:: ``remove_copy``
+
+* |StdRemoveCopy|_
+
+.. _StdRemoveCopyIf: ./all/StdRemoveCopyIf.html
+
+.. |StdRemoveCopyIf| replace:: ``remove_copy_if``
+
+* |StdRemoveCopyIf|_
+
+.. _StdReplace: ./all/StdReplace.html
+
+.. |StdReplace| replace:: ``replace``
+
+* |StdReplace|_
+
+.. _StdReplaceIf: ./all/StdReplaceIf.html
+
+.. |StdReplaceIf| replace:: ``replace_if``
+
+* |StdReplaceIf|_
+
+.. _StdReplaceCopy: ./all/StdReplaceCopy.html
+
+.. |StdReplaceCopy| replace:: ``replace_copy``
+
+* |StdReplaceCopy|_
+
+.. _StdReplaceCopyIf: ./all/StdReplaceCopyIf.html
+
+.. |StdReplaceCopyIf| replace:: ``replace_copy_if``
+
+* |StdReplaceCopyIf|_
+
+.. _StdSwapRanges: ./all/StdSwapRanges.html
+
+.. |StdSwapRanges| replace:: ``swap_ranges``
+
+* |StdSwapRanges|_
+
+.. _StdReverse: ./all/StdReverse.html
+
+.. |StdReverse| replace:: ``reverse``
+
+* |StdReverse|_
+
+.. _StdReverseCopy: ./all/StdReverseCopy.html
+
+.. |StdReverseCopy| replace:: ``reverse_copy``
+
+* |StdReverseCopy|_
+
+.. _StdRotate: ./all/StdRotate.html
+
+.. |StdRotate| replace:: ``rotate``
+
+* |StdRotate|_
+
+.. _StdRotateCopy: ./all/StdRotateCopy.html
+
+.. |StdRotateCopy| replace:: ``rotate_copy``
+
+* |StdRotateCopy|_
+
+.. _StdShiftLeft: ./all/StdShiftLeft.html
+
+.. |StdShiftLeft| replace:: ``shift_left``
+
+* |StdShiftLeft|_
+
+.. _StdShiftRight: ./all/StdShiftRight.html
+
+.. |StdShiftRight| replace:: ``shift_right``
+
+* |StdShiftRight|_
+
+.. _StdUnique: ./all/StdUnique.html
+
+.. |StdUnique| replace:: ``unique``
+
+* |StdUnique|_
+
+.. _StdUniqueCopy: ./all/StdUniqueCopy.html
+
+.. |StdUniqueCopy| replace:: ``unique_copy``
+
+* |StdUniqueCopy|_


### PR DESCRIPTION
### THIS PR:
* API/algorithms/std-algorithms/StdModSeq transition from .rst to new .rst

before (.md) | after (.rst)
:----------------: | :-------------:
![image](https://user-images.githubusercontent.com/62652182/222978490-551b1814-7abe-40cf-a9ac-983887d342fd.png) | ![image](https://user-images.githubusercontent.com/62652182/222978545-aa10deea-0d31-41fb-81c7-0c679a8a2f3a.png)
