### PR TITLE
fix switched "inclusive" and "exclusive" in `parallel_scan` documentation

### DIFF
--- a/docs/source/API/core/parallel-dispatch/parallel_scan.rst
+++ b/docs/source/API/core/parallel-dispatch/parallel_scan.rst
@@ -16,8 +16,8 @@ Usage
     Kokkos::parallel_scan( policy, functor, result);
     Kokkos::parallel_scan( policy, functor );
 
-Dispatches parallel work defined by ``functor`` according to the *ExecutionPolicy* ``policy`` and perform a pre (inclusive) or post (exclusive) scan of the contributions
-provided by the work items. The optional label ``name`` is used by profiling and debugging tools.  If provided, the final result is placed in result. 
+Dispatches parallel work defined by ``functor`` according to the *ExecutionPolicy* ``policy`` and perform a pre (exclusive) or post (inclusive) scan of the contributions
+provided by the work items. The optional label ``name`` is used by profiling and debugging tools.  If provided, the final result is placed in result.
 
 Interface
 ---------
@@ -33,14 +33,14 @@ Interface
 Parameters:
 ~~~~~~~~~~~
 
-* ``name``: A user provided string which is used in profiling and debugging tools via the Kokkos Profiling Hooks. 
+* ``name``: A user provided string which is used in profiling and debugging tools via the Kokkos Profiling Hooks.
 * ExecPolicy: An *ExecutionPolicy* which defines iteration space and other execution properties. Valid policies are:
 
   - ``IntegerType``: defines a 1D iteration range, starting from 0 and going to a count.
-  - `RangePolicy <../policies/RangePolicy.html>`_: defines a 1D iteration range. 
+  - `RangePolicy <../policies/RangePolicy.html>`_: defines a 1D iteration range.
   - `ThreadVectorRange <../policies/ThreadVectorRange.html>`_: defines a 1D iteration range to be executed through vector parallelization dividing the threads within a team.  Only valid inside a parallel region executed through a ``TeamPolicy`` or a ``TaskTeam``.
 * FunctorType: A valid functor with (at minimum) an ``operator()`` with a matching signature for the ``ExecPolicy`` combined with the reduced type.
-* ReturnType: a POD type with ``operator +=`` and ``operator =``, or a ``Kokkos::View``.  
+* ReturnType: a POD type with ``operator +=`` and ``operator =``, or a ``Kokkos::View``.
 
 Requirements:
 ~~~~~~~~~~~~~
@@ -49,15 +49,15 @@ Requirements:
 
   - The ``WorkTag`` free form of the operator is used if ``ExecPolicy`` is an ``IntegerType`` or ``ExecPolicy::work_tag`` is ``void``.
   - ``HandleType`` is an ``IntegerType`` if ``ExecPolicy`` is an ``IntegerType`` else it is ``ExecPolicy::member_type``.
-* The type ``ReturnType`` of the ``functor`` operator must be compatible with the ``ReturnType`` of the parallel_scan and must match the arguments of the ``init`` and ``join`` functions of the functor.  
+* The type ``ReturnType`` of the ``functor`` operator must be compatible with the ``ReturnType`` of the parallel_scan and must match the arguments of the ``init`` and ``join`` functions of the functor.
 * the functor must define FunctorType::value_type the same as ReturnType
-    
+
 Semantics
 ---------
 
-* Neither concurrency nor order of execution are guaranteed. 
-* The ``ReturnType`` content will be overwritten, i.e. the value does not need to be initialized to the reduction-neutral element. 
-* The input value to the operator may contain a partial result, Kokkos may only combine the thread local contributions in the end. The operator should modify the input value according to the desired scan operation. 
+* Neither concurrency nor order of execution are guaranteed.
+* The ``ReturnType`` content will be overwritten, i.e. the value does not need to be initialized to the reduction-neutral element.
+* The input value to the operator may contain a partial result, Kokkos may only combine the thread local contributions in the end. The operator should modify the input value according to the desired scan operation.
 
 Examples
 --------
@@ -82,8 +82,8 @@ Examples
           if(is_final) post(i) = partial_sum;
         }, result);
 
-        // pre: 0,0,1,3,6,10,...
-        // post: 0,1,3,6,10,...
+        // pre (exclusive): 0,0,1,3,6,10,...
+        // post (inclusive): 0,1,3,6,10,...
         // result: N*(N-1)/2
         printf("Result: %i %li\n",N,result);
       }


### PR DESCRIPTION
Fixes #446