### PR TITLE
New readme section : Requirements to build html page in virtual environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Python Virtual Environment
-/venv
+/env
 # PyCharm files
 /.idea
 # Rendered html files

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ python3 -m http.server
 ```
 
 ```bash
+# list installed packages
+python3 -m pip list
+
 # leave virtual environment
 deactivate
 ```

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ cd docs/generated_docs
 python3 -m http.server
 ```
 
+Usefull commands:
 ```bash
 # list installed packages
 python3 -m pip list

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is needed just for local render of documentation, so it can be checked befo
 Requirements are in `build_requirements.txt`
 Could be installed with: `pip install -r build_requirements.txt`
 
-## Build
+### Build
 
 ```
 cd docs
@@ -20,7 +20,7 @@ cd docs
 make clean
 ```
 
-## Displaying the site locally
+### Displaying the site locally
 
 `docs/generated_docs/index.html` can be opened in a web browser, or alternatively you can use python's built-in http server:
 
@@ -32,3 +32,38 @@ python3 -m http.server
 Then, navigate to http://localhost:8000
 
 Alternatively, if you would like to auto refresh every time you run make, the documentation works with [httpwatcher](https://pypi.org/project/httpwatcher/).
+
+## Requirements to build html page in virtual environments
+
+```bash
+# 1. install virtualenv (if needed)
+python3 -m pip install --user virtualenv
+
+# 2. clone this repository
+git clone git@github.com:kokkos/kokkos-core-wiki.git
+cd kokkos-core-wiki
+
+# 3. create virtual environment
+python3 -m venv env
+
+# 4. activate virtual environment
+source env/bin/activate
+
+# 5. install doc requirements
+python3 -m pip install -r build_requirements.txt
+
+# 6. build
+cd docs
+make html
+
+# 7. display
+cd docs/generated_docs
+python3 -m http.server
+```
+
+```bash
+# leave virtual environment
+deactivate
+```
+
+Source: https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/


### PR DESCRIPTION
Simple guide for indicate:
- how to set up from scratch a Python virtual environment locally on a machine,
- install in that virtual environment all the requirements for the wiki build and
- do the build in that "safe" environment

The aim is to help documentation creators to:
- be in a controlled environment where they can be sure of using the right tools, versions, etc,
- detect potential errors or warnings as early as possible 