### PR TITLE
Change `Experimental::for_each` return type to void

### DIFF
--- a/docs/source/API/algorithms/std-algorithms/all/StdForEach.md
+++ b/docs/source/API/algorithms/std-algorithms/all/StdForEach.md
@@ -8,24 +8,24 @@ namespace Kokkos{
 namespace Experimental{
 
 template <class ExecutionSpace, class InputIterator, class UnaryFunctorType>
-UnaryFunctorType for_each(const ExecutionSpace& exespace,                            (1)
-                      InputIterator first, InputIterator last,
-                      UnaryFunctorType functor);
+void for_each(const ExecutionSpace& exespace,                            (1)
+              InputIterator first, InputIterator last,
+              UnaryFunctorType functor);
 
 template <class ExecutionSpace, class InputIterator, class UnaryFunctorType>
-UnaryFunctorType for_each(const std::string& label, const ExecutionSpace& exespace,  (2)
-                      InputIterator first, InputIterator last,
-                      UnaryFunctorType functor);
+void for_each(const std::string& label, const ExecutionSpace& exespace,  (2)
+              InputIterator first, InputIterator last,
+              UnaryFunctorType functor);
 
 template <class ExecutionSpace, class DataType, class... Properties, class UnaryFunctorType>
-UnaryFunctorType for_each(const ExecutionSpace& exespace,
-             const Kokkos::View<DataType, Properties...>& view,                      (3)
-             UnaryFunctorType functor);
+void for_each(const ExecutionSpace& exespace,
+              const Kokkos::View<DataType, Properties...>& view,                      (3)
+              UnaryFunctorType functor);
 
 template <class ExecutionSpace, class DataType, class... Properties, class PredicateType>
-UnaryFunctorType for_each(const std::string& label, const ExecutionSpace& exespace,
-             const Kokkos::View<DataType, Properties...>& view,                      (4)
-             UnaryFunctorType func);
+void for_each(const std::string& label, const ExecutionSpace& exespace,
+              const Kokkos::View<DataType, Properties...>& view,                      (4)
+              UnaryFunctorType func);
 
 } //end namespace Experimental
 } //end namespace Kokkos
@@ -74,7 +74,7 @@ Applies the UnaryFunctorType `func` to the result of dereferencing each iterator
 
 ## Return
 
-`func`
+(nothing)
 
 
 ## Example


### PR DESCRIPTION
To reflect the changes from kokkos/kokkos#6910

We were returning a copy of the function object argument and now return nothing to align with `std::for_each` overload that takes an execution policy.  This is an experimental facility and advertising that we return `void` is compatible with our policies so we don't need to mention the change in the doc.