### PR TITLE
fix heading for where_expression

### DIFF
--- a/docs/source/API/simd/where_expression.md
+++ b/docs/source/API/simd/where_expression.md
@@ -1,4 +1,4 @@
-`Experimental::where_expression`
+# `Experimental::where_expression`
 
 Header File: `Kokkos_SIMD.hpp`
 


### PR DESCRIPTION
without this, the contents of
the where_expression documentation
spill into the high-level index
for the SIMD API instead of being
their own proper sub-section