### PR TITLE
Update Initialization section of the Programming Guide

### DIFF
--- a/docs/source/ProgrammingGuide/Initialization.md
+++ b/docs/source/ProgrammingGuide/Initialization.md
@@ -62,37 +62,20 @@ You can alternatively set the corresponding environment variable of a flag (all 
 ***
 <sup>1</sup> This is the preferred set of defaults when CUDA and OpenMP are enabled. If you use a thread-parallel host execution space, we prefer Kokkos' OpenMP back-end, as this ensures compatibility of Kokkos' threads with the application's direct use of OpenMP threads. Kokkos cannot promise that its Threads back-end will not conflict with the application's direct use of operating system threads.
 
-## 5.2 Initialization by struct
+## 5.2 Programmatic Initialization
 
-Instead of giving [`Kokkos::initialize()`](../API/core/initialize_finalize/initialize) command-line arguments, one may directly pass in initialization parameters using the following struct:
-
-```c++
-struct Kokkos::InitArguments {
-  int num_threads;
-  int num_numa;
-  int device_id;
-  int ndevices;
-  int skip_device;
-  bool disable_warnings;
-};
-```
-The `num_threads` field corresponds to the `--kokkos-threads` command-line argument, `num_numa` to `--kokkos-numa`, `device_id` to `--device-id`, `ndevices` to the first value in `--num-devices` and `skip_devices` to the second value in `--num-devices`. (See Table 5.1 for details.) Not all parameters are observed by all execution spaces, and the struct might expand in the future if needed.
-
-If you set `num_threads` or `num_numa` to zero or less, Kokkos will try to determine default values if possible or otherwise set them to 1. In particular, Kokkos can use the `hwloc` library to determine default settings using the assumption that the process binding mask is unique, i.e., that this process does not share any cores with another process. Note that the default value of each parameter is -1.
-
-Here is an example of how to use the struct.
+Instead of giving [`Kokkos::initialize()`](../API/core/initialize_finalize/initialize) command-line arguments, one may directly pass in initialization parameters using the [`Kokkos::InitializationSettings`](../API/core/initialize_finalize/InitializationSettings) class.
 
 ```c++
-Kokkos::InitArguments args;
-// 8 (CPU) threads per NUMA region
-args.num_threads = 8;
-// 2 (CPU) NUMA regions per process
-args.num_numa = 2;
-// If Kokkos was built with CUDA enabled, use the GPU with device ID 1.
-args.device_id = 1;
+    auto settings = Kokkos::InitializationSettings()
+                    .set_num_threads(8)
+                    .set_device_id(0)
+                    .set_disable_warnings(false);
 
-Kokkos::initialize(args);
+	Kokkos::initialize(settings);
 ```
+
+The `set_num_threads` method corresponds to the `--kokkos-num-threads` command-line argument, etc. To use the default parameter value, simply do not call the `set_<parameter>` method.
 
 ## 5.3 Finalization
 

--- a/docs/source/ProgrammingGuide/Initialization.md
+++ b/docs/source/ProgrammingGuide/Initialization.md
@@ -43,15 +43,7 @@ Kokkos chooses the two spaces using the following list:
 
 The highest execution space in the list which is enabled is Kokkos' default execution space, and the highest enabled host execution space is Kokkos' default host execution space. For example, if  `Kokkos::Cuda`, `Kokkos::OpenMP`, and `Kokkos::Serial` are enabled, then `Kokkos::Cuda` is the default execution space and `Kokkos::OpenMP` is the default host execution space.<sup>1</sup>  In cases where the highest enabled backend is a host parallel execution space the `DefaultExecutionSpace` and the `DefaultHostExecutionSpace` will be the same.
 
-Command-line arguments come in "prefixed" and "non-prefixed" versions. Prefixed versions start with the string `--kokkos-`. [`Kokkos::initialize`](../API/core/initialize_finalize/initialize) will remove prefixed options from the input list, but will preserve non-prefixed options. Argument options are given with an equals (`=`) sign. If the same argument occurs more than once, the last one is used. Furthermore, prefixed versions of the command line arguments take precedence over the non-prefixed ones. For example, the arguments
-
-    --kokkos-threads=4 --threads=2
-
-set the number of threads to 4, while
-
-    --kokkos-threads=4 --threads=2 --kokkos-threads=3
-
-set the number of threads to 3. Table 5.1 gives a full list of command-line options.
+Table 5.1 gives a full list of command-line options.
 
 <h4>Table 5.1: Command-line Core options for Kokkos::initialize</h4>
 

--- a/docs/source/ProgrammingGuide/Initialization.md
+++ b/docs/source/ProgrammingGuide/Initialization.md
@@ -53,15 +53,19 @@ set the number of threads to 4, while
 
 set the number of threads to 3. Table 5.1 gives a full list of command-line options.
 
-<h4>Table 5.1: Command-line options for Kokkos::initialize</h4>
+<h4>Table 5.1: Command-line Core options for Kokkos::initialize</h4>
 
 Argument | Description
 :---      | :---
---kokkos-help  <br/> --help   | print this message
---kokkos-threads=INT <br/> --threads=INT  | specify total number of threads or number of threads per NUMA region if used in conjunction with `--numa` option.
---kokkos-numa=INT <br/> --numa=INT | specify number of NUMA regions used by process.
---device-id=INT | specify device id to be used by Kokkos.
---num-devices=INT[,INT] | used when running MPI jobs. Specify the number of devices per node to be used. Process to device mapping happens by obtaining the local MPI rank and assigning devices round-robin. The optional second argument allows for an existing device to be ignored. This is most useful on workstations with multiple GPUs, one of which is used to drive screen output.
+  --kokkos-help                  | print this message
+  --kokkos-disable-warnings      | disable kokkos warning messages
+  --kokkos-print-configuration   | print configuration
+  --kokkos-tune-internals        | allow Kokkos to autotune policies and declare tuning features through the tuning system. If left off, Kokkos uses heuristics
+  --kokkos-num-threads=INT       | specify total number of threads to use for parallel regions on the host.
+  --kokkos-device-id=INT         | specify device id to be used by Kokkos.
+  --kokkos-map-device-id-by=(random\|mpi\_rank)| strategy to select device-id automatically from available devices. </br> - random:   choose a random device from available. </br> - mpi_rank: choose device-id based on a round robin assignment of local MPI ranks. Works with OpenMPI, MVAPICH, SLURM, and derived implementations.
+
+You can alternatively set the corresponding environment variable of a flag (all letters in upper-case and underscores instead of hyphens). For example, to disable warning messages, you can either specify `--kokkos-disable-warnings` or set the `KOKKOS_DISABLE_WARNINGS` environment variable to `yes`.
 
 ***
 <sup>1</sup> This is the preferred set of defaults when CUDA and OpenMP are enabled. If you use a thread-parallel host execution space, we prefer Kokkos' OpenMP back-end, as this ensures compatibility of Kokkos' threads with the application's direct use of OpenMP threads. Kokkos cannot promise that its Threads back-end will not conflict with the application's direct use of operating system threads.

--- a/docs/source/ProgrammingGuide/Initialization.md
+++ b/docs/source/ProgrammingGuide/Initialization.md
@@ -14,7 +14,7 @@ For specific capabilities check their API reference:
 
 ## 5.1 Initialization by command-line arguments
 
-The simplest way to initialize Kokkos is by calling the following function:
+The simplest way to initialize Kokkos is by calling the [`Kokkos::initialize()`](../API/core/initialize_finalize/initialize) function:
 ```c++
 Kokkos::initialize(int& argc, char* argv[]);
 ```
@@ -77,11 +77,15 @@ Instead of giving [`Kokkos::initialize()`](../API/core/initialize_finalize/initi
 
 The `set_num_threads` method corresponds to the `--kokkos-num-threads` command-line argument, etc. To use the default parameter value, simply do not call the `set_<parameter>` method.
 
-## 5.3 Finalization
+## 5.4 Interaction with MPI
+
+[`Kokkos::initialize()`](../API/core/initialize_finalize/initialize) generally should be called after `MPI_Init` when Kokkos is initialized within an MPI context. This allows proper device mapping.
+
+## 5.4 Finalization
 
 At the end of each program, Kokkos needs to be shut down in order to free resources; do this by calling [`Kokkos::finalize()`](../API/core/initialize_finalize/finalize). You may wish to set this to be called automatically at program exit, either by setting an `atexit` hook or by attaching the function to `MPI_COMM_SELF` so that it is called automatically at `MPI_Finalize`.
 
-## 5.4 Example Code
+## 5.5 Example Code
 
 A minimal Kokkos code thus would look like this:
 


### PR DESCRIPTION
Programming Guide Initialization section was describing pre-3.7 version. 

I have updated according to Core documentation and I have removed mentions that are deprecated to try to be clearer. Core documentation has all the details about deprecation and advanced usage.