### PR TITLE
Add documentation for new AMD GPU naming convention

### DIFF
--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -253,6 +253,26 @@ Architecture Keywords
       * Optimize for the NVIDIA Ada generation CC 8.9 :sup:`since Kokkos 4.1`
       * ``OFF``
 
+    * * ``Kokkos_ARCH_AMD_GFX906``
+      * Optimize for AMD GPU MI50/MI60 GFX906 :sup:`since Kokkos 4.2`
+      * ``OFF``
+
+    * * ``Kokkos_ARCH_AMD_GFX908``
+      * Optimize for AMD GPU MI100 GFX908 :sup:`since Kokkos 4.2`
+      * ``OFF``
+
+    * * ``Kokkos_ARCH_AMD_GFX90A``
+      * Optimize for AMD GPU MI200 series GFX90A :sup:`since Kokkos 4.2`
+      * ``OFF``
+
+    * * ``Kokkos_ARCH_AMD_GFX1030``
+      * Optimize for AMD GPU V620/W6800 GFX1030 :sup:`since Kokkos 4.2` 
+      * ``OFF``
+    
+    * * ``Kokkos_ARCH_AMD_GFX1100``
+      * Optimize for AMD GPU 7900xt GFX1100 :sup:`since Kokkos 4.2` 
+      * ``OFF``
+
     * * ``Kokkos_ARCH_AMPERE80``
       * Optimize for the NVIDIA Ampere generation CC 8.0
       * ``OFF``
@@ -365,8 +385,9 @@ Architecture Keywords
       * Optimize for MAXWELL53 architecture
       * ``OFF``
 
-    * * ``Kokkos_ARCH_NAVI1030`` :red:`[Since 4.0]`
-      * Optimize for AMD GPU V620/W6800 GFX1030
+    * * ``Kokkos_ARCH_NAVI1030``
+      * Optimize for AMD GPU V620/W6800 GFX1030 :sup:`since Kokkos 4.0`
+      * Prefer ``Kokkos_ARCH_AMD_GFX1030``
       * ``OFF``
 
     * * ``Kokkos_ARCH_PASCAL60``
@@ -405,20 +426,23 @@ Architecture Keywords
       * Optimize for TURING75 architecture
       * ``OFF``
 
-    * * ``Kokkos_ARCH_VEGA900`` :red:`[Removed in 4.0]`
-      * Optimize for AMD GPU MI25 GFX900
+    * * ``Kokkos_ARCH_VEGA900``
+      * Optimize for AMD GPU MI25 GFX900 :sup:`removed in 4.0`
       * ``OFF``
 
     * * ``Kokkos_ARCH_VEGA906``
       * Optimize for AMD GPU MI50/MI60 GFX906
+      * Prefer ``Kokkos_ARCH_AMD_GFX906``
       * ``OFF``
 
     * * ``Kokkos_ARCH_VEGA908``
       * Optimize for AMD GPU MI100 GFX908
+      * Prefer ``Kokkos_ARCH_AMD_GFX908``
       * ``OFF``
 
     * * ``Kokkos_ARCH_VEGA90A``
       * Optimize for AMD GPU MI200 series GFX90A
+      * Prefer ``Kokkos_ARCH_AMD_GFX90A``
       * ``OFF``
 
     * * ``Kokkos_ARCH_VOLTA70``
@@ -450,3 +474,34 @@ request Ahead-Of-Time compilation. Just-In-Time compilation means that the compi
 are actually executed and only at that point the architecture to compile for is determined. On the other hand, Ahead-Of-Time
 compilation describes the standard model where the compiler is only invoked once to create the binary and the architecture to
 compile for is determined before the program is run.
+
+.. _kweyword_amd:
+
+AMD Architectures
+=================
+
+.. list-table::
+    :widths: 65 35
+    :header-rows: 1
+    :align: left
+
+    * - AMD GPU
+      - Kokkos ARCH
+    
+    * * ``7900xt``
+      * AMD_GFX1100
+      
+    * * ``MI50/MI60``
+      * AMD_GFX906
+      
+    * * ``MI100``
+      * AMD_GFX908
+      
+    * * ``MI200`` series: ``MI210``, ``MI250``, ``MI250X``
+      * AMD_GFX90A
+    
+    * * ``V620``
+      * AMD_GFX1030
+     
+    * * ``W6800``
+      * AMD_GFX1030


### PR DESCRIPTION
This PR is related to https://github.com/kokkos/kokkos/pull/6266. It adds the documentation for the new naming convention and a table that help users to find the correct flag.