### PR TITLE
use proper sphinx class syntax for `MinMaxLoc`

### DIFF
--- a/docs/source/API/core/builtinreducers/MinMaxLoc.rst
+++ b/docs/source/API/core/builtinreducers/MinMaxLoc.rst
@@ -1,9 +1,6 @@
 ``MinMaxLoc``
 =============
 
-.. role::cpp(code)
-    :language: cpp
-
 .. role:: cppkokkos(code)
     :language: cppkokkos
 
@@ -15,94 +12,105 @@ Usage
 -----
 
 .. code-block:: cpp
-        
-    MinMaxLoc<T,I,S>::value_type result;
-    parallel_reduce(N,Functor,MinMaxLoc<T,I,S>(result));
 
-Synopsis 
+   MinMaxLoc<T,I,S>::value_type result;
+   parallel_reduce(N,Functor,MinMaxLoc<T,I,S>(result));
+
+Synopsis
 --------
 
 .. code-block:: cpp
 
-    template<class Scalar, class Space>
-    class MinMaxLoc{
-        public:
-            typedef MinMaxLoc reducer;
-            typedef MinMaxLocScalar<typename std::remove_cv<Scalar>::type,
-                                    typename std::remove_cv<Index>::type> value_type;
-            typedef Kokkos::View<value_type, Space> result_view_type;
-            
-            KOKKOS_INLINE_FUNCTION
-            void join(value_type& dest, const value_type& src) const;
+   template<class Scalar, class Space>
+   class MinMaxLoc{
+     public:
+       typedef MinMaxLoc reducer;
+       typedef MinMaxLocScalar<typename std::remove_cv<Scalar>::type,
+                               typename std::remove_cv<Index>::type> value_type;
+       typedef Kokkos::View<value_type, Space> result_view_type;
 
-            KOKKOS_INLINE_FUNCTION
-            void init(value_type& val) const;
+       KOKKOS_INLINE_FUNCTION
+       void join(value_type& dest, const value_type& src) const;
 
-            KOKKOS_INLINE_FUNCTION
-            value_type& reference() const;
+       KOKKOS_INLINE_FUNCTION
+       void init(value_type& val) const;
 
-            KOKKOS_INLINE_FUNCTION
-            result_view_type view() const;
+       KOKKOS_INLINE_FUNCTION
+       value_type& reference() const;
 
-            KOKKOS_INLINE_FUNCTION
-            MinMaxLoc(value_type& value_);
+       KOKKOS_INLINE_FUNCTION
+       result_view_type view() const;
 
-            KOKKOS_INLINE_FUNCTION
-            MinMaxLoc(const result_view_type& value_);
-    };
+       KOKKOS_INLINE_FUNCTION
+       MinMaxLoc(value_type& value_);
 
-Public Class Members
---------------------
+       KOKKOS_INLINE_FUNCTION
+       MinMaxLoc(const result_view_type& value_);
+   };
 
-Typedefs
-~~~~~~~~
+Interface
+---------
 
-* ``reducer``: The self type.
-* ``value_type``: The reduction scalar type (specialization of `MinMaxLocScalar <MinMaxLocScalar.html>`_)
-* ``result_view_type``: A ``Kokkos::View`` referencing the reduction result 
+.. cppkokkos:class:: template<class Scalar, class Space> MinMaxLoc
 
-Constructors
-~~~~~~~~~~~~
+   .. rubric:: Public Types
 
-.. cppkokkos:kokkosinlinefunction:: MinMaxLoc(value_type& value_);
+   .. cppkokkos:type:: reducer
 
-    * Constructs a reducer which references a local variable as its result location.  
+      The self type
 
-.. cppkokkos:kokkosinlinefunction:: MinMaxLoc(const result_view_type& value_);
+   .. cppkokkos:type:: value_type
 
-    * Constructs a reducer which references a specific view as its result location.
+      The reduction scalar type (specialization of `MinMaxLocScalar <MinMaxLocScalar.html>`_)
 
-Functions
-~~~~~~~~~
+   .. cppkokkos:type:: result_view_type
 
-.. cppkokkos:kokkosinlinefunction:: void join(value_type& dest, const value_type& src) const;
-   
-    * Store minimum with location of ``src`` and ``dest`` into ``dest``.
-    * Store maximum with location of ``src`` and ``dest`` into ``dest``.
+      A ``Kokkos::View`` referencing the reduction result
 
-.. cppkokkos:kokkosinlinefunction:: void init( value_type& val) const;
+   .. rubric:: Constructors
 
-    Initialize ``val.min_val`` using the ``Kokkos::reduction_identity<Scalar>::min()`` method. The default implementation sets ``val=<TYPE>_MAX``.
+   .. cppkokkos:kokkosinlinefunction:: MinMaxLoc(value_type& value_);
 
-    Initialize ``val.max_val`` using the ``Kokkos::reduction_identity<Index>::max()`` method. The default implementation sets ``val=<TYPE>_MIN``.
+      Constructs a reducer which references a local variable as its result location.
 
-    Initialize ``val.min_loc`` using the ``Kokkos::reduction_identity<Scalar>::min()`` method. The default implementation sets ``val=<TYPE>_MAX``.
+   .. cppkokkos:kokkosinlinefunction:: MinMaxLoc(const result_view_type& value_);
 
-    Initialize ``val.max_loc`` using the ``Kokkos::reduction_identity<Index>::max()`` method. The default implementation sets ``val=<TYPE>_MAX``.
+      Constructs a reducer which references a specific view as its result location.
 
-.. cppkokkos:kokkosinlinefunction:: value_type& reference() const;
+   .. rubric:: Public Member Functions
 
-    * Returns a reference to the result provided in class constructor.
+   .. cppkokkos:kokkosinlinefunction:: void join(value_type& dest, const value_type& src) const;
 
-.. cppkokkos:kokkosinlinefunction:: result_view_type view() const;
+      Store minimum with location of ``src`` and ``dest`` into ``dest``.
+      Store maximum with location of ``src`` and ``dest`` into ``dest``.
 
-    * Returns a view of the result place provided in class constructor.
+   .. cppkokkos:kokkosinlinefunction:: void init( value_type& val) const;
+
+      Initialize ``val.min_val`` using the ``Kokkos::reduction_identity<Scalar>::min()`` method. The default implementation sets ``val=<TYPE>_MAX``.
+
+      Initialize ``val.max_val`` using the ``Kokkos::reduction_identity<Index>::max()`` method. The default implementation sets ``val=<TYPE>_MIN``.
+
+      Initialize ``val.min_loc`` using the ``Kokkos::reduction_identity<Scalar>::min()`` method. The default implementation sets ``val=<TYPE>_MAX``.
+
+      Initialize ``val.max_loc`` using the ``Kokkos::reduction_identity<Index>::max()`` method. The default implementation sets ``val=<TYPE>_MAX``.
+
+   .. cppkokkos:kokkosinlinefunction:: value_type& reference() const;
+
+      Returns a reference to the result provided in class constructor.
+
+   .. cppkokkos:kokkosinlinefunction:: result_view_type view() const;
+
+      Returns a view of the result place provided in class constructor.
 
 Additional Information
-~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^
 
 * ``MinMaxLoc<T,I,S>::value_type`` is Specialization of MinMaxLocScalar on non-const ``T`` and non-const ``I``
+
 * ``MinMaxLoc<T,I,S>::result_view_type`` is ``Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>``. Note that the S (memory space) must be the same as the space where the result resides.
-* Requires: ``Scalar`` has ``operator =``, ``operator <`` and ``operator >`` defined. ``Kokkos::reduction_identity<Scalar>::min()`` and ``Kokkos::reduction_identity<Scalar>::max()`` are a valid expressions. 
+
+* Requires: ``Scalar`` has ``operator =``, ``operator <`` and ``operator >`` defined. ``Kokkos::reduction_identity<Scalar>::min()`` and ``Kokkos::reduction_identity<Scalar>::max()`` are a valid expressions.
+
 * Requires: ``Index`` has ``operator =`` defined. ``Kokkos::reduction_identity<Scalar>::min()`` is a valid expressions.
+
 * In order to use MinMaxLoc with a custom type of either ``Scalar`` or ``Index``, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined. See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details.


### PR DESCRIPTION
fix `MinMaxLoc` according to #397 

| before | after |
| ------ | ----- | 
| ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/8bd083d2-73de-483e-b9e0-70a7037fe40c) | ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/9c94e68b-bad5-4a8e-94d9-42beb1174c4b) |
| ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/28cf8204-b7cd-461d-831d-29e83fb3d9d8) | ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/0f55ff4f-4d93-4c08-aca7-a6e96a5427ed) |
| ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/7aa2568c-b10c-4833-853e-1f23f17d5d91) | ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/118ee53b-58ae-41ff-b71e-c8665776a616) |
