### PR TITLE
use proper sphinx class syntax for `MinMaxLocScalar`

### DIFF
--- a/docs/source/API/core/builtinreducers/MinMaxLocScalar.rst
+++ b/docs/source/API/core/builtinreducers/MinMaxLocScalar.rst
@@ -13,40 +13,53 @@ Usage
 
 .. code-block:: cpp
 
-    MinMaxLoc<T,I,S>::value_type result;
-    parallel_reduce(N,Functor,MinMaxLoc<T,I,S>(result));
-    T minValue = result.min_val;
-    T maxValue = result.max_val;
-    I minLoc = result.min_loc;
-    I maxLoc = result.max_loc;
+   MinMaxLoc<T,I,S>::value_type result;
+   parallel_reduce(N,Functor,MinMaxLoc<T,I,S>(result));
+   T minValue = result.min_val;
+   T maxValue = result.max_val;
+   I minLoc = result.min_loc;
+   I maxLoc = result.max_loc;
 
 Synopsis
 --------
 
 .. code-block:: cpp
 
-    template<class Scalar, class Index>
-    struct MinMaxLocScalar{
-        Scalar min_val;
-        Scalar max_val;
-        Index min_loc;
-        Index max_loc;
+   template<class Scalar, class Index>
+   struct MinMaxLocScalar{
+     Scalar min_val;
+     Scalar max_val;
+     Index min_loc;
+     Index max_loc;
 
-        void operator = (const MinMaxLocScalar& rhs);
-    };
+     void operator = (const MinMaxLocScalar& rhs);
+   };
 
-Public Members
---------------
+Interface
+---------
 
-Variables
-~~~~~~~~~
+.. cppkokkos:struct:: template<class Scalar, class Index> MinMaxLocScalar
 
-* ``min_val``: Scalar minimum Value.
-* ``max_val``: Scalar maximum Value.
-* ``min_loc``: minimum location(Index).
-* ``max_loc``: maximum location(Index).
+   .. rubric:: Public Types
 
-Assignment operators
-~~~~~~~~~~~~~~~~~~~~
+   .. cppkokkos:type:: min_val
 
-* ``void operator = (const MinMaxLocScalar& rhs);`` assign ``min_val``, ``max_val``, ``min_loc`` and ``max_loc`` from ``rhs``;
+      Scalar minimum Value.
+
+   .. cppkokkos:type:: max_val
+
+      Scalar maximum Value.
+
+   .. cppkokkos:type:: min_loc
+
+      Minimum location(Index).
+
+   .. cppkokkos:type:: max_loc
+
+      Maximum location(Index).
+
+   .. rubric:: Public Member Functions
+
+   .. cppkokkos:function:: void operator = (const MinMaxLocScalar& rhs)
+
+      Assign ``min_val``, ``max_val``, ``min_loc`` and ``max_loc`` from ``rhs``

--- a/docs/source/API/core/builtinreducers/MinMaxLocScalar.rst
+++ b/docs/source/API/core/builtinreducers/MinMaxLocScalar.rst
@@ -4,7 +4,8 @@
 .. role::cpp(code)
     :language: cpp
 
-Template class for storing the min and max values with indices for min/max location reducers. Should be accessed via ``::value_type`` defined for particular reducer.
+Template class for storing the min and max values with indices for min/max location reducers.
+Should be accessed via ``::value_type`` defined for a particular reducer.
 
 Header File: ``<Kokkos_Core.hpp>``
 
@@ -40,25 +41,25 @@ Interface
 
 .. cppkokkos:struct:: template<class Scalar, class Index> MinMaxLocScalar
 
-   .. rubric:: Public Types
+   .. rubric:: Public Members
 
-   .. cppkokkos:type:: min_val
+   .. cppkokkos:member:: Scalar min_val
 
       Scalar minimum Value.
 
-   .. cppkokkos:type:: max_val
+   .. cppkokkos:member:: Scalar max_val
 
       Scalar maximum Value.
 
-   .. cppkokkos:type:: min_loc
+   .. cppkokkos:member:: Index min_loc
 
       Minimum location(Index).
 
-   .. cppkokkos:type:: max_loc
+   .. cppkokkos:member:: Index max_loc
 
       Maximum location(Index).
 
-   .. rubric:: Public Member Functions
+   .. rubric:: Assignment Operator
 
    .. cppkokkos:function:: void operator = (const MinMaxLocScalar& rhs)
 


### PR DESCRIPTION
fix `MinMaxLocScalar` according to #397 

| before | after |
| ------ | ----- | 
| ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/ad6b9179-5c8d-45a1-a8ef-efa5b476a14a) | <img width="877" alt="image" src="https://github.com/kokkos/kokkos-core-wiki/assets/18708772/a4fd736e-a4a3-4b4b-abeb-4f0514009b0a"> |
| ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/84841a58-2701-42e6-beb5-f15edb9c7f51) | <img width="882" alt="image" src="https://github.com/kokkos/kokkos-core-wiki/assets/18708772/b8a5f783-3b57-4acf-84ee-406c34ece198"> |

