### PR TITLE
use proper sphinx class syntax for `LAnd`

### DIFF
--- a/docs/source/API/core/builtinreducers/LAnd.rst
+++ b/docs/source/API/core/builtinreducers/LAnd.rst
@@ -27,7 +27,7 @@ Synopsis
             typedef LAnd reducer;
             typedef typename std::remove_cv<Scalar>::type value_type;
             typedef Kokkos::View<value_type, Space> result_view_type;
-            
+
             KOKKOS_INLINE_FUNCTION
             void join(value_type& dest, const value_type& src) const;
 
@@ -47,51 +47,61 @@ Synopsis
             LAnd(const result_view_type& value_);
     };
 
+Interface
+---------
 
-Public Class Members
---------------------
+.. cppkokkos:class:: template<class Scalar, class Space> LAnd
 
-Typedefs
-~~~~~~~~
+    .. rubric:: Public Types
 
-* ``reducer``: The self type.
-* ``value_type``: The reduction scalar type.
-* ``result_view_type``: A ``Kokkos::View`` referencing the reduction result 
+    .. cppkokkos:type:: reducer
 
-Constructors
-~~~~~~~~~~~~
- 
-.. cppkokkos:kokkosinlinefunction:: LAnd(value_type& value_);
+        The self type
 
-    * Constructs a reducer which references a local variable as its result location.
+    .. cppkokkos:type:: value_type
 
-.. cppkokkos:kokkosinlinefunction:: LAnd(const result_view_type& value_);
+        The reduction scalar type.
 
-    * Constructs a reducer which references a specific view as its result location.
+    .. cppkokkos:type:: result_view_type
 
-Functions
-~~~~~~~~~
+        A ``Kokkos::View`` referencing the reduction result
 
-.. cppkokkos:kokkosinlinefunction:: void join(value_type& dest, const value_type& src) const;
+    .. rubric:: Constructors
 
-    * Store logical ``and`` of ``src`` and ``dest`` into ``dest``:  ``dest = src && dest;``.
+    .. cppkokkos:kokkosinlinefunction:: LAnd(value_type& value_);
 
-.. cppkokkos:kokkosinlinefunction:: void init(value_type& val) const;
+        Constructs a reducer which references a local variable as its result location.
 
-    * Initialize ``val`` using the ``Kokkos::reduction_identity<Scalar>::land()`` method. The default implementation sets ``val=1``.
+    .. cppkokkos:kokkosinlinefunction:: LAnd(const result_view_type& value_);
 
-.. cppkokkos:kokkosinlinefunction:: value_type& reference() const;
+        Constructs a reducer which references a specific view as its result location.
 
-    * Returns a reference to the result provided in class constructor.
+    .. rubric:: Public Member Functions
 
-.. cppkokkos:kokkosinlinefunction:: result_view_type view() const;
+    .. cppkokkos:kokkosinlinefunction:: void join(value_type& dest, const value_type& src) const;
 
-    * Returns a view of the result place provided in class constructor.
+        Store logical ``and`` of ``src`` and ``dest`` into ``dest``:  ``dest = src && dest;``.
+
+    .. cppkokkos:kokkosinlinefunction:: void init(value_type& val) const;
+
+        Initialize ``val`` using the ``Kokkos::reduction_identity<Scalar>::land()`` method. The default implementation sets ``val=1``.
+
+    .. cppkokkos:kokkosinlinefunction:: value_type& reference() const;
+
+        Returns a reference to the result provided in class constructor.
+
+    .. cppkokkos:kokkosinlinefunction:: result_view_type view() const;
+
+        Returns a view of the result place provided in class constructor.
+
 
 Additional Information
 ~~~~~~~~~~~~~~~~~~~~~~
 
 * ``LAnd<T,S>::value_type`` is non-const ``T``
+
 * ``LAnd<T,S>::result_view_type`` is ``Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>``. Note that the S (memory space) must be the same as the space where the result resides.
+
 * Requires: ``Scalar`` has ``operator =`` and ``operator &&`` defined. ``Kokkos::reduction_identity<Scalar>::land()`` is a valid expression. 
+
 * In order to use LAnd with a custom type, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined.  See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details


### PR DESCRIPTION
fix `LAnd` according to #397 

| before | after |
| ------ | ----- | 
| ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/a592127c-74b1-4d88-baa6-426b8e131c72) | ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/10a14d24-6c6b-4f34-a5ff-88a1b0df1bd6) |
| ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/874b6b17-cf74-45ce-a326-c596aa377aeb) | ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/64f9d868-a7f1-4ed6-9c27-c47c30bc7fb3) |
| ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/14d0a085-e557-4b3d-b0c2-32c7a12b8a60) | ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/482ddee9-5291-46ba-bd26-fbbc42322f55) |

