### PR TITLE
[Draft] initial versioning using sphinx-multiversioning

### DIFF
--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -3,4 +3,4 @@ furo==2022.6.4.1
 myst-parser==0.18.0
 sphinx-copybutton==0.5.0
 m2r2==0.3.2
-sphinx-multiversion=0.2.4
+sphinx-multiversion==0.2.4

--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -3,3 +3,4 @@ furo==2022.6.4.1
 myst-parser==0.18.0
 sphinx-copybutton==0.5.0
 m2r2==0.3.2
+sphinx-multiversion=0.2.4

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,5 +1,5 @@
 html:
-	sphinx-build -b html ./source/ ./generated_docs/
+	sphinx-multiversion ./source/ ./generated_docs/
 	python3 ./source/edit_button_handler.py
 
 clean:

--- a/docs/source/_templates/sidebar/variant-selector.html
+++ b/docs/source/_templates/sidebar/variant-selector.html
@@ -1,0 +1,28 @@
+<!-- Borrowed from https://github.com/pradyunsg/furo/compare/main...raddessi:main.issue-372-multiversion-example -->
+{% if versions %}
+<div class="sidebar-tree">
+  {%- if versions.branches %}
+  <p class="caption" role="heading">
+    <span class="caption-text">{{ _('Branches') }}</span>
+  </p>
+  <ul>
+    {%- for item in versions.branches %}
+    <li class="toctree-l1">
+      <a class="reference internal" href="{{ item.url }}">{{ item.name }}</a>
+    </li>
+    {%- endfor %}
+  </ul>
+  {%- endif %} {%- if versions.tags %}
+  <p class="caption" role="heading">
+    <span class="caption-text">{{ _('Tags') }}</span>
+  </p>
+  <ul>
+    {%- for item in versions.tags %}
+    <li class="toctree-l1">
+      <a class="reference internal" href="{{ item.url }}">{{ item.name }}</a>
+    </li>
+    {%- endfor %}
+  </ul>
+  {%- endif %}
+</div>
+{% endif %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,7 +38,8 @@ extensions = ["myst_parser",
               "sphinx.ext.viewcode",
               "sphinx.ext.intersphinx",
               "sphinx_copybutton",
-              "cppkokkos"]
+              "cppkokkos",
+              "sphinx_multiversion"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -71,6 +72,17 @@ source_suffix = {
     '.md': 'markdown',
 }
 
+html_sidebars = {
+    "**": [
+        "sidebar/brand.html",
+        "sidebar/search.html",
+        "sidebar/scroll-start.html",
+        "sidebar/navigation.html",
+        "sidebar/scroll-end.html",
+        "sidebar/variant-selector.html",
+    ]
+}
+
 myst_heading_anchors = 4
 
 myst_enable_extensions = [
@@ -81,3 +93,9 @@ myst_enable_extensions = [
 # rst_prolog = """
 # .. include:: special.rst
 # """
+
+# Multiversioning
+smv_tag_whitelist = r'^\d+\.\d+\.\d+$'   # Tags formatted with x.x.x
+smv_branch_whitelist = r'main|test'
+smv_released_pattern = r'^tags/\d+\.\d+\.\d+$'   # Tags formatted with x.x.x
+smv_outputdir_format = '{ref.name}'


### PR DESCRIPTION
https://github.com/kokkos/kokkos-core-wiki/issues/272 needs to be updated/completed before merging this

Right now `test` is whitelisted as a valid branch name for versioning, you can create a local `test` branch to try it out. When we merge, we should probably remove that.

There are some changes that will need to be done with the CI to get this to work properly. We also need to have a branch (and ensure that it is pulled in the CI) for 3.7 and 4.0.

Right now the multiversioning uses "main" for the main branch, but "latest" is more conventional. I can't figure out a good way of getting it to use "latest" without renaming the branch.

### More info

sphinx-multiversioning works by reading all tags and branches in the *local* git repository. I've currently whitelisted the branches "main" and "test" (just for testing purposes) and any tag that is of the format "x.x.x.x".

It will generate a subfolder with the git ref name under the generated_docs folder

I had to tweak the `edit_button_handler.py` script to work with multiple versions, but fortunately sphinx-multiversioning outputs a json file that contains all the generated versions, so I just read that.