### PR TITLE
Clarify parallel_scan behavior

### DIFF
--- a/docs/source/API/core/parallel-dispatch/parallel_scan.rst
+++ b/docs/source/API/core/parallel-dispatch/parallel_scan.rst
@@ -58,6 +58,8 @@ Semantics
 * Neither concurrency nor order of execution are guaranteed.
 * The ``ReturnType`` content will be overwritten, i.e. the value does not need to be initialized to the reduction-neutral element.
 * The input value to the operator may contain a partial result, Kokkos may only combine the thread local contributions in the end. The operator should modify the input value according to the desired scan operation.
+* It is not guaranteed that the functor will ever be called with ``final = false``.
+* The functor might be called multiple times with ``final = false`` and the user has to make sure that the behavior in this case stays the same for repeated calls.
 
 Examples
 --------


### PR DESCRIPTION
Related to https://github.com/kokkos/kokkos/issues/6897.
This documents current behavior. The `Serial` backend calls the functor only once with `final=true` while the `Cuda` backend calls the functor once with `final=false` in its first kernel,  once with `final=false` and once with `final=true` in its second kernel.
This led to hard-to-understand problems when trying to cache results for `final=false`. The very least we can do is to document current restrictions better.