### PR TITLE
use proper sphinx class syntax for `BAnd`

### DIFF
--- a/docs/source/API/core/builtinreducers/BAnd.rst
+++ b/docs/source/API/core/builtinreducers/BAnd.rst
@@ -50,9 +50,9 @@ Synopsis
 Interface
 ---------
 
-.. cppkokkos:class:: template<class Scalar, class Space> LayoutLeft
+.. cppkokkos:class:: template<class Scalar, class Space> BAnd
 
-   .. rubric:: Public Nested Typedefs
+   .. rubric:: Public Types
 
    .. cppkokkos:type:: reducer
 
@@ -76,7 +76,7 @@ Interface
 
       Constructs a reducer which references a specific view as its result location.
 
-   .. rubric:: Methods
+   .. rubric:: Public Member Functions
 
    .. cppkokkos:kokkosinlinefunction:: void join(value_type& dest, const value_type& src) const;
 

--- a/docs/source/API/core/builtinreducers/BAnd.rst
+++ b/docs/source/API/core/builtinreducers/BAnd.rst
@@ -16,7 +16,7 @@ Usage
     T result;
     parallel_reduce(N,Functor,BAnd<T,S>(result));
 
-Synopsis 
+Synopsis
 --------
 
 .. code-block:: cpp
@@ -27,7 +27,7 @@ Synopsis
             typedef BAnd reducer;
             typedef typename std::remove_cv<Scalar>::type value_type;
             typedef Kokkos::View<value_type, Space> result_view_type;
-            
+
             KOKKOS_INLINE_FUNCTION
             void join(value_type& dest, const value_type& src) const;
 
@@ -47,50 +47,61 @@ Synopsis
             BAnd(const result_view_type& value_);
     };
 
-Public Class Members
---------------------
+Interface
+---------
 
-Typedefs
-~~~~~~~~
-   
-* ``reducer``: The self type.
-* ``value_type``: The reduction scalar type.
-* ``result_view_type``: A ``Kokkos::View`` referencing the reduction result 
+.. cppkokkos:class:: template<class Scalar, class Space> LayoutLeft
 
-Constructors
-~~~~~~~~~~~~
+   .. rubric:: Public Nested Typedefs
 
-.. cppkokkos:kokkosinlinefunction:: BAnd(value_type& value_);
+   .. cppkokkos:type:: reducer
 
-    * Constructs a reducer which references a local variable as its result location.
+      The self type
 
-.. cppkokkos:kokkosinlinefunction:: BAnd(const result_view_type& value_);
+   .. cppkokkos:type:: value_type
 
-    * Constructs a reducer which references a specific view as its result location.
+      The reduction scalar type.
 
-Functions
-~~~~~~~~~
+   .. cppkokkos:type:: result_view_type
 
-.. cppkokkos:kokkosinlinefunction:: void join(value_type& dest, const value_type& src) const;
+      A ``Kokkos::View`` referencing the reduction result
 
-    * Store bitwise ``and`` of ``src`` and ``dest`` into ``dest``:  ``dest = src & dest;``. 
+   .. rubric:: Constructors
 
-.. cppkokkos:kokkosinlinefunction:: void init(value_type& val) const;
+   .. cppkokkos:kokkosinlinefunction:: BAnd(value_type& value_);
 
-    * Initialize ``val`` using the ``Kokkos::reduction_identity<Scalar>::land()`` method. The default implementation sets ``val=~(0)``.
+      Constructs a reducer which references a local variable as its result location.
 
-.. cppkokkos:kokkosinlinefunction:: value_type& reference() const;
+   .. cppkokkos:kokkosinlinefunction:: BAnd(const result_view_type& value_);
 
-    * Returns a reference to the result provided in class constructor.
+      Constructs a reducer which references a specific view as its result location.
 
-.. cppkokkos:kokkosinlinefunction:: result_view_type view() const;
+   .. rubric:: Methods
 
-    * Returns a view of the result place provided in class constructor.
+   .. cppkokkos:kokkosinlinefunction:: void join(value_type& dest, const value_type& src) const;
+
+      Store bitwise ``and`` of ``src`` and ``dest`` into ``dest``:  ``dest = src & dest;``.
+
+   .. cppkokkos:kokkosinlinefunction:: void init(value_type& val) const;
+
+      Initialize ``val`` using the ``Kokkos::reduction_identity<Scalar>::land()`` method. The default implementation sets ``val=~(0)``.
+
+   .. cppkokkos:kokkosinlinefunction:: value_type& reference() const;
+
+      Returns a reference to the result provided in class constructor.
+
+   .. cppkokkos:kokkosinlinefunction:: result_view_type view() const;
+
+      Returns a view of the result place provided in class constructor.
+
 
 Additional Information
 ~~~~~~~~~~~~~~~~~~~~~~
 
 * ``BAnd<T,S>::value_type`` is non-const ``T``
+
 * ``BAnd<T,S>::result_view_type`` is ``Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>``. Note that the S (memory space) must be the same as the space where the result resides.
-* Requires: ``Scalar`` has ``operator =`` and ``operator &`` defined. ``Kokkos::reduction_identity<Scalar>::band()`` is a valid expression. 
+
+* Requires: ``Scalar`` has ``operator =`` and ``operator &`` defined. ``Kokkos::reduction_identity<Scalar>::band()`` is a valid expression.
+
 * In order to use BAnd with a custom type, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined. See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details


### PR DESCRIPTION
fix `BAnd` according to #397 

| before | after |
| ------ | ----- | 
| <img width="883" alt="image" src="https://github.com/kokkos/kokkos-core-wiki/assets/18708772/cdf8e35d-5fa9-4c55-97ff-766a69bcc897"> | <img width="890" alt="image" src="https://github.com/kokkos/kokkos-core-wiki/assets/18708772/e6e78eee-0361-4828-9eae-28798b324ea7"> | 
| <img width="718" alt="image" src="https://github.com/kokkos/kokkos-core-wiki/assets/18708772/28d2a811-0c20-4b05-bf59-d137c2222486"> | <img width="721" alt="image" src="https://github.com/kokkos/kokkos-core-wiki/assets/18708772/87804433-77de-4c47-ba5d-2496c939b452">  | 
| <img width="732" alt="image" src="https://github.com/kokkos/kokkos-core-wiki/assets/18708772/e5359d1c-c31f-4563-b9a9-9e522df5f220"> |  <img width="699" alt="image" src="https://github.com/kokkos/kokkos-core-wiki/assets/18708772/0b1216ea-d808-42c8-8643-b9b4776514c9"> | 


 