### PR TITLE
Fix cppkokkos to avoid warnings

### DIFF
--- a/docs/source/_ext/cppkokkos.py
+++ b/docs/source/_ext/cppkokkos.py
@@ -4445,7 +4445,7 @@ class Symbol:
                 candSymbol.isRedeclaration = True
                 raise _DuplicateSymbolError(symbol, declaration)
 
-            if declaration.objectType != "function":
+            if declaration.objectType not in ['function', 'kokkosinlinefunction']:
                 assert len(withDecl) <= 1
                 handleDuplicateDeclaration(withDecl[0], candSymbol)
                 # (not reachable)
@@ -4457,7 +4457,7 @@ class Symbol:
             for symbol in withDecl:
                 # but all existing must be functions as well,
                 # otherwise we declare it to be a duplicate
-                if symbol.declaration.objectType != 'function':
+                if symbol.declaration.objectType not in ['function', 'kokkosinlinefunction']:
                     handleDuplicateDeclaration(symbol, candSymbol)
                     # (not reachable)
                 oldId = symbol.declaration.get_newest_id()


### PR DESCRIPTION
Related to #378

`kokkosinlinefunction` triggered "Duplicate C++ declaration, also defined...". 
This was due to cppkokkos.py missing to include this customization in a couple places. This PR fixes that so that these warnings are solved. 
NOTE: this does not fix the warnings all together, since to get rid of all of them we need #397 