### PR TITLE
1/2 Upgrade `cppkokkos` domain: Removal of specializations for Kokkos that are no longer useful

### DIFF
--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -1,5 +1,5 @@
-Sphinx==5.0.1
-furo==2022.6.4.1
-myst-parser==0.18.0
+Sphinx==7.2.2
+furo==2023.8.17
+myst-parser==2.0.0
 sphinx-copybutton==0.5.0
 m2r2==0.3.2

--- a/docs/source/API/core/policies/RangePolicy.rst
+++ b/docs/source/API/core/policies/RangePolicy.rst
@@ -9,7 +9,7 @@ Header File: ``<Kokkos_Core.hpp>``
 Usage
 -----
 
-.. code-block:: cppkokkos
+.. code-block:: cpp
 
     Kokkos::RangePolicy<>(begin, end, args...)
     Kokkos::RangePolicy<ARGS>(begin, end, args...)
@@ -117,7 +117,7 @@ Optional ``InitArgs``:
 Examples
 --------
 
-.. code-block:: cppkokkos
+.. code-block:: cpp
 
     RangePolicy<> policy_1(0, N);
     RangePolicy<Cuda> policy_2(5,N-5);
@@ -128,7 +128,7 @@ Examples
 
 Note: providing a single integer as a policy to a parallel pattern, implies a defaulted ``RangePolicy``
 
-.. code-block:: cppkokkos
+.. code-block:: cpp
 
     // These two calls are identical
     parallel_for("Loop", N, functor);

--- a/docs/source/_ext/cppkokkos.py
+++ b/docs/source/_ext/cppkokkos.py
@@ -7181,9 +7181,6 @@ class CPPKokkosInlinefunctionObject(CPPKokkosObject):
 class CPPKokkosDeprecatedTypeObject(CPPKokkosObject):
     object_type = 'deprecated-type'
 
-class CPPKokkosConceptObject(CPPKokkosObject):
-    object_type = 'concept'
-
 class CPPKokkosMemberObject(CPPKokkosObject):
     object_type = 'member'
 # @@@@@!
@@ -7690,7 +7687,6 @@ class CPPKokkosDomain(Domain):
         'var': CPPKokkosMemberObject,
         'type': CPPKokkosTypeObject,
         'deprecated-type': CPPKokkosDeprecatedTypeObject,
-        'concept': CPPKokkosConceptObject,
         'enum': CPPKokkosEnumObject,
         'enum-struct': CPPKokkosEnumObject,
         'enum-class': CPPKokkosEnumObject,


### PR DESCRIPTION
## Purpose of this PR

The [Sphinx tool](https://www.sphinx-doc.org/en/master/index.html) is currently in version `7.2.2`.

`kokkos-core-wiki` uses version `5.0.1`.

`kokkos-core-wiki` uses [the C++ domain](https://github.com/sphinx-doc/sphinx/blob/master/sphinx/domains/cpp.py) file from Sphinx with a few specializations to suit the needs of Kokkos code writing. For example to add `KOKKOS_INLINE_FUNCTION` in [Synopsis here](https://kokkos.github.io/kokkos-core-wiki/API/core/builtinreducers/BAnd.html?highlight=kokkos_inline_function).

We would like to update the `cppkokkos` domain file with Sphinx C++ domain without losing the Kokkos specializations.

## Preliminary work

We want to use as much as possible the new Sphinx native C++ directives for declaring entities.
