### PR TITLE
Document the new header `<Kokkos_Abort.hpp>`

### DIFF
--- a/docs/source/API/core/utilities/abort.rst
+++ b/docs/source/API/core/utilities/abort.rst
@@ -11,3 +11,12 @@ Defined in header ``<Kokkos_Core.hpp>``
     KOKKOS_FUNCTION void abort(const char *const msg);
 
 Causes abnormal program termination with error explanatory string being printed.
+
+Notes
+-----
+
+.. _KokkosAbort: https://github.com/kokkos/kokkos/blob/4.2.00/core/src/Kokkos_Abort.hpp
+
+.. |KokkosAbort| replace:: ``<Kokkos_Abort.hpp>``
+
+* Since version 4.2, one may include |KokkosAbort|_ instead of ``<Kokkos_Core.hpp>``.


### PR DESCRIPTION
Added in kokkos/kokkos#6445 and mentioned in the 4.2 changelog