### PR TITLE
Update partition_space.md: add requirement

### DIFF
--- a/docs/source/API/core/spaces/partition_space.md
+++ b/docs/source/API/core/spaces/partition_space.md
@@ -28,7 +28,7 @@ std::vector<ExecSpace> partition_space(const ExecSpace& space, Args...args);
 ### Requirements
 
 - `(std::is_arithmetic_v<Args> && ...)` is `true`.
-- `ExecutionSpace().currency() >= N_PARTITIONS`
+- `ExecutionSpace().concurrency() >= N_PARTITIONS`
 
 ### Semantics
 

--- a/docs/source/API/core/spaces/partition_space.md
+++ b/docs/source/API/core/spaces/partition_space.md
@@ -27,7 +27,8 @@ std::vector<ExecSpace> partition_space(const ExecSpace& space, Args...args);
 
 ### Requirements
 
-- `(std::is_arithmetic_v<Args> && ...)` is `true`. 
+- `(std::is_arithmetic_v<Args> && ...)` is `true`.
+- `ExecutionSpace().currency() >= N_PARTITIONS`
 
 ### Semantics
 


### PR DESCRIPTION
While porting the KokkosKernels CI to a new machine, I encountered a hard-coded number of partitions in one of our unit tests. The runtime abort message provided by kokkos indicated that this test was splitting the pool size on OpenMP into too many execution space partitions. It was not clear from the wiki docs how to determine the number of available partitions. This commit is intended to make the documentation clearer.