### PR TITLE
use proper sphinx class syntax for `BOr`

### DIFF
--- a/docs/source/API/core/builtinreducers/BOr.rst
+++ b/docs/source/API/core/builtinreducers/BOr.rst
@@ -56,43 +56,43 @@ Interface
 
    .. cppkokkos:type:: reducer
 
-     The self type
+      The self type
 
    .. cppkokkos:type:: value_type
 
-     The reduction scalar type.
+      The reduction scalar type.
 
    .. cppkokkos:type:: result_view_type
 
-     A ``Kokkos::View`` referencing the reduction result
+      A ``Kokkos::View`` referencing the reduction result
 
    .. rubric:: Constructors
 
    .. cppkokkos:kokkosinlinefunction:: BOr(value_type& value_);
 
-     Constructs a reducer which references a local variable as its result location.
+      Constructs a reducer which references a local variable as its result location.
 
    .. cppkokkos:kokkosinlinefunction:: BOr(const result_view_type& value_);
 
-     Constructs a reducer which references a specific view as its result location.
+      Constructs a reducer which references a specific view as its result location.
 
    .. rubric:: Public Member Functions
 
    .. cppkokkos:kokkosinlinefunction:: void join(value_type& dest, const value_type& src) const;
 
-     Store logical ``or`` of ``src`` and ``dest`` into ``dest``:  ``dest = src | dest;``.
+      Store logical ``or`` of ``src`` and ``dest`` into ``dest``:  ``dest = src | dest;``.
 
    .. cppkokkos:kokkosinlinefunction:: void init(value_type& val) const;
 
-     Initialize ``val`` using the ``Kokkos::reduction_identity<Scalar>::land()`` method. The default implementation sets ``val=0``.
+      Initialize ``val`` using the ``Kokkos::reduction_identity<Scalar>::land()`` method. The default implementation sets ``val=0``.
 
    .. cppkokkos:kokkosinlinefunction:: value_type& reference() const;
 
-     Returns a reference to the result provided in class constructor.
+      Returns a reference to the result provided in class constructor.
 
    .. cppkokkos:kokkosinlinefunction:: result_view_type view() const;
 
-     Returns a view of the result place provided in class constructor.
+      Returns a view of the result place provided in class constructor.
 
 Additional Information
 ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
fix `BOr` according to #397 

| before | after |
| ------ | ----- | 
| ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/d19b8719-4938-4391-9861-cf260b344e6b) | ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/29db3346-dcea-4497-92e1-81fad4ff2dfc) |
| ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/b6a03506-dead-457c-bdbe-c2d4d222130b) | ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/ca352e7b-c995-4abf-b5ea-b893c9e62e5b) |
| ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/0fb2ff7d-8a0e-4b00-8555-5fda57a3cf77) | ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/a3de00b1-d66f-406c-b49c-90f36c18e376) |
