### PR TITLE
#5635: Update documentation to cover new overloads for parallel_scan

### DIFF
--- a/docs/source/API/core/parallel-dispatch/parallel_scan.rst
+++ b/docs/source/API/core/parallel-dispatch/parallel_scan.rst
@@ -38,7 +38,7 @@ Parameters:
 
   - ``IntegerType``: defines a 1D iteration range, starting from 0 and going to a count.
   - `RangePolicy <../policies/RangePolicy.html>`_: defines a 1D iteration range.
-  - `TeamThreadRange <../policies/TeamThreadRange.html>`_: defined a 1D iteration range to be executed through thread parallelization dividing the range over the threads of the team.
+  - `TeamThreadRange <../policies/TeamThreadRange.html>`_: defined a 1D iteration range to be executed through thread parallelization dividing the range over the threads of the team. Only valid inside a parallel region executed through a ``TeamPolicy`` or a ``TaskTeam``.
   - `ThreadVectorRange <../policies/ThreadVectorRange.html>`_: defines a 1D iteration range to be executed through vector parallelization dividing the threads within a team.  Only valid inside a parallel region executed through a ``TeamPolicy`` or a ``TaskTeam``.
 * FunctorType: A valid functor with (at minimum) an ``operator()`` with a matching signature for the ``ExecPolicy`` combined with the reduced type.
 * ReturnType: a POD type with ``operator +=`` and ``operator =``, or a ``Kokkos::View``.

--- a/docs/source/API/core/parallel-dispatch/parallel_scan.rst
+++ b/docs/source/API/core/parallel-dispatch/parallel_scan.rst
@@ -38,6 +38,7 @@ Parameters:
 
   - ``IntegerType``: defines a 1D iteration range, starting from 0 and going to a count.
   - `RangePolicy <../policies/RangePolicy.html>`_: defines a 1D iteration range.
+  - `TeamThreadRange <../policies/TeamThreadRange.html>`_: defined a 1D iteration range to be executed through thread parallelization dividing the range over the threads of the team.
   - `ThreadVectorRange <../policies/ThreadVectorRange.html>`_: defines a 1D iteration range to be executed through vector parallelization dividing the threads within a team.  Only valid inside a parallel region executed through a ``TeamPolicy`` or a ``TaskTeam``.
 * FunctorType: A valid functor with (at minimum) an ``operator()`` with a matching signature for the ``ExecPolicy`` combined with the reduced type.
 * ReturnType: a POD type with ``operator +=`` and ``operator =``, or a ``Kokkos::View``.

--- a/docs/source/API/core/policies/TeamThreadRange.rst
+++ b/docs/source/API/core/policies/TeamThreadRange.rst
@@ -14,6 +14,8 @@ Usage
     parallel_for(TeamThreadRange(team,range), [=] (int i) {...});
     parallel_reduce(TeamThreadRange(team,begin,end), 
         [=] (int i, double& lsum) {...},sum);
+    parallel_scan(TeamThreadRange(team,begin,end),
+        [=] (lint i, double& lsum, bool final) {...},sum);
 
 TeamThreadRange is a `nested execution policy <./NestedPolicies.html>`_ used inside hierarchical parallelism. In contrast to global policies, the public interface for nested policies is implemented as functions, in order to enable implicit templating on the execution space type via the team handle.
 


### PR DESCRIPTION
Related to https://github.com/kokkos/kokkos/issues/5635