### PR TITLE
Delete outdated note about `TeamPolicy::set_scratch_size()`

### DIFF
--- a/docs/source/ProgrammingGuide/HierarchicalParallelism.md
+++ b/docs/source/ProgrammingGuide/HierarchicalParallelism.md
@@ -146,7 +146,7 @@ struct functor {
   }
 };
 ```
-The `set_scratch_size` function of the [`TeamPolicy`](../API/core/policies/TeamPolicy) takes two or three arguments. The first argument specifies the level in the scratch hierarchy for which a specific size is requested. Different levels have different restrictions. Generally, the first level is restricted to a few tens of kilobytes roughly corresponding to L1 cache size. The second level can be used to get an aggregate over all teams of a few gigabyte, corresponding to available space in high-bandwidth memory. The third level mostly falls back to capacity memory in the node. The second and third argument are either per-thread or per-team sizes for scratch memory. Note like previously discussed, the setter function does not modify the instance it is called on, but returns a copy of the policy object with adjusted scratch size request.
+The `set_scratch_size` function of the [`TeamPolicy`](../API/core/policies/TeamPolicy) takes two or three arguments. The first argument specifies the level in the scratch hierarchy for which a specific size is requested. Different levels have different restrictions. Generally, the first level is restricted to a few tens of kilobytes roughly corresponding to L1 cache size. The second level can be used to get an aggregate over all teams of a few gigabyte, corresponding to available space in high-bandwidth memory. The third level mostly falls back to capacity memory in the node. The second and third argument are either per-thread or per-team sizes for scratch memory.
 
 Here are some examples:
 


### PR DESCRIPTION
Fix #491 