### PR TITLE
Fix `Github` typo on the front page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,27 +24,27 @@ The `Kokkos EcoSystem <https://github.com/kokkos>`_ includes:
 
    * - ``kokkos``
      - (this library) Programming Model - Parallel Execution and Memory Abstraction
-     - `Github link <https://github.com/kokkos/kokkos>`__
+     - `GitHub link <https://github.com/kokkos/kokkos>`__
 
    * - ``kokkos-kernels``
      - Sparse, dense, batched math kernels
-     - `Github link <https://github.com/kokkos/kokkos-kernels>`__
+     - `GitHub link <https://github.com/kokkos/kokkos-kernels>`__
 
    * - ``kokkos-tools``
      - Profiling and debugging tools
-     - `Github link <https://github.com/kokkos/kokkos-tools>`__
+     - `GitHub link <https://github.com/kokkos/kokkos-tools>`__
 
    * - ``pykokkos``
      - Provides Python bindings to the Kokkos performance portable parallel programming.
-     - `Github link <https://github.com/kokkos/pykokkos>`__
+     - `GitHub link <https://github.com/kokkos/pykokkos>`__
 
    * - ``kokkos-remote-spaces``
      - Shared memory semantics across multiple processes
-     - `Github link <https://github.com/kokkos/kokkos-remote-spaces>`__
+     - `GitHub link <https://github.com/kokkos/kokkos-remote-spaces>`__
 
    * - ``kokkos-resilience``
      - Resilience and Checkpointing Extensions for Kokkos
-     - `Github link <https://github.com/kokkos/kokkos-resilience>`__
+     - `GitHub link <https://github.com/kokkos/kokkos-resilience>`__
 
 Related Work for the C++ standard library
 -----------------------------------------
@@ -64,12 +64,12 @@ Relevant and related efforts include:
    * - ``mdspan``
      - Reference implementation of mdspan targeting C++23
      - `P0009 <https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0009r16.html>`__
-     - `Github link <https://github.com/kokkos/mdspan>`__
+     - `GitHub link <https://github.com/kokkos/mdspan>`__
 
    * - ``stdBLAS``
      - Reference Implementation for stdBLAS
      - `P1673 <https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p1673r8.html>`__
-     - `Github link <https://github.com/kokkos/stdBLAS>`__
+     - `GitHub link <https://github.com/kokkos/stdBLAS>`__
 
 Questions?
 ----------


### PR DESCRIPTION
fixes #223 