### PR TITLE
Fix "Invalid C++ declaration: Expected end of definition." warning

### DIFF
--- a/docs/source/API/core/utilities/complex.rst
+++ b/docs/source/API/core/utilities/complex.rst
@@ -32,7 +32,9 @@ Description
 
    .. rubric:: Private Members
 
-   .. cppkokkos:member:: value_type im, re
+   .. cppkokkos:member:: value_type im
+
+   .. cppkokkos:member:: value_type re
 
       Private data members representing the real and the imaginary parts.
 


### PR DESCRIPTION
Related to #378

| Before | After |
|----------|--------|
| ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/c53f0950-01ff-4dd6-a6ad-4e9edcd1b32b) | ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/f2c27129-13ae-42da-b5b8-23542f047a2c) |


