### PR TITLE
RangePolicy constructor updates from Release 4.3

### DIFF
--- a/docs/source/API/core/policies/RangePolicy.rst
+++ b/docs/source/API/core/policies/RangePolicy.rst
@@ -176,6 +176,28 @@ Preconditions:
 
 * The start index must not be greater than the end index.
 
+CTAD Constructors (since 4.3):
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: cppkokkos
+
+   int64_t work_begin = /* ... */; // conversions as well
+   int64_t work_end   = /* ... */; // conversions as well
+   ChunkSize cs       = /* ... */; // conversions as well
+   DefaultExecutionSpace des;      // conversions as well
+   SomeExecutionSpace ses;         // different from DefaultExecutionSpace
+
+   // Deduces to RangePolicy<>
+   RangePolicy rp0;
+   RangePolicy rp1(work_begin, work_end);
+   RangePolicy rp2(work_begin, work_end, cs);
+   RangePolicy rp3(des, work_begin, work_end);
+   RangePolicy rp4(des, work_begin, work_end, cs);
+
+   // Deduces to RangePolicy<SomeExecutionSpace>
+   RangePolicy rp5(ses, work_begin, work_end);
+   RangePolicy rp6(ses, work_begin, work_end, cs);
+
 Examples
 --------
 

--- a/docs/source/API/core/policies/RangePolicy.rst
+++ b/docs/source/API/core/policies/RangePolicy.rst
@@ -26,7 +26,7 @@ Synopsis
     template<class ... Args>
     class Kokkos::RangePolicy {
         typedef RangePolicy execution_policy;
-        typedef typename traits::index_type member_type ;
+        typedef typename traits::index_type member_type;
         typedef typename traits::index_type index_type;
 
         //Inherited from PolicyTraits<Args...>
@@ -41,23 +41,23 @@ Synopsis
         RangePolicy(const RangePolicy&) = default;
         RangePolicy(RangePolicy&&) = default;
 
-        inline RangePolicy();
+        RangePolicy();
 
         template<class ... Args>
-        inline RangePolicy( const execution_space & work_space
-                          , const member_type work_begin
-                          , const member_type work_end
-                          , Args ... args);
+        RangePolicy( const execution_space & work_space
+                   , member_type work_begin
+                   , member_type work_end
+                   , Args ... args );
 
         template<class ... Args>
-        inline RangePolicy( const member_type work_begin
-                          , const member_type work_end
-                          , Args ... args);
+        RangePolicy( member_type work_begin
+                   , member_type work_end
+                   , Args ... args );
 
         // retrieve chunk_size
-        inline member_type chunk_size() const;
+        member_type chunk_size() const;
         // set chunk_size to a discrete value
-        inline RangePolicy set_chunk_size(int chunk_size_);
+        RangePolicy& set_chunk_size(int chunk_size_);
 
         // return ExecSpace instance provided to the constructor
         KOKKOS_INLINE_FUNCTION const execution_space & space() const;
@@ -101,11 +101,11 @@ Constructors
 
    Default Constructor uninitialized policy.
 
-.. cppkokkos:function:: template<class ... InitArgs> RangePolicy(const int64_t& begin, const int64_t& end, const InitArgs ... init_args)
+.. cppkokkos:function:: template<class ... InitArgs> RangePolicy(int64_t begin, int64_t end, InitArgs ... init_args)
 
    Provide a start and end index as well as optional arguments to control certain behavior (see below).
 
-.. cppkokkos:function:: template<class ... InitArgs> RangePolicy(const ExecutionSpace& space, const int64_t& begin, const int64_t& end, const InitArgs ... init_args)
+.. cppkokkos:function:: template<class ... InitArgs> RangePolicy(const ExecutionSpace& space, int64_t begin, int64_t end, InitArgs ... init_args)
 
    Provide a start and end index and an ``ExecutionSpace`` instance to use as the execution resource, as well as optional arguments to control certain behavior (see below).
 

--- a/docs/source/API/core/policies/RangePolicy.rst
+++ b/docs/source/API/core/policies/RangePolicy.rst
@@ -16,7 +16,7 @@ Usage
     Kokkos::RangePolicy<...>(Space(), begin, end)
     Kokkos::RangePolicy<...>(Space(), begin, end, chunk_size)
 
-RangePolicy defines an execution policy for a 1D iteration space starting at begin and going to end with an open interval.
+RangePolicy defines an execution policy for a 1D iteration space starting at ``begin`` and going to ``end`` with an open interval.
 
 Synopsis
 --------

--- a/docs/source/API/core/policies/RangePolicy.rst
+++ b/docs/source/API/core/policies/RangePolicy.rst
@@ -28,12 +28,11 @@ Synopsis
     };
 
     template<class ... Args>
-    class Kokkos::RangePolicy {
-        typedef RangePolicy execution_policy;
-        typedef typename traits::index_type member_type;
-        typedef typename traits::index_type index_type;
+    struct Kokkos::RangePolicy {
+        using execution_policy = RangePolicy;
+        using member_type = PolicyTraits<Args...>::index_type;
 
-        //Inherited from PolicyTraits<Args...>
+        // Inherited from PolicyTraits<Args...>
         using execution_space   = PolicyTraits<Args...>::execution_space;
         using schedule_type     = PolicyTraits<Args...>::schedule_type;
         using work_tag          = PolicyTraits<Args...>::work_tag;
@@ -41,7 +40,7 @@ Synopsis
         using iteration_pattern = PolicyTraits<Args...>::iteration_pattern;
         using launch_bounds     = PolicyTraits<Args...>::launch_bounds;
 
-        //Constructors
+        // Constructors
         RangePolicy(const RangePolicy&) = default;
         RangePolicy(RangePolicy&&) = default;
 

--- a/docs/source/API/core/policies/RangePolicy.rst
+++ b/docs/source/API/core/policies/RangePolicy.rst
@@ -47,38 +47,21 @@ Synopsis
 
         RangePolicy();
 
-        // since 4.3
         RangePolicy( member_type work_begin
                    , member_type work_end );
 
-        // since 4.3
         RangePolicy( member_type work_begin
                    , member_type work_end
                    , ChunkSize chunk_size );
 
-        // since 4.3
         RangePolicy( const execution_space & work_space
                    , member_type work_begin
                    , member_type work_end );
 
-        // since 4.3
         RangePolicy( const execution_space & work_space
                    , member_type work_begin
                    , member_type work_end
                    , ChunkSize chunk_size );
-
-        // until 4.3
-        template<class ... Args>
-        RangePolicy( const execution_space & work_space
-                   , member_type work_begin
-                   , member_type work_end
-                   , Args ... args );
-
-        // until 4.3
-        template<class ... Args>
-        RangePolicy( member_type work_begin
-                   , member_type work_end
-                   , Args ... args );
 
         // retrieve chunk_size
         member_type chunk_size() const;
@@ -132,9 +115,6 @@ Constructors
 
    Default Constructor uninitialized policy.
 
-Since 4.3:
-^^^^^^^^^^
-
 .. cppkokkos:function:: RangePolicy(int64_t begin, int64_t end)
 
    Provide a start and end index.
@@ -150,22 +130,6 @@ Since 4.3:
 .. cppkokkos:function:: RangePolicy(const ExecutionSpace& space, int64_t begin, int64_t end, ChunkSize chunk_size)
 
    Provide a start and end index and an ``ExecutionSpace`` instance to use as the execution resource, as well as a ``ChunkSize``.
-
-Until 4.3:
-^^^^^^^^^^
-
-.. cppkokkos:function:: template<class ... InitArgs> RangePolicy(int64_t begin, int64_t end, InitArgs ... init_args)
-
-   Provide a start and end index as well as optional arguments to control certain behavior (see below).
-
-.. cppkokkos:function:: template<class ... InitArgs> RangePolicy(const ExecutionSpace& space, int64_t begin, int64_t end, InitArgs ... init_args)
-
-   Provide a start and end index and an ``ExecutionSpace`` instance to use as the execution resource, as well as optional arguments to control certain behavior (see below).
-
-Optional ``InitArgs`` (until 4.3):
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-* ``ChunkSize``
 
 Preconditions:
 ^^^^^^^^^^^^^^

--- a/docs/source/API/core/policies/RangePolicy.rst
+++ b/docs/source/API/core/policies/RangePolicy.rst
@@ -11,10 +11,14 @@ Usage
 
 .. code-block:: cppkokkos
 
-    Kokkos::RangePolicy<>(begin, end, args...)
-    Kokkos::RangePolicy<ARGS>(begin, end, args...)
-    Kokkos::RangePolicy<>(Space(), begin, end, args...)
-    Kokkos::RangePolicy<ARGS>(Space(), begin, end, args...)
+    Kokkos::RangePolicy<>(begin, end)
+    Kokkos::RangePolicy<ARGS>(begin, end)
+    Kokkos::RangePolicy<>(begin, end, chunk_size)
+    Kokkos::RangePolicy<ARGS>(begin, end, chunk_size)
+    Kokkos::RangePolicy<>(Space(), begin, end)
+    Kokkos::RangePolicy<ARGS>(Space(), begin, end)
+    Kokkos::RangePolicy<>(Space(), begin, end, chunk_size)
+    Kokkos::RangePolicy<ARGS>(Space(), begin, end, chunk_size)
 
 RangePolicy defines an execution policy for a 1D iteration space starting at begin and going to end with an open interval.
 
@@ -22,6 +26,10 @@ Synopsis
 --------
 
 .. code-block:: cpp
+
+    struct Kokkos::ChunkSize {
+        ChunkSize(int value_);
+    };
 
     template<class ... Args>
     class Kokkos::RangePolicy {
@@ -43,12 +51,34 @@ Synopsis
 
         RangePolicy();
 
+        // since 4.3
+        RangePolicy( member_type work_begin
+                   , member_type work_end );
+
+        // since 4.3
+        RangePolicy( member_type work_begin
+                   , member_type work_end
+                   , ChunkSize chunk_size );
+
+        // since 4.3
+        RangePolicy( const execution_space & work_space
+                   , member_type work_begin
+                   , member_type work_end );
+
+        // since 4.3
+        RangePolicy( const execution_space & work_space
+                   , member_type work_begin
+                   , member_type work_end
+                   , ChunkSize chunk_size );
+
+        // until 4.3
         template<class ... Args>
         RangePolicy( const execution_space & work_space
                    , member_type work_begin
                    , member_type work_end
                    , Args ... args );
 
+        // until 4.3
         template<class ... Args>
         RangePolicy( member_type work_begin
                    , member_type work_end
@@ -97,9 +127,36 @@ Public Class Members
 Constructors
 ~~~~~~~~~~~~
 
+.. cppkokkos:function:: ChunkSize(int value_)
+
+   Provide a hint for optimal chunk-size to be used during scheduling.
+   For the SYCL backend, the workgroup size used in a ``parallel_for`` kernel can be set via this passed to ``RangePolicy``.
+
 .. cppkokkos:function:: RangePolicy()
 
    Default Constructor uninitialized policy.
+
+Since 4.3:
+^^^^^^^^^^
+
+.. cppkokkos:function:: RangePolicy(int64_t begin, int64_t end)
+
+   Provide a start and end index.
+
+.. cppkokkos:function:: RangePolicy(int64_t begin, int64_t end, ChunkSize chunk_size)
+
+   Provide a start and end index as well as a ``ChunkSize``.
+
+.. cppkokkos:function:: RangePolicy(const ExecutionSpace& space, int64_t begin, int64_t end)
+
+   Provide a start and end index and an ``ExecutionSpace`` instance to use as the execution resource.
+
+.. cppkokkos:function:: RangePolicy(const ExecutionSpace& space, int64_t begin, int64_t end, ChunkSize chunk_size)
+
+   Provide a start and end index and an ``ExecutionSpace`` instance to use as the execution resource, as well as a ``ChunkSize``.
+
+Until 4.3:
+^^^^^^^^^^
 
 .. cppkokkos:function:: template<class ... InitArgs> RangePolicy(int64_t begin, int64_t end, InitArgs ... init_args)
 
@@ -109,12 +166,13 @@ Constructors
 
    Provide a start and end index and an ``ExecutionSpace`` instance to use as the execution resource, as well as optional arguments to control certain behavior (see below).
 
-Optional ``InitArgs``:
-^^^^^^^^^^^^^^^^^^^^^^
+Optional ``InitArgs`` (until 4.3):
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* ``ChunkSize`` : Provide a hint for optimal chunk-size to be used during scheduling. For the SYCL backend, the workgroup size used in a ``parallel_for`` kernel can be set via this variable.
+* ``ChunkSize``
 
 Preconditions:
+^^^^^^^^^^^^^^
 
 * The start index must not be greater than the end index.
 

--- a/docs/source/API/core/policies/RangePolicy.rst
+++ b/docs/source/API/core/policies/RangePolicy.rst
@@ -13,8 +13,14 @@ Usage
 
     Kokkos::RangePolicy<...>(begin, end)
     Kokkos::RangePolicy<...>(begin, end, chunk_size)
-    Kokkos::RangePolicy<...>(Space(), begin, end)
-    Kokkos::RangePolicy<...>(Space(), begin, end, chunk_size)
+    Kokkos::RangePolicy<...>(exec, begin, end)
+    Kokkos::RangePolicy<...>(exec, begin, end, chunk_size)
+
+    // CTAD Constructors (since 4.3)
+    Kokkos::RangePolicy(begin, end)
+    Kokkos::RangePolicy(begin, end, chunk_size)
+    Kokkos::RangePolicy(exec, begin, end)
+    Kokkos::RangePolicy(exec, begin, end, chunk_size)
 
 RangePolicy defines an execution policy for a 1D iteration space starting at ``begin`` and going to ``end`` with an open interval.
 
@@ -46,33 +52,33 @@ Synopsis
 
         RangePolicy();
 
-        RangePolicy( member_type work_begin
-                   , member_type work_end );
+        RangePolicy( index_type work_begin
+                   , index_type work_end );
 
-        RangePolicy( member_type work_begin
-                   , member_type work_end
+        RangePolicy( index_type work_begin
+                   , index_type work_end
                    , ChunkSize chunk_size );
 
         RangePolicy( const execution_space & work_space
-                   , member_type work_begin
-                   , member_type work_end );
+                   , index_type work_begin
+                   , index_type work_end );
 
         RangePolicy( const execution_space & work_space
-                   , member_type work_begin
-                   , member_type work_end
+                   , index_type work_begin
+                   , index_type work_end
                    , ChunkSize chunk_size );
 
         // retrieve chunk_size
-        member_type chunk_size() const;
+        index_type chunk_size() const;
         // set chunk_size to a discrete value
         RangePolicy& set_chunk_size(int chunk_size_);
 
         // return ExecSpace instance provided to the constructor
-        KOKKOS_INLINE_FUNCTION const execution_space & space() const;
+        KOKKOS_FUNCTION const execution_space & space() const;
         // return Range begin
-        KOKKOS_INLINE_FUNCTION member_type begin() const;
+        KOKKOS_FUNCTION member_type begin() const;
         // return Range end
-        KOKKOS_INLINE_FUNCTION member_type end()   const;
+        KOKKOS_FUNCTION member_type end()   const;
     };
 
 Parameters
@@ -134,6 +140,7 @@ Preconditions:
 ^^^^^^^^^^^^^^
 
 * The start index must not be greater than the end index.
+* The actual constructors are templated so we can check that they are converted to ``index_type`` safely (see `#6754 <https://github.com/kokkos/kokkos/pull/6754>`_).
 
 CTAD Constructors (since 4.3):
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/API/core/policies/RangePolicy.rst
+++ b/docs/source/API/core/policies/RangePolicy.rst
@@ -11,14 +11,10 @@ Usage
 
 .. code-block:: cppkokkos
 
-    Kokkos::RangePolicy<>(begin, end)
-    Kokkos::RangePolicy<ARGS>(begin, end)
-    Kokkos::RangePolicy<>(begin, end, chunk_size)
-    Kokkos::RangePolicy<ARGS>(begin, end, chunk_size)
-    Kokkos::RangePolicy<>(Space(), begin, end)
-    Kokkos::RangePolicy<ARGS>(Space(), begin, end)
-    Kokkos::RangePolicy<>(Space(), begin, end, chunk_size)
-    Kokkos::RangePolicy<ARGS>(Space(), begin, end, chunk_size)
+    Kokkos::RangePolicy<...>(begin, end)
+    Kokkos::RangePolicy<...>(begin, end, chunk_size)
+    Kokkos::RangePolicy<...>(Space(), begin, end)
+    Kokkos::RangePolicy<...>(Space(), begin, end, chunk_size)
 
 RangePolicy defines an execution policy for a 1D iteration space starting at begin and going to end with an open interval.
 


### PR DESCRIPTION
This updates the existing RangePolicy constructor documentation as per https://github.com/kokkos/kokkos/pull/6845 and adds a section for the CTAD constructors as per https://github.com/kokkos/kokkos/pull/6850.

This addresses issue #519 and part of issue #515.