### PR TITLE
Remove all mentions of `Kokkos::Experimental::HBWSpace` and memkind

### DIFF
--- a/docs/source/API/core/KokkosConcepts.rst
+++ b/docs/source/API/core/KokkosConcepts.rst
@@ -244,7 +244,7 @@ The ``MemorySpace`` Concept
 ---------------------------
 
 Looking at the common functionality in the current implementations of ``CudaSpace``, ``CudaUVMSpace``,
-``HostSpace``, ``OpenMPTargetSpace``, and ``HBWSpace``, the current concept for ``MemorySpace`` looks something like:
+``HostSpace``, and ``OpenMPTargetSpace``, the current concept for ``MemorySpace`` looks something like:
 
 .. code-block:: cpp
 

--- a/docs/source/API/core/Macros.rst
+++ b/docs/source/API/core/Macros.rst
@@ -26,8 +26,6 @@ General Settings
 +-------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
 | ``KOKKOS_ENABLE_DEPRECATION_WARNING``           | Defined if deprecated features generate deprecation warnings.                                               |
 +-------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| ``KOKKOS_ENABLE_HBWSPACE``                      | Defined if the experimental ``HBWSpace`` memory space is enabled, enabled by KOKKOS_ENABLE_MEMKIND.         |
-+-------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
 | ``KOKKOS_ENABLE_TUNING``                        | Whether bindings for tunings are available (see `#2422 <https://github.com/kokkos/kokkos/pull/2422>`_).     |
 +-------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
 | ``KOKKOS_ENABLE_COMPLEX_ALIGN``                 | Whether complex types are aligned.                                                                          |

--- a/docs/source/API/core/Macros.rst
+++ b/docs/source/API/core/Macros.rst
@@ -130,8 +130,6 @@ These defines give information about what third-party libaries Kokkos was compil
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------+
 | ``KOKKOS_ENABLE_LIBRT``       | Defined if Kokkos links to the POSIX librt for backwards compatibility.                                               |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------+
-| ``KOKKOS_ENABLE_MEMKIND``     | Defined if Kokkos enables the `Memkind <https://github.com/memkind/memkind>`_ heap manager, enables HBWSpace.         |
-+-------------------------------+-----------------------------------------------------------------------------------------------------------------------+
 | ``KOKKOS_ENABLE_LIBDL``       | Defined if Kokkos links to the dynamic linker (libdl).                                                                |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------+
 | ``KOKKOS_ENABLE_LIBQUADMATH`` | Defined if Kokkos links to the `GCC Quad-Precision Math Library API <https://gcc.gnu.org/onlinedocs/libquadmath/>`_.  |

--- a/docs/source/ProgrammingGuide/Compiling.md
+++ b/docs/source/ProgrammingGuide/Compiling.md
@@ -256,7 +256,7 @@ Variable  | Description
 `KOKKOS_ARCH (IN)` | The backend architecture to build for.
 `Options` <br><br><br> `Default` | KNL, KNC, SNB, HSW, BDW, Kepler, Kepler30, Kepler35, Kepler37, Maxwell, Maxwell50, Pascal60, Pascal61, ARMv8, ARMv81, ARMv8-ThunderX, BGQ, Power7, Power8 <br><br> (no particular architecture flags are set).
 `KOKKOS_USE_TPLS (IN)` | Enable optional third party libraries.
-`Options` <br> `Default`  | hwloc, librt, experimental_memkind <br> (none)
+`Options` <br> `Default`  | hwloc, librt <br> (none)
 `KOKKOS_OPTIONS (IN)` | Enable optional settings
 `Options` <br> `Default` | aggressive_vectorization <br> (none)
 `KOKKOS_CUDA_OPTIONS (IN)` | Enable optional settings specific to CUDA.

--- a/docs/source/ProgrammingGuide/View.md
+++ b/docs/source/ProgrammingGuide/View.md
@@ -387,7 +387,6 @@ The following is the accessibility matrix for execution and memory spaces:
 | | Serial | OpenMP | Threads | Cuda | HIP |
 |---|---|---|---|---|---|
 |HostSpace| x | x | x | - | - |
-|HBWSpace| x | x | x | - | - |
 |CudaSpace| - | - | - | x | - |
 |CudaUVMSpace| x | x | x | x | - |
 |CudaHostPinnedSpace| x | x | x | x | - |

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -197,10 +197,6 @@ The following options control finding and configuring non-CMake TPLs:
       * Location of HWLOC install prefix
       * PATH Default:
 
-    * * ``Kokkos_MEMKIND_DIR`` or ``MEMKIND_ROOT``
-      * Location of MEMKIND install prefix
-      * PATH Default:
-
     * * ``Kokkos_LIBDL_DIR`` or ``LIBDL_ROOT``
       * Location of LIBDL install prefix
       * PATH Default:

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -171,9 +171,6 @@ The following options control enabling TPLs:
     * * ``Kokkos_ENABLE_HWLOC``
       * Whether to enable the HWLOC library
       * ``Off``
-    * * ``Kokkos_ENABLE_MEMKIND``
-      * Whether to enable the MEMKIND library
-      * ``Off``
     * * ``Kokkos_ENABLE_LIBDL``
       * Whether to enable the LIBDL library
       * ``On``

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -170,13 +170,13 @@ The following options control enabling TPLs:
       * ``OFF``
     * * ``Kokkos_ENABLE_HWLOC``
       * Whether to enable the HWLOC library
-      * ``Off``
+      * ``OFF``
     * * ``Kokkos_ENABLE_LIBDL``
       * Whether to enable the LIBDL library
-      * ``On``
+      * ``ON``
     * * ``Kokkos_ENABLE_LIBRT``
       * Whether to enable the LIBRT library
-      * ``Off``
+      * ``OFF``
 
 The following options control finding and configuring non-CMake TPLs:
 


### PR DESCRIPTION
Following the merge of kokkos/kokkos#6791