### PR TITLE
use proper sphinx class syntax for `Max`

### DIFF
--- a/docs/source/API/core/builtinreducers/Max.rst
+++ b/docs/source/API/core/builtinreducers/Max.rst
@@ -47,50 +47,60 @@ Synopsis
             Max(const result_view_type& value_);
     };
 
-Public Class Members
---------------------
+Interface
+---------
 
-Typedefs
-~~~~~~~~
-   
-* ``reducer``: The self type.
-* ``value_type``: The reduction scalar type.
-* ``result_view_type``: A ``Kokkos::View`` referencing the reduction result 
+.. cppkokkos:class:: template<class Scalar, class Space> Max
 
-Constructors
-~~~~~~~~~~~~
- 
-.. cppkokkos:kokkosinlinefunction:: Max(value_type& value_);
+    .. rubric:: Public Types
 
-    * Constructs a reducer which references a local variable as its result location.
+    .. cppkokkos:type:: reducer
 
-.. cppkokkos:kokkosinlinefunction:: Max(const result_view_type& value_);
+        The self type.
 
-    * Constructs a reducer which references a specific view as its result location.
+    .. cppkokkos:type:: value_type
 
-Functions
-~~~~~~~~~
+        The reduction scalar type.
 
-.. cppkokkos:kokkosinlinefunction:: void join(value_type& dest, const value_type& src) const;
+    .. cppkokkos:type:: result_view_type
+        
+        A ``Kokkos::View`` referencing the reduction result 
 
-    * Store maximum of ``src`` and ``dest`` into ``dest``: ``dest = ( src > dest ) ? src :dest;``. 
+    .. rubric:: Constructors
 
-.. cppkokkos:kokkosinlinefunction:: void init(value_type& val) const;
+    .. cppkokkos:kokkosinlinefunction:: Max(value_type& value_);
 
-    * Initialize ``val`` using the ``Kokkos::reduction_identity<Scalar>::max()`` method. The default implementation sets ``val=<TYPE>_MIN``.
+        Constructs a reducer which references a local variable as its result location.
 
-.. cppkokkos:kokkosinlinefunction:: value_type& reference() const;
+    .. cppkokkos:kokkosinlinefunction:: Max(const result_view_type& value_);
 
-    * Returns a reference to the result provided in class constructor.
+        Constructs a reducer which references a specific view as its result location.
 
-.. cppkokkos:kokkosinlinefunction:: result_view_type view() const;
+    .. rubric:: Public Member Functions
 
-    * Returns a view of the result place provided in class constructor.
+    .. cppkokkos:kokkosinlinefunction:: void join(value_type& dest, const value_type& src) const;
+
+        Store maximum of ``src`` and ``dest`` into ``dest``: ``dest = ( src > dest ) ? src :dest;``. 
+
+    .. cppkokkos:kokkosinlinefunction:: void init(value_type& val) const;
+
+        Initialize ``val`` using the ``Kokkos::reduction_identity<Scalar>::max()`` method. The default implementation sets ``val=<TYPE>_MIN``.
+
+    .. cppkokkos:kokkosinlinefunction:: value_type& reference() const;
+
+        Returns a reference to the result provided in class constructor.
+
+    .. cppkokkos:kokkosinlinefunction:: result_view_type view() const;
+
+        Returns a view of the result place provided in class constructor.
 
 Additional Information
 ~~~~~~~~~~~~~~~~~~~~~~
 
 * ``Max<T,S>::value_type`` is non-const ``T``
+
 * ``Max<T,S>::result_view_type`` is ``Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>``. Note that the S (memory space) must be the same as the space where the result resides.
+
 * Requires: ``Scalar`` has ``operator =`` and ``operator >`` defined. ``Kokkos::reduction_identity<Scalar>::max()`` is a valid expression. 
+
 * In order to use Max with a custom type, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined.  See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details

--- a/docs/source/API/core/builtinreducers/Max.rst
+++ b/docs/source/API/core/builtinreducers/Max.rst
@@ -13,94 +13,94 @@ Usage
 
 .. code-block:: cpp
 
-    T result;
-    parallel_reduce(N,Functor,Max<T,S>(result));
+   T result;
+   parallel_reduce(N,Functor,Max<T,S>(result));
 
 Synopsis
 --------
 
 .. code-block:: cpp
 
-    template<class Scalar, class Space>
-    class Max{
-        public:
-            typedef Max reducer;
-            typedef typename std::remove_cv<Scalar>::type value_type;
-            typedef Kokkos::View<value_type, Space> result_view_type;
-            
-            KOKKOS_INLINE_FUNCTION
-            void join(value_type& dest, const value_type& src) const;
+   template<class Scalar, class Space>
+   class Max{
+     public:
+       typedef Max reducer;
+       typedef typename std::remove_cv<Scalar>::type value_type;
+       typedef Kokkos::View<value_type, Space> result_view_type;
 
-            KOKKOS_INLINE_FUNCTION
-            void init(value_type& val) const;
+       KOKKOS_INLINE_FUNCTION
+       void join(value_type& dest, const value_type& src) const;
 
-            KOKKOS_INLINE_FUNCTION
-            value_type& reference() const;
+       KOKKOS_INLINE_FUNCTION
+       void init(value_type& val) const;
 
-            KOKKOS_INLINE_FUNCTION
-            result_view_type view() const;
+       KOKKOS_INLINE_FUNCTION
+       value_type& reference() const;
 
-            KOKKOS_INLINE_FUNCTION
-            Max(value_type& value_);
+       KOKKOS_INLINE_FUNCTION
+       result_view_type view() const;
 
-            KOKKOS_INLINE_FUNCTION
-            Max(const result_view_type& value_);
-    };
+       KOKKOS_INLINE_FUNCTION
+       Max(value_type& value_);
+
+       KOKKOS_INLINE_FUNCTION
+       Max(const result_view_type& value_);
+   };
 
 Interface
 ---------
 
 .. cppkokkos:class:: template<class Scalar, class Space> Max
 
-    .. rubric:: Public Types
+   .. rubric:: Public Types
 
-    .. cppkokkos:type:: reducer
+   .. cppkokkos:type:: reducer
 
-        The self type.
+      The self type.
 
-    .. cppkokkos:type:: value_type
+   .. cppkokkos:type:: value_type
 
-        The reduction scalar type.
+      The reduction scalar type.
 
-    .. cppkokkos:type:: result_view_type
-        
-        A ``Kokkos::View`` referencing the reduction result 
+   .. cppkokkos:type:: result_view_type
 
-    .. rubric:: Constructors
+      A ``Kokkos::View`` referencing the reduction result
 
-    .. cppkokkos:kokkosinlinefunction:: Max(value_type& value_);
+   .. rubric:: Constructors
 
-        Constructs a reducer which references a local variable as its result location.
+   .. cppkokkos:kokkosinlinefunction:: Max(value_type& value_);
 
-    .. cppkokkos:kokkosinlinefunction:: Max(const result_view_type& value_);
+      Constructs a reducer which references a local variable as its result location.
 
-        Constructs a reducer which references a specific view as its result location.
+   .. cppkokkos:kokkosinlinefunction:: Max(const result_view_type& value_);
 
-    .. rubric:: Public Member Functions
+      Constructs a reducer which references a specific view as its result location.
 
-    .. cppkokkos:kokkosinlinefunction:: void join(value_type& dest, const value_type& src) const;
+   .. rubric:: Public Member Functions
 
-        Store maximum of ``src`` and ``dest`` into ``dest``: ``dest = ( src > dest ) ? src :dest;``. 
+   .. cppkokkos:kokkosinlinefunction:: void join(value_type& dest, const value_type& src) const;
 
-    .. cppkokkos:kokkosinlinefunction:: void init(value_type& val) const;
+      Store maximum of ``src`` and ``dest`` into ``dest``: ``dest = ( src > dest ) ? src :dest;``.
 
-        Initialize ``val`` using the ``Kokkos::reduction_identity<Scalar>::max()`` method. The default implementation sets ``val=<TYPE>_MIN``.
+   .. cppkokkos:kokkosinlinefunction:: void init(value_type& val) const;
 
-    .. cppkokkos:kokkosinlinefunction:: value_type& reference() const;
+      Initialize ``val`` using the ``Kokkos::reduction_identity<Scalar>::max()`` method. The default implementation sets ``val=<TYPE>_MIN``.
 
-        Returns a reference to the result provided in class constructor.
+   .. cppkokkos:kokkosinlinefunction:: value_type& reference() const;
 
-    .. cppkokkos:kokkosinlinefunction:: result_view_type view() const;
+      Returns a reference to the result provided in class constructor.
 
-        Returns a view of the result place provided in class constructor.
+   .. cppkokkos:kokkosinlinefunction:: result_view_type view() const;
+
+      Returns a view of the result place provided in class constructor.
 
 Additional Information
-~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^
 
 * ``Max<T,S>::value_type`` is non-const ``T``
 
 * ``Max<T,S>::result_view_type`` is ``Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>``. Note that the S (memory space) must be the same as the space where the result resides.
 
-* Requires: ``Scalar`` has ``operator =`` and ``operator >`` defined. ``Kokkos::reduction_identity<Scalar>::max()`` is a valid expression. 
+* Requires: ``Scalar`` has ``operator =`` and ``operator >`` defined. ``Kokkos::reduction_identity<Scalar>::max()`` is a valid expression.
 
 * In order to use Max with a custom type, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined.  See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details


### PR DESCRIPTION
fix `Max` according to #397 

| before | after |
| ------ | ----- | 
| ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/1d9a2888-14d0-41d7-91e7-3ca9ed9de422) | ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/508824cd-51f4-4d57-9430-b1d788bb26d3) |
| ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/1430240a-fc41-4406-b2e8-0da9133a9f6b) | ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/d788a007-a693-4d13-9446-8eba3cc2870c) |
| ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/2328cb77-d51f-43da-afe1-434495e83374) | ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/05363ecb-b79a-4af0-b1ef-be54ff45ba91) |
