### PR TITLE
add correct header to include for each container

### DIFF
--- a/docs/source/API/containers/Bitset.rst
+++ b/docs/source/API/containers/Bitset.rst
@@ -4,7 +4,7 @@
 .. role:: cpp(code)
    :language: cpp
 
-Header file: ``Kokkos_Bitset.hpp``
+Header file: ``<Kokkos_Bitset.hpp>``
 
 Class Interface
 ---------------

--- a/docs/source/API/containers/Bitset.rst
+++ b/docs/source/API/containers/Bitset.rst
@@ -1,8 +1,9 @@
-``Bitset``
-==========
 
 .. role:: cpp(code)
    :language: cpp
+
+``Bitset``
+==========
 
 Header file: ``<Kokkos_Bitset.hpp>``
 

--- a/docs/source/API/containers/DualView.rst
+++ b/docs/source/API/containers/DualView.rst
@@ -1,8 +1,6 @@
+
 ``DualView``
 ============
-
-.. role:: cppkokkos(code)
-    :language: cppkokkos
 
 Header file: ``<Kokkos_DualView.hpp>``
 

--- a/docs/source/API/containers/DualView.rst
+++ b/docs/source/API/containers/DualView.rst
@@ -4,6 +4,10 @@
 .. role:: cppkokkos(code)
     :language: cppkokkos
 
+Header file: ``<Kokkos_DualView.hpp>``
+
+|
+
 Container to manage mirroring a ``Kokkos::View`` that references device memory with
 a ``Kokkos::View`` that references host memory. The class provides capabilities to manage
 data which exists in two different memory spaces at the same time. It supports views with

--- a/docs/source/API/containers/DynRankView.rst
+++ b/docs/source/API/containers/DynRankView.rst
@@ -7,7 +7,7 @@
 .. role:: cppkokkos(code)
     :language: cppkokkos
 
-Header File: ``<Kokkos_DynRankView.hpp>``
+Header file: ``<Kokkos_DynRankView.hpp>``
 
 Usage
 -----

--- a/docs/source/API/containers/DynRankView.rst
+++ b/docs/source/API/containers/DynRankView.rst
@@ -1,11 +1,11 @@
 
 .. include:: ../../mydefs.rst
 
-``DynRankView``
-===============
-
 .. role:: cppkokkos(code)
     :language: cppkokkos
+
+``DynRankView``
+===============
 
 Header file: ``<Kokkos_DynRankView.hpp>``
 

--- a/docs/source/API/containers/DynamicView.rst
+++ b/docs/source/API/containers/DynamicView.rst
@@ -1,8 +1,9 @@
-``DynamicView``
-===============
 
 .. role:: cppkokkos(code)
     :language: cppkokkos
+
+``DynamicView``
+===============
 
 Header file: ``<Kokkos_DynamicView.hpp>``
 

--- a/docs/source/API/containers/DynamicView.rst
+++ b/docs/source/API/containers/DynamicView.rst
@@ -4,7 +4,7 @@
 .. role:: cppkokkos(code)
     :language: cppkokkos
 
-Header File: ``<Kokkos_DynamicView.hpp>``
+Header file: ``<Kokkos_DynamicView.hpp>``
 
 
 Description

--- a/docs/source/API/containers/Offset-View.rst
+++ b/docs/source/API/containers/Offset-View.rst
@@ -1,7 +1,4 @@
 
-.. role:: cppkokkos(code)
-	  :language: cppkokkos
-
 ``OffsetView``
 ==============
 

--- a/docs/source/API/containers/Offset-View.rst
+++ b/docs/source/API/containers/Offset-View.rst
@@ -1,10 +1,13 @@
-``OffsetView``
-==============
-
-An ``OffsetView`` can be used when the indices of an array begin at something other than zero.
 
 .. role:: cppkokkos(code)
 	  :language: cppkokkos
+
+``OffsetView``
+==============
+
+Header file: ``<Kokkos_OffsetView.hpp>``
+
+An ``OffsetView`` can be used when the indices of an array begin at something other than zero.
 
 .. warning::
 

--- a/docs/source/API/containers/StaticCrsGraph.rst
+++ b/docs/source/API/containers/StaticCrsGraph.rst
@@ -1,7 +1,4 @@
 
-.. role:: cpp(code)
-   :language: cpp
-
 ``StaticCrsGraph``
 ==================
 

--- a/docs/source/API/containers/StaticCrsGraph.rst
+++ b/docs/source/API/containers/StaticCrsGraph.rst
@@ -1,8 +1,11 @@
-``StaticCrsGraph``
-==================
 
 .. role:: cpp(code)
    :language: cpp
+
+``StaticCrsGraph``
+==================
+
+Header file: ``<Kokkos_StaticCrsGraph.hpp>``
 
 The StaticCrsGraph is a Compressed row storage array with the row map, the column indices and the non-zero entries stored in 3 different Kokkos::Views.  Appropriate types and functions are provided to simplify manipulation and access to CRS data on either a host or device.
 

--- a/docs/source/API/containers/Unordered-Map.rst
+++ b/docs/source/API/containers/Unordered-Map.rst
@@ -1,9 +1,11 @@
-``UnorderedMap``
-================
 
 .. role:: cppkokkos(code)
 	:language: cppkokkos
 
+``UnorderedMap``
+================
+
+Header file: ``<Kokkos_UnorderedMap.hpp>``
 
 Kokkos's unordered map is designed to efficiently handle tens of thousands of concurrent insertions.
 Consequently, the API is significantly different from the standard unordered_map.

--- a/docs/source/API/containers/vector.rst
+++ b/docs/source/API/containers/vector.rst
@@ -1,8 +1,11 @@
-``vector``
-==========
 
 .. role:: cppkokkos(code)
     :language: cppkokkos
+
+``vector``
+==========
+
+Header file: ``<Kokkos_Vector.hpp>``
 
 The Kokkos Vector is semantically similar to the std::vector, but it is designed to overcome issues with memory allocations and copies when working with devices that have different memory spaces. The ``Kokkos::Vector`` is a Rank-1 DualView that implements the same interface as the std::vector. This allows programs that rely heavily on std::vector to grant access to program data from within a non-host execution space. Note that many of the std::vector compatible functions are host only, so access may be limited based on kernel complexity. Below is a synopsis of the class and the description for each method specifies whether it is supported on the host, device or both.
 


### PR DESCRIPTION
solves #339 
- adds corresponding header to containers (except scatter view since thre is a pending PR for it) 
- moved to top the alias rst command for domain and removed where not currently needed