### PR TITLE
Add a note that `Kokkos::printf` is only available in release 4.2

### DIFF
--- a/docs/source/API/core/utilities/printf.rst
+++ b/docs/source/API/core/utilities/printf.rst
@@ -9,7 +9,7 @@ Defined in header ``<Kokkos_Core.hpp>``
 .. code-block:: cpp
 
     template <typename... Args>
-    KOKKOS_FUNCTION void printf(const char* format, Args... args);
+    KOKKOS_FUNCTION void printf(const char* format, Args... args);  // (since 4.2)
 
 Prints the data specified in ``format`` and ``args...`` to ``stdout``.
 The behavior is analogous to ``std::printf``, but the return type is ``void``


### PR DESCRIPTION
We had a report on Slack about getting an `namespace "Kokkos" has no member "printf"` error.
Nothing in the documentation captures that it was added in 4.2