### PR TITLE
use proper sphinx class syntax for `MinMaxScalar`

### DIFF
--- a/docs/source/API/core/builtinreducers/MinMaxScalar.rst
+++ b/docs/source/API/core/builtinreducers/MinMaxScalar.rst
@@ -12,35 +12,43 @@ Usage
 -----
 
 .. code-block:: cpp
-        
-    MinMax<T,S>::value_type result;
-    parallel_reduce(N,Functor,MinMax<T,S>(result));
-    T minValue = result.min_val;
-    T maxValue = result.max_val;
+
+   MinMax<T,S>::value_type result;
+   parallel_reduce(N,Functor,MinMax<T,S>(result));
+   T minValue = result.min_val;
+   T maxValue = result.max_val;
 
 Synopsis
 --------
 
 .. code-block:: cpp
 
-    template<class Scalar>
-    struct MinMaxScalar{
-        Scalar min_val;
-        Scalar max_val;
+   template<class Scalar>
+   struct MinMaxScalar{
+     Scalar min_val;
+     Scalar max_val;
 
-        void operator = (const MinMaxScalar& rhs);
-    };
+     void operator = (const MinMaxScalar& rhs);
+   };
 
-Public Members
---------------
 
-Variables
-~~~~~~~~~
+Interface
+---------
 
-* ``min_val``: Scalar minimum Value.
-* ``max_val``: Scalar maximum Value.
+.. cppkokkos:struct:: template<class Scalar> MinMaxScalar
 
-Assignment operators
-~~~~~~~~~~~~~~~~~~~~
+   .. rubric:: Public Types
 
-* ``void operator = (const MinMaxScalar& rhs);`` assign ``min_val`` and ``max_val`` from ``rhs``;
+   .. cppkokkos:type:: min_val
+
+      Scalar minimum Value.
+
+   .. cppkokkos:type:: max_val
+
+      Scalar maximum Value.
+
+   .. rubric:: Public Member Functions
+
+   .. cppkokkos:function:: void operator = (const MinMaxScalar& rhs)
+
+      Assign ``min_val`` and ``max_val`` from ``rhs``


### PR DESCRIPTION
fix `MinMaxScalar` according to #397 

| before | after |
| ------ | ----- | 
| ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/b8eca392-80d2-414c-a922-2bf25b2e11d2) | ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/02b8c99f-64b6-4ed2-bacd-c97e720058ad) |
| ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/790683ea-a023-4dcd-9a9b-0691a990acb6) | ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/3965e6b9-7339-4477-90a2-cada8788642a) |
