### PR TITLE
Add a note that device_id and num_threads are only available since 4.1

### DIFF
--- a/docs/source/API/core/utilities/device_id.rst
+++ b/docs/source/API/core/utilities/device_id.rst
@@ -8,7 +8,7 @@ Defined in header ``<Kokkos_Core.hpp>``
 
 .. code-block:: cpp
 
-    [[nodiscard]] int device_id() noexcept;
+    [[nodiscard]] int device_id() noexcept;  // (since 4.1)
 
 Returns the id of the device that is used by ``DefaultExecutionSpace`` or
 ``-1`` if only host backends are enabled.

--- a/docs/source/API/core/utilities/num_threads.rst
+++ b/docs/source/API/core/utilities/num_threads.rst
@@ -8,7 +8,7 @@ Defined in header ``<Kokkos_Core.hpp>``
 
 .. code-block:: cpp
 
-    [[nodiscard]] int num_threads() noexcept;
+    [[nodiscard]] int num_threads() noexcept;  // (since 4.1)
 
 Returns the number of concurrent threads that are used by ``DefaultHostExecutionSpace``.
 


### PR DESCRIPTION
I am not sure how to annotate in the utilities table of content because it just parses the files header and I don't necessarily want the "since 4.1" in the title but I think a comment in the synopsis is good enough for now.
See kokkos/kokkos#6084