### PR TITLE
Require reducers to define a monoid

### DIFF
--- a/docs/source/API/core/builtinreducers/ReducerConcept.rst
+++ b/docs/source/API/core/builtinreducers/ReducerConcept.rst
@@ -105,7 +105,7 @@ The reducer is assumed to define a commutative monoid with respect to the value 
       return result;
     }
 
-is commutative and associative with identity element defined by ``reducer.init(el)``.
+is commutative and associative with identity element that can be set by calling ``reducer.init(el)``.
 
 
 Built-In Reducers

--- a/docs/source/API/core/builtinreducers/ReducerConcept.rst
+++ b/docs/source/API/core/builtinreducers/ReducerConcept.rst
@@ -95,7 +95,7 @@ Functions
 Requirements
 ~~~~~~~~~~~~
 
-The reducer is assumend to define a commutative monoid with respect to the value type it is used with, i.e., the binary operation
+The reducer is assumed to define a commutative monoid with respect to the value type it is used with, i.e., the binary operation
 
 .. code-block:: cpp
 

--- a/docs/source/API/core/builtinreducers/ReducerConcept.rst
+++ b/docs/source/API/core/builtinreducers/ReducerConcept.rst
@@ -92,6 +92,22 @@ Functions
 
     * Returns a view of the result place.
 
+Requirements
+~~~~~~~~~~~~
+
+The reducer is assumend to define a commutative monoid with respect to the value type it is used with, i.e., the binary operation
+
+.. code-block:: cpp
+
+    value_type op(const value_type& val1, const value_type& val2) {
+      value_type result = val1;
+      reducer.join(result, val2);
+      return result;
+    }
+
+is commutative and associative with identity element defined by ``reducer.init(el)``.
+
+
 Built-In Reducers
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/pull/6065#issuecomment-1518014632.