### PR TITLE
use proper sphinx class syntax for `MinMax`

### DIFF
--- a/docs/source/API/core/builtinreducers/MinMax.rst
+++ b/docs/source/API/core/builtinreducers/MinMax.rst
@@ -13,86 +13,96 @@ Usage
 
 .. code-block:: cpp
 
-    MinMax<T,S>::value_type result;
-    parallel_reduce(N,Functor,MinMax<T,S>(result));
+   MinMax<T,S>::value_type result;
+   parallel_reduce(N,Functor,MinMax<T,S>(result));
 
-Synopsis 
+Synopsis
 --------
 
 .. code-block:: cpp
 
-    template<class Scalar, class Space>
-    class MinMax{
-        public:
-            typedef MinMax reducer;
-            typedef MinMaxScalar<typename std::remove_cv<Scalar>::type> value_type;
-            typedef Kokkos::View<value_type, Space> result_view_type;
-            
-            KOKKOS_INLINE_FUNCTION
-            void join(value_type& dest, const value_type& src) const;
+   template<class Scalar, class Space>
+   class MinMax{
+     public:
+       typedef MinMax reducer;
+       typedef MinMaxScalar<typename std::remove_cv<Scalar>::type> value_type;
+       typedef Kokkos::View<value_type, Space> result_view_type;
 
-            KOKKOS_INLINE_FUNCTION
-            void init(value_type& val) const;
+       KOKKOS_INLINE_FUNCTION
+       void join(value_type& dest, const value_type& src) const;
 
-            KOKKOS_INLINE_FUNCTION
-            value_type& reference() const;
+       KOKKOS_INLINE_FUNCTION
+       void init(value_type& val) const;
 
-            KOKKOS_INLINE_FUNCTION
-            result_view_type view() const;
+       KOKKOS_INLINE_FUNCTION
+       value_type& reference() const;
 
-            KOKKOS_INLINE_FUNCTION
-            MinMax(value_type& value_);
+       KOKKOS_INLINE_FUNCTION
+       result_view_type view() const;
 
-            KOKKOS_INLINE_FUNCTION
-            MinMax(const result_view_type& value_);
-    };
+       KOKKOS_INLINE_FUNCTION
+       MinMax(value_type& value_);
 
-Public Class Members
---------------------
+       KOKKOS_INLINE_FUNCTION
+       MinMax(const result_view_type& value_);
+   };
 
-Typedefs
-~~~~~~~~
-   
-* ``reducer``: The self type.
-* ``value_type``: The reduction scalar type (specialization of `MinMaxScalar <MinMaxScalar.html>`_)
-* ``result_view_type``: A ``Kokkos::View`` referencing the reduction result 
+Interface
+---------
 
-Constructors
-~~~~~~~~~~~~
- 
-.. cppkokkos:kokkosinlinefunction:: MinMax(value_type& value_);
+.. cppkokkos:class:: template<class Scalar, class Space> MinMax
 
-    * Constructs a reducer which references a local variable as its result location.  
+   .. rubric:: Public Types
 
-.. cppkokkos:kokkosinlinefunction:: MinMax(const result_view_type& value_);
+   .. cppkokkos:type:: reducer
 
-    * Constructs a reducer which references a specific view as its result location.
+      The self type.
 
-Functions
-~~~~~~~~~
+   .. cppkokkos:type:: value_type
 
-.. cppkokkos:kokkosinlinefunction:: void join(value_type& dest, const value_type& src) const;
+      The reduction scalar type (specialization of `MinMaxScalar <MinMaxScalar.html>`_)
 
-    * Store minimum of ``src`` and ``dest`` into ``dest``:  ``dest.min_val = (src.min_val < dest.min_val) ? src.min_val :dest.min_val;``.
-    * Store maximum of ``src`` and ``dest`` into ``dest``:  ``dest.max_val = (src.max_val < dest.max_val) ? src.max_val :dest.max_val;``.
- 
-.. cppkokkos:kokkosinlinefunction:: void init(value_type& val) const;
+   .. cppkokkos:type:: result_view_type
 
-    * Initialize ``val.min_val`` using the ``Kokkos::reduction_identity<Scalar>::min()`` method. The default implementation sets ``val=<TYPE>_MAX``.
-    * Initialize ``val.max_val`` using the ``Kokkos::reduction_identity<Index>::max()`` method. The default implementation sets ``val=<TYPE>_MIN``.
+      A ``Kokkos::View`` referencing the reduction result
 
-.. cppkokkos:kokkosinlinefunction:: value_type& reference() const;
+   .. rubric:: Constructors
 
-    * Returns a reference to the result provided in class constructor.
+   .. cppkokkos:kokkosinlinefunction:: MinMax(value_type& value_);
 
-.. cppkokkos:kokkosinlinefunction:: result_view_type view() const;
+      Constructs a reducer which references a local variable as its result location.
 
-    * Returns a view of the result place provided in class constructor.
+   .. cppkokkos:kokkosinlinefunction:: MinMax(const result_view_type& value_);
+
+      Constructs a reducer which references a specific view as its result location.
+
+   .. rubric:: Public Member Functions
+
+   .. cppkokkos:kokkosinlinefunction:: void join(value_type& dest, const value_type& src) const;
+
+      Store minimum of ``src`` and ``dest`` into ``dest``:  ``dest.min_val = (src.min_val < dest.min_val) ? src.min_val :dest.min_val;``.
+      Store maximum of ``src`` and ``dest`` into ``dest``:  ``dest.max_val = (src.max_val < dest.max_val) ? src.max_val :dest.max_val;``.
+
+   .. cppkokkos:kokkosinlinefunction:: void init(value_type& val) const;
+
+      Initialize ``val.min_val`` using the ``Kokkos::reduction_identity<Scalar>::min()`` method. The default implementation sets ``val=<TYPE>_MAX``.
+      Initialize ``val.max_val`` using the ``Kokkos::reduction_identity<Index>::max()`` method. The default implementation sets ``val=<TYPE>_MIN``.
+
+   .. cppkokkos:kokkosinlinefunction:: value_type& reference() const;
+
+      Returns a reference to the result provided in class constructor.
+
+   .. cppkokkos:kokkosinlinefunction:: result_view_type view() const;
+
+      Returns a view of the result place provided in class constructor.
 
 Additional Information
-~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^
 
 * ``MinMax<T,S>::value_type`` is Specialization of MinMaxScalar on non-const ``T``
+
 * ``MinMax<T,S>::result_view_type`` is ``Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>``. Note that the S (memory space) must be the same as the space where the result resides.
-* Requires: ``Scalar`` has ``operator =``, ``operator <`` and ``operator >`` defined. ``Kokkos::reduction_identity<Scalar>::min()`` and ``Kokkos::reduction_identity<Scalar>::max()`` are a valid expressions. 
+
+* Requires: ``Scalar`` has ``operator =``, ``operator <`` and ``operator >`` defined. ``Kokkos::reduction_identity<Scalar>::min()`` and ``Kokkos::reduction_identity<Scalar>::max()`` are a valid expressions.
+
 * In order to use MinMax with a custom type of ``Scalar``, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined.  See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details


### PR DESCRIPTION
fix `MinMax` according to #397 

| before | after |
| ------ | ----- | 
| ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/872491ec-af86-4768-b2ad-34b507a296ec) | ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/06fa9d63-dc0a-49a3-b85f-dd0a1df5d049) |
|![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/64a347a1-fc73-4a22-ad25-df4c37a44211) | ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/91f90d8c-1951-4fdb-9a11-1f965054cb17) |
| ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/c2af4a55-4c9f-42b1-8400-f2fcdb99d677) | ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/c2d6c7a0-adb0-437f-b917-24d4e07d85f2) |
