### PR TITLE
Add Profiling API section and document `ProfilingSection` and `ScopedRegion`

### DIFF
--- a/docs/source/API/core-index.rst
+++ b/docs/source/API/core-index.rst
@@ -60,3 +60,4 @@ API: Core
    ./core/Utilities
    ./core/Detection-Idiom
    ./core/Macros
+   ./core/Profiling

--- a/docs/source/API/core/Profiling.rst
+++ b/docs/source/API/core/Profiling.rst
@@ -1,0 +1,17 @@
+Profiling
+=========
+
+Kokkos::Profiling::ScopedRegion
+-------------------------------
+See `Profiling::ScopedRegion <profiling/scoped_region.html>`_ for details.`
+
+Kokkos::Profiling::ProfilingSection
+-----------------------------------
+See `Profiling::ProfilingSection <profiling/profiling_section.html>`_ for details.`
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+   ./profiling/scoped_region
+   ./profiling/profiling_section

--- a/docs/source/API/core/profiling/profiling_section.rst
+++ b/docs/source/API/core/profiling/profiling_section.rst
@@ -1,0 +1,58 @@
+``Profiling::ProfilingSection``
+===============================
+
+.. role:: cppkokkos(code)
+   :language: cppkokkos
+
+Defined in header ``<Kokkos_Profiling_ProfileSection.hpp>``
+
+Usage
+-----
+
+.. code-block:: cpp
+
+   Kokkos::Profiling::ProfilingSection section("label");
+   section.start();
+   // <code>
+   section.stop();
+    
+
+
+The class ``ProfilingSection`` is a section ID wrapper that provides a
+convenient `RAII-style <https://en.cppreference.com/w/cpp/language/raii>`_
+mechanism to manage a user-defined profiling section.
+
+When a ``ProfilingSection`` object is created, a profiling section is created
+with the user-provided stringand the objects holds on to the section ID.
+
+When control leaves the scope in which the ``ProfilingSection`` object was
+created, the ``ProfilingSection`` is destructed, and the underlying section is
+properly destroyed.
+
+The ``ProfilingSection`` class is non-copyable.
+
+
+.. cppkokkos:Function:: ProfilingSection(std::string const& sectionName);
+
+   Constructs a section with user-provided label.
+   Calls ``Profiling::createProfileSection(sectionName, &sectionID);``
+
+.. cppkokkos:Function:: ~ProfilingSection();
+
+   Deletes the section.
+   Calls ``Profiling.destroyProfileSection(sectionID);``
+
+.. cppkokkos:Function:: void start();
+
+   Starts the section.
+   Calls ``Profiling::startSection(sectionID);``
+
+.. cppkokkos:Function:: void stop();
+
+   Ends the section.
+   Calls ``Profiling::stopSection(sectionID);``
+
+
+**See also**
+
+`ScopedRegion <scoped_region.html>`_: implements a scope-based region ownership wrapper

--- a/docs/source/API/core/profiling/scoped_region.rst
+++ b/docs/source/API/core/profiling/scoped_region.rst
@@ -1,0 +1,66 @@
+``Profiling::ScopedRegion``
+===========================
+
+.. role:: cppkokkos(code)
+   :language: cppkokkos
+
+Defined in header ``<Kokkos_Profiling_ScopedRegion.hpp>``
+
+Usage
+-----
+
+.. code-block:: cpp
+
+   Kokkos::Profiling::ScopedRegion region("label");  // (since 4.1)
+
+
+
+The class ``ScopedRegion`` is a `RAII
+<https://en.cppreference.com/w/cpp/language/raii>`_ wrapper that "pushes" a
+user-defined profiling region when an object is created and properly "pops"
+that region upon destruction when the scope is exited. This is useful in
+particular to profile code that has non-trivial control flow (e.g.  early
+return).
+
+The ``ScopedRegion`` class is non-copyable.
+
+.. cppkokkos:Function:: ScopedRegion(std::string const& regionName);
+
+   Starts a user-defined region with provided label.
+   Calls ``Profiling::pushRegion(regionName)``
+
+.. cppkokkos:Function:: ~ScopedRegion();
+
+   Ends the region.
+   Calls ``Profiling::popRegion()``
+
+Example
+-------
+
+.. code-block:: cpp
+
+   #include <Kokkos_Profiling_ScopedRegion.hpp>
+
+   void do_work_v1() {
+     Kokkos::Profiling::pushRegion("MyApp::do_work");
+     // <code>
+     if (cond) {
+       Kokkos::Profiling::popRegion();  // must remember to pop here as well
+       return;
+     }
+     // <more code>
+     Kokkos::Profiling::popRegion();
+   }
+
+   void do_work_v2() {
+     Kokkos::Profiling::ScopedRegion region("MyApp::do_work");
+     // <code>
+     if (cond) return;
+     // <more code>
+   }
+
+
+
+**See also**
+
+`ProfilingSection <profiling_section.html>`_: Implements a scope-based section ownership wrapper


### PR DESCRIPTION
I keep getting the following error
```
docs/source/API/core/profiling/scoped_region.rst:40: WARNING: Could not lex literal_block as "cpp". Highlighting skipped.
```
I would appreciate some help to fix

I intend to get into the documentation of the profiling interface in follow up PRs.
This PR specifically documents the `Profiling::ProfilingSection` and `Profiling::ScopedRegion` RAII-style helper classes.