### PR TITLE
Remove `Kokkos_ENABLE_PROFILING_LOAD_PRINT` and pretend it never existed

### DIFF
--- a/docs/source/API/core/Macros.rst
+++ b/docs/source/API/core/Macros.rst
@@ -28,8 +28,6 @@ General Settings
 +-------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
 | ``KOKKOS_ENABLE_HBWSPACE``                      | Defined if the experimental ``HBWSpace`` memory space is enabled, enabled by KOKKOS_ENABLE_MEMKIND.         |
 +-------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| ``KOKKOS_ENABLE_PROFILING_LOAD_PRINT``          | Kokkos will output a message when the profiling library is loaded.                                          |
-+-------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
 | ``KOKKOS_ENABLE_TUNING``                        | Whether bindings for tunings are available (see `#2422 <https://github.com/kokkos/kokkos/pull/2422>`_).     |
 +-------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
 | ``KOKKOS_ENABLE_COMPLEX_ALIGN``                 | Whether complex types are aligned.                                                                          |

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -138,10 +138,6 @@ Enable Options
       * Perform extra large memory tests
       * ``OFF``
 
-    * * ``Kokkos_ENABLE_PROFILING_LOAD_PRINT``
-      * Print information about which profiling tools got loaded
-      * ``OFF``
-
     * * ``Kokkos_ENABLE_TESTS``
       * Build tests
       * ``OFF``


### PR DESCRIPTION
I propose to keep things simple and just remove it rather than saying it was removed in 4.1

See kokkos/kokkos#6150