### PR TITLE
use proper sphinx class syntax for `MinLoc`

### DIFF
--- a/docs/source/API/core/builtinreducers/MinLoc.rst
+++ b/docs/source/API/core/builtinreducers/MinLoc.rst
@@ -13,87 +13,98 @@ Usage
 
 .. code-block:: cpp
 
-    MinLoc<T,I,S>::value_type result;
-    parallel_reduce(N,Functor,MinLoc<T,I,S>(result));
+   MinLoc<T,I,S>::value_type result;
+   parallel_reduce(N,Functor,MinLoc<T,I,S>(result));
 
-Synopsis 
+Synopsis
 --------
 
 .. code-block:: cpp
 
-    template<class Scalar, class Index, class Space>
-    class MinLoc{
-        public:
-            typedef MinLoc reducer;
-            typedef ValLocScalar<typename std::remove_cv<Scalar>::type,
-                                    typename std::remove_cv<Index>::type > value_type;
-            typedef Kokkos::View<value_type, Space> result_view_type;
-            
-            KOKKOS_INLINE_FUNCTION
-            void join(value_type& dest, const value_type& src) const;
+   template<class Scalar, class Index, class Space>
+   class MinLoc{
+     public:
+       typedef MinLoc reducer;
+       typedef ValLocScalar<typename std::remove_cv<Scalar>::type,
+                            typename std::remove_cv<Index>::type > value_type;
+       typedef Kokkos::View<value_type, Space> result_view_type;
 
-            KOKKOS_INLINE_FUNCTION
-            void init(value_type& val) const;
+       KOKKOS_INLINE_FUNCTION
+       void join(value_type& dest, const value_type& src) const;
 
-            KOKKOS_INLINE_FUNCTION
-            value_type& reference() const;
+       KOKKOS_INLINE_FUNCTION
+       void init(value_type& val) const;
 
-            KOKKOS_INLINE_FUNCTION
-            result_view_type view() const;
+       KOKKOS_INLINE_FUNCTION
+       value_type& reference() const;
 
-            KOKKOS_INLINE_FUNCTION
-            MinLoc(value_type& value_);
+       KOKKOS_INLINE_FUNCTION
+       result_view_type view() const;
 
-            KOKKOS_INLINE_FUNCTION
-            MinLoc(const result_view_type& value_);
-    };
+       KOKKOS_INLINE_FUNCTION
+       MinLoc(value_type& value_);
 
-Public Class Members
---------------------
+       KOKKOS_INLINE_FUNCTION
+       MinLoc(const result_view_type& value_);
+   };
 
-Typedefs
-~~~~~~~~
-   
-* ``reducer``: The self type.
-* ``value_type``: The reduction scalar type (specialization of `ValLocScalar <ValLocScalar.html>`_)
-* ``result_view_type``: A ``Kokkos::View`` referencing the reduction result 
+Interface
+---------
 
-Constructors
-~~~~~~~~~~~~
+.. cppkokkos:class:: template<class Scalar, class Index, class Space> MinLoc
 
-.. cppkokkos:kokkosinlinefunction:: MinLoc(value_type& value_);
+   .. rubric:: Public Types
 
-    * Constructs a reducer which references a local variable as its result location.  
+   .. cppkokkos:type:: reducer
 
-.. cppkokkos:kokkosinlinefunction:: MinLoc(const result_view_type& value_);
+      The self type.
 
-    * Constructs a reducer which references a specific view as its result location.
+   .. cppkokkos:type:: value_type
 
-Functions
-~~~~~~~~~
+      The reduction scalar type (specialization of `ValLocScalar <ValLocScalar.html>`_)
 
-.. cppkokkos:kokkosinlinefunction:: void join(value_type& dest, const value_type& src) const;
+   .. cppkokkos:type:: result_view_type
 
-    * Store minimum with index of ``src`` and ``dest`` into ``dest``:  ``dest = (src.val < dest.val) ? src :dest;``. 
+      A ``Kokkos::View`` referencing the reduction result
 
-.. cppkokkos:kokkosinlinefunction:: void init(value_type& val) const;
+   .. rubric:: Constructors
 
-    * Initialize ``val.val`` using the ``Kokkos::reduction_identity<Scalar>::min()`` method. The default implementation sets ``val=<TYPE>_MAX``.
-    * Initialize ``val.loc`` using the ``Kokkos::reduction_identity<Index>::min()`` method. The default implementation sets ``val=<TYPE>_MAX``.
+   .. cppkokkos:kokkosinlinefunction:: MinLoc(value_type& value_);
 
-.. cppkokkos:kokkosinlinefunction:: value_type& reference() const;
+      Constructs a reducer which references a local variable as its result location.
 
-    * Returns a reference to the result provided in class constructor.
+   .. cppkokkos:kokkosinlinefunction:: MinLoc(const result_view_type& value_);
 
-.. cppkokkos:kokkosinlinefunction:: result_view_type view() const;
+      Constructs a reducer which references a specific view as its result location.
 
-    * Returns a view of the result place provided in class constructor.
+   .. rubric:: Public Member Functions
+
+   .. cppkokkos:kokkosinlinefunction:: void join(value_type& dest, const value_type& src) const;
+
+      Store minimum with index of ``src`` and ``dest`` into ``dest``:  ``dest = (src.val < dest.val) ? src :dest;``.
+
+   .. cppkokkos:kokkosinlinefunction:: void init(value_type& val) const;
+
+      Initialize ``val.val`` using the ``Kokkos::reduction_identity<Scalar>::min()`` method. The default implementation sets ``val=<TYPE>_MAX``.
+      Initialize ``val.loc`` using the ``Kokkos::reduction_identity<Index>::min()`` method. The default implementation sets ``val=<TYPE>_MAX``.
+
+   .. cppkokkos:kokkosinlinefunction:: value_type& reference() const;
+
+      Returns a reference to the result provided in class constructor.
+
+   .. cppkokkos:kokkosinlinefunction:: result_view_type view() const;
+
+      Returns a view of the result place provided in class constructor.
 
 Additional Information
-~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^
 
 * ``MinLoc<T,I,S>::value_type`` is Specialization of ValLocScalar on non-const ``T`` and non-const ``I``
+
 * ``MinLoc<T,I,S>::result_view_type`` is ``Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>``. Note that the S (memory space) must be the same as the space where the result resides.
-* Requires: ``Scalar`` has ``operator =`` and ``operator <`` defined. ``Kokkos::reduction_identity<Scalar>::min()`` is a valid expression. 
-* Requires: ``Index`` has ``operator =`` defined. ``Kokkos::reduction_identity<Index>::min()`` is a valid expression. 
+
+* Requires: ``Scalar`` has ``operator =`` and ``operator <`` defined. ``Kokkos::reduction_identity<Scalar>::min()`` is a valid expression.
+
+* Requires: ``Index`` has ``operator =`` defined. ``Kokkos::reduction_identity<Index>::min()`` is a valid expression.
+
 * In order to use MinLoc with a custom type of either ``Scalar`` or ``Index``, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined. See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details


### PR DESCRIPTION
fix `MinLoc` according to #397 

| before | after |
| ------ | ----- | 
| ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/94e5de9a-e7b4-4cd5-b08f-79bf21add24b) | ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/53c81c2f-0f54-4a1f-bdf5-38e7eee79d62) |
| ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/f5966aaa-791d-4ec1-be3a-b1966e0c0916) | ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/f1459b4d-b5bd-497f-84ab-04da54a5b900) |
| ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/db839a87-d3d6-448b-82be-4689180dde43) | ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/3783e0ad-ae39-4eff-b173-98ed82b5b61b) |

