### PR TITLE
#378: Add sphinx-build options to ensure that the documentation builds warning free

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,5 +1,5 @@
 html:
-	sphinx-build -b html ./source/ ./generated_docs/
+	sphinx-build -b html ./source/ ./generated_docs/ -W --keep-going
 	python3 ./source/edit_button_handler.py
 
 clean:


### PR DESCRIPTION
Ensure that the CI fails if the PR code generates warnings.

## The solution
Use Sphinx's native options:
- ``-W``
**Turn warnings into errors.** This means that the build stops at the first warning and sphinx-build exits with exit status 1.

- ``--keep-going``
With -W option, **keep going processing when getting warnings to the end of build**, and sphinx-build exits with **exit status 1**.

Link to Sphinx documentation: https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-W

## Why set the ``--keep-going`` option?
This option finishes the build. This displays all warnings, if any, and makes it easier for the developer to resolve them. If you remove this option, the build stops at the first warning encountered and displays only the first warning. It might be better to remove this option, whatever you prefer.

## Advantages of this solution
This solution avoids making changes in the CI and has the desired effect: if a warning is detected by Sphinx, compilation doesn't finish, returns a exit status 1 and the CI makes a failure.