### PR TITLE
create_mirror and create_mirror_view: clarified difference

### DIFF
--- a/docs/source/API/core/view/create_mirror.rst
+++ b/docs/source/API/core/view/create_mirror.rst
@@ -16,7 +16,7 @@ Usage
 -----
 
 The key difference between ``create_mirror`` and ``create_mirror_view`` is the following: ``create_mirror`` `always` allocates new memory in the specified space (shown below for host space), while ``create_mirror_view`` only allocates memory if the View to be mirrored (``a_view``) is not already accessible from the specified space, and otherwise simply returns ``a_view``.
-Use ``create_mirror_view`` when the mirror is solely used for providing access in different execution spaces, and use ``create_mirror`` if you need the data to be independent, e.g. for having an previous and a updated version of the data.
+Use ``create_mirror_view`` when the mirror is solely used for providing access in different execution spaces, and use ``create_mirror`` if you need the data to be independent, e.g. for having a previous and an updated version of the data.
 
 .. code-block:: cpp
 

--- a/docs/source/API/core/view/create_mirror.rst
+++ b/docs/source/API/core/view/create_mirror.rst
@@ -26,9 +26,9 @@ Use ``create_mirror_view`` when you want to skip the memory allocation and copy 
     // host_mirror_view may point to the same memory as a_view, if a_view is host-accessible
     auto host_mirror_view = create_mirror_view(a_view);
 
-    // You can specify the execution space from which the mirror view must be accessible
-    auto host_mirror_space = create_mirror(ExecSpace(),a_view);
-    auto host_mirror_view_space = create_mirror_view(ExecSpace(),a_view);
+    // You can specify the space from which the mirror view must be accessible
+    auto mirror = create_mirror(memory_space_instance, a_view);
+    auto mirror_view = create_mirror_view(memory_space_instance, a_view);
 
 
 Description

--- a/docs/source/API/core/view/create_mirror.rst
+++ b/docs/source/API/core/view/create_mirror.rst
@@ -15,13 +15,21 @@ A common desired use case is to have a memory allocation in GPU memory and an id
 Usage
 -----
 
+The key difference between ``create_mirror`` and ``create_mirror_view`` is the following: ``create_mirror`` `always` allocates new memory in the specified space (shown below for host space), while ``create_mirror_view`` only allocates memory if the View to be mirrored (``a_view``) is not already accessible from the specified space, and otherwise simply returns ``a_view``.
+Use ``create_mirror_view`` when you want to skip the memory allocation and copy within the same execution space, and use ``create_mirror`` if you need the data to be independent, e.g. for overlapping computation and I/O.
+
 .. code-block:: cpp
 
+    // Both host_mirror and host_mirror_view have the correct properties for deepCopy from/to a_view
+    // host_mirror is guaranteed to have separately allocated memory from a_view
     auto host_mirror = create_mirror(a_view);
+    // host_mirror_view may point to the same memory as a_view, if a_view is host-accessible
     auto host_mirror_view = create_mirror_view(a_view);
 
+    // You can specify the execution space from which the mirror view must be accessible
     auto host_mirror_space = create_mirror(ExecSpace(),a_view);
     auto host_mirror_view_space = create_mirror_view(ExecSpace(),a_view);
+
 
 Description
 -----------

--- a/docs/source/API/core/view/create_mirror.rst
+++ b/docs/source/API/core/view/create_mirror.rst
@@ -16,11 +16,11 @@ Usage
 -----
 
 The key difference between ``create_mirror`` and ``create_mirror_view`` is the following: ``create_mirror`` `always` allocates new memory in the specified space (shown below for host space), while ``create_mirror_view`` only allocates memory if the View to be mirrored (``a_view``) is not already accessible from the specified space, and otherwise simply returns ``a_view``.
-Use ``create_mirror_view`` when you want to skip the memory allocation and copy within the same execution space, and use ``create_mirror`` if you need the data to be independent, e.g. for overlapping computation and I/O.
+Use ``create_mirror_view`` when the mirror is solely used for providing access in different execution spaces, and use ``create_mirror`` if you need the data to be independent, e.g. for having an previous and a updated version of the data.
 
 .. code-block:: cpp
 
-    // Both host_mirror and host_mirror_view have the correct properties for deepCopy from/to a_view
+    // Both host_mirror and host_mirror_view have the correct properties for deep_copy from/to a_view
     // host_mirror is guaranteed to have separately allocated memory from a_view
     auto host_mirror = create_mirror(a_view);
     // host_mirror_view may point to the same memory as a_view, if a_view is host-accessible


### PR DESCRIPTION
Added a paragraph to "Usage", before the code example, and added comments to the code example.

I was thinking about changing the variable names in the second half of the code example from `host_mirror_space*` to `space_mirror*`, as now they don't *have* to be in host space, if another space is provided. Though I'm not yet familiar enough with Kokkos to know whether `ExecName()` is pseudo code or evaluates to the default execution space or something like that.