### PR TITLE
use proper sphinx class syntax for `Min`

### DIFF
--- a/docs/source/API/core/builtinreducers/Min.rst
+++ b/docs/source/API/core/builtinreducers/Min.rst
@@ -13,84 +13,94 @@ Usage
 
 .. code-block:: cpp
 
-    T result;
-    parallel_reduce(N,Functor,Min<T,S>(result));
+   T result;
+   parallel_reduce(N,Functor,Min<T,S>(result));
 
-Synopsis 
+Synopsis
 --------
 
 .. code-block:: cpp
 
-    template<class Scalar, class Space>
-    class Min{
-        public:
-            typedef Min reducer;
-            typedef typename std::remove_cv<Scalar>::type value_type;
-            typedef Kokkos::View<value_type, Space> result_view_type;
-            
-            KOKKOS_INLINE_FUNCTION
-            void join(value_type& dest, const value_type& src) const;
+   template<class Scalar, class Space>
+   class Min{
+     public:
+       typedef Min reducer;
+       typedef typename std::remove_cv<Scalar>::type value_type;
+       typedef Kokkos::View<value_type, Space> result_view_type;
 
-            KOKKOS_INLINE_FUNCTION
-            void init(value_type& val) const;
+       KOKKOS_INLINE_FUNCTION
+       void join(value_type& dest, const value_type& src) const;
 
-            KOKKOS_INLINE_FUNCTION
-            value_type& reference() const;
+       KOKKOS_INLINE_FUNCTION
+       void init(value_type& val) const;
 
-            KOKKOS_INLINE_FUNCTION
-            result_view_type view() const;
+       KOKKOS_INLINE_FUNCTION
+       value_type& reference() const;
 
-            KOKKOS_INLINE_FUNCTION
-            Min(value_type& value_);
+       KOKKOS_INLINE_FUNCTION
+       result_view_type view() const;
 
-            KOKKOS_INLINE_FUNCTION
-            Min(const result_view_type& value_);
-    };
+       KOKKOS_INLINE_FUNCTION
+       Min(value_type& value_);
 
-Public Class Members
---------------------
+       KOKKOS_INLINE_FUNCTION
+       Min(const result_view_type& value_);
+   };
 
-Typedefs
-~~~~~~~~
-   
-* ``reducer``: The self type.
-* ``value_type``: The reduction scalar type.
-* ``result_view_type``: A ``Kokkos::View`` referencing the reduction result 
+Interface
+---------
 
-Constructors
-~~~~~~~~~~~~
+.. cppkokkos:class:: template<class Scalar, class Space> Min
 
-.. cppkokkos:kokkosinlinefunction:: Min(value_type& value_);
+   .. rubric:: Public Types
 
-    * Constructs a reducer which references a local variable as its result location.  
+   .. cppkokkos:type:: reducer
 
-.. cppkokkos:kokkosinlinefunction:: Min(const result_view_type& value_);
+      The self type
 
-    * Constructs a reducer which references a specific view as its result location.
+   .. cppkokkos:type:: value_type
 
-Functions
-~~~~~~~~~
+      The reduction scalar type.
 
-.. cppkokkos:kokkosinlinefunction:: void join(value_type& dest, const value_type& src) const;
+   .. cppkokkos:type:: result_view_type
 
-    * Store minimum of ``src`` and ``dest`` into ``dest``:  ``dest = (src < dest) ? src :dest;``. 
+      A ``Kokkos::View`` referencing the reduction result
 
-.. cppkokkos:kokkosinlinefunction:: void init(value_type& val) const;
+   .. rubric:: Constructors
 
-    * Initialize ``val`` using the ``Kokkos::reduction_identity<Scalar>::min()`` method. The default implementation sets ``val=<TYPE>_MAX``.
+   .. cppkokkos:kokkosinlinefunction:: Min(value_type& value_);
 
-.. cppkokkos:kokkosinlinefunction:: value_type& reference() const;
+      Constructs a reducer which references a local variable as its result location.
 
-    * Returns a reference to the result provided in class constructor.
+   .. cppkokkos:kokkosinlinefunction:: Min(const result_view_type& value_);
 
-.. cppkokkos:kokkosinlinefunction:: result_view_type view() const;
+      Constructs a reducer which references a specific view as its result location.
 
-    * Returns a view of the result place provided in class constructor.
+   .. rubric:: Public Member Functions
+
+   .. cppkokkos:kokkosinlinefunction:: void join(value_type& dest, const value_type& src) const;
+
+      Store minimum of ``src`` and ``dest`` into ``dest``:  ``dest = (src < dest) ? src :dest;``.
+
+   .. cppkokkos:kokkosinlinefunction:: void init(value_type& val) const;
+
+      Initialize ``val`` using the ``Kokkos::reduction_identity<Scalar>::min()`` method. The default implementation sets ``val=<TYPE>_MAX``.
+
+   .. cppkokkos:kokkosinlinefunction:: value_type& reference() const;
+
+      Returns a reference to the result provided in class constructor.
+
+   .. cppkokkos:kokkosinlinefunction:: result_view_type view() const;
+
+      Returns a view of the result place provided in class constructor.
 
 Additional Information
-~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^
 
 * ``Min<T,S>::value_type`` is non-const ``T``
+
 * ``Min<T,S>::result_view_type`` is ``Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>``. Note that the S (memory space) must be the same as the space where the result resides.
-* Requires: ``Scalar`` has ``operator =`` and ``operator <`` defined. ``Kokkos::reduction_identity<Scalar>::min()`` is a valid expression. 
+
+* Requires: ``Scalar`` has ``operator =`` and ``operator <`` defined. ``Kokkos::reduction_identity<Scalar>::min()`` is a valid expression.
+
 * In order to use Min with a custom type, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined. See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details


### PR DESCRIPTION
fix `Min` according to #397 

| before | after |
| ------ | ----- | 
| ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/53d531e3-1c79-4891-8886-b587924bcf29) | ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/bf52cbf9-1de6-4fea-ad07-d397b4d9b34f) |
| ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/d666808d-6eb3-4ddc-b1fa-ad8bd1d9a1f1) | ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/cbc6be22-bd79-4201-9052-ef675458fb14) |
| ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/d8a42bcf-5de6-46dc-86b8-b7801cf4b6af) | ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/56807b03-b7e1-46c2-b95d-a1d8ec0854f3) |

