### PR TITLE
Removed reference for simple `parallel_for`

### DIFF
--- a/docs/source/API/core/parallel-dispatch/parallel_for.rst
+++ b/docs/source/API/core/parallel-dispatch/parallel_for.rst
@@ -74,7 +74,7 @@ More Detailed Examples are provided in the ExecutionPolicy documentation.
 
         int N = atoi(argv[1]);
 
-        Kokkos::parallel_for("Loop1", N, KOKKOS_LAMBDA (const int& i) {
+        Kokkos::parallel_for("Loop1", N, KOKKOS_LAMBDA (const int i) {
             printf("Greeting from iteration %i\n",i);
         });
 


### PR DESCRIPTION
On behalf of @dalg24 

citation: "Passing the `int` by reference is not smart here"