### PR TITLE
Update `AoSoA` API in Cabana's use case

### DIFF
--- a/docs/source/usecases/SoA-and-AoSoA-with-Cabana.md
+++ b/docs/source/usecases/SoA-and-AoSoA-with-Cabana.md
@@ -55,7 +55,7 @@ class AoSoA;
 : The Kokkos memory space that carries information about where to allocate storage.
 
 `VectorLength`
-: The vector length for the structure of arrays (optional). If not specified, a default defined for each each memory space is used; this value will likely need to be modified for optimal performance.
+: The vector length for the structure of arrays (optional). If not specified, a default (defined per memory space) is used; this value may need to be modified for optimal performance.
 
 `MemoryTraits`
 : The Kokkos memory traits that tells who controls memory allocation and deallocation (optional).

--- a/docs/source/usecases/SoA-and-AoSoA-with-Cabana.md
+++ b/docs/source/usecases/SoA-and-AoSoA-with-Cabana.md
@@ -42,8 +42,7 @@ Defined in header [`<Cabana_AoSoA.hpp>`](https://github.com/ECP-copa/Cabana/blob
 
 ```C++
 template <class DataTypes, class MemorySpace,
-          int VectorLength = Impl::PerformanceTraits<
-              typename MemorySpace::execution_space>::vector_length,
+          int VectorLength = DEDUCED-FROM-MEMORY-SPACE,
           class MemoryTraits = Kokkos::MemoryManaged>
 class AoSoA;
 ```

--- a/docs/source/usecases/SoA-and-AoSoA-with-Cabana.md
+++ b/docs/source/usecases/SoA-and-AoSoA-with-Cabana.md
@@ -41,9 +41,9 @@ MemberTypes<Types...>;
 Defined in header [`<Cabana_AoSoA.hpp>`](https://github.com/ECP-copa/Cabana/blob/master/core/src/Cabana_AoSoA.hpp)
 
 ```C++
-template <class DataTypes, class DeviceType,
+template <class DataTypes, class MemorySpace,
           int VectorLength = Impl::PerformanceTraits<
-              typename DeviceType::execution_space>::vector_length,
+              typename MemorySpace::execution_space>::vector_length,
           class MemoryTraits = Kokkos::MemoryManaged>
 class AoSoA;
 ```
@@ -52,8 +52,8 @@ class AoSoA;
 `DataTypes`
 : The types of the elements stored in the underlying `Cabana::SoA`s.
 
-`DeviceType`
-: The Kokkos device type that carries the information about where to execute code and where to allocate storage.
+`MemorySpace`
+: The Kokkos memory space that carries information about where to allocate storage.
 
 `VectorLength`
 : The vector length for the structure of arrays (optional).

--- a/docs/source/usecases/SoA-and-AoSoA-with-Cabana.md
+++ b/docs/source/usecases/SoA-and-AoSoA-with-Cabana.md
@@ -55,7 +55,7 @@ class AoSoA;
 : The Kokkos memory space that carries information about where to allocate storage.
 
 `VectorLength`
-: The vector length for the structure of arrays (optional).
+: The vector length for the structure of arrays (optional). If not specified, a default defined for each each memory space is used; this value will likely need to be modified for optimal performance.
 
 `MemoryTraits`
 : The Kokkos memory traits that tells who controls memory allocation and deallocation (optional).


### PR DESCRIPTION
This page had never been updated since the device type template parameter was deprecated on the Cabana side.

@streeve please review