### PR TITLE
#420: Fix warning in view.rst

### DIFF
--- a/docs/source/API/core/view/view.rst
+++ b/docs/source/API/core/view/view.rst
@@ -25,15 +25,15 @@ Parameters
 
 .. _LayoutRight: layoutRight.html
 
-.. |LayoutRight| replace:: :cppkokkos:func:`LayoutRight`
+.. |LayoutRight| replace:: ``LayoutRight()``
 
 .. _LayoutLeft: layoutLeft.html
 
-.. |LayoutLeft| replace:: :cppkokkos:func:`LayoutLeft`
+.. |LayoutLeft| replace:: ``LayoutLeft()``
 
 .. _LayoutStride: layoutStride.html
 
-.. |LayoutStride| replace:: :cppkokkos:func:`LayoutStride`
+.. |LayoutStride| replace:: ``LayoutStride()``
 
 Template parameters other than ``DataType`` are optional, but ordering is enforced.
 That means for example that ``LayoutType`` can be omitted but if both ``MemorySpace``


### PR DESCRIPTION
fixes this:
```
/kokkos-core-wiki/docs/source/API/core/view/view.rst:28: WARNING: cppkokkos:func targets a class (LayoutRight).
/kokkos-core-wiki/docs/source/API/core/view/view.rst:32: WARNING: cppkokkos:func targets a class (LayoutLeft).
/kokkos-core-wiki/docs/source/API/core/view/view.rst:36: WARNING: cppkokkos:func targets a kokkosinlinefunction (LayoutStride).
```

| before | after |
| :---: | :----: |
| ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/b9f823ac-45eb-4d81-bbca-7f1aacc0d535) | ![image](https://github.com/kokkos/kokkos-core-wiki/assets/62652182/4e414202-cb7c-470b-b389-3c40ff7ff2ba) |
