### PR TITLE
Fix a link in requirements.rst

### DIFF
--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -126,7 +126,7 @@ Build system:
 =============
 
 * CMake >= 3.16: required
-* CMake >= 3.18: Fortran linkage. This does not affect most mixed Fortran/Kokkos builds. See https://github.com/kokkos/kokkos/blob/master/BUILD.md#known-issues.
+* CMake >= 3.18: Fortran linkage. This does not affect most mixed Fortran/Kokkos builds. See `known build issues <https://github.com/kokkos/kokkos/blob/master/BUILD.md#known-issues>`_.
 * CMake >= 3.21.1 for NVC++
 
 Primary tested compiler are passing in release mode

--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -126,7 +126,7 @@ Build system:
 =============
 
 * CMake >= 3.16: required
-* CMake >= 3.18: Fortran linkage. This does not affect most mixed Fortran/Kokkos builds. See [build issues](BUILD.md#KnownIssues).
+* CMake >= 3.18: Fortran linkage. This does not affect most mixed Fortran/Kokkos builds. See https://github.com/kokkos/kokkos/blob/master/BUILD.md#known-issues.
 * CMake >= 3.21.1 for NVC++
 
 Primary tested compiler are passing in release mode


### PR DESCRIPTION
This should really point to the main repository and is currently not displayed as a link at all.