### PR TITLE
Correct display of superscripts

### DIFF
--- a/docs/source/ProgrammingGuide/Initialization.rst
+++ b/docs/source/ProgrammingGuide/Initialization.rst
@@ -92,6 +92,7 @@ The values are case insensitive.
 
 
 :sup:`1` This is the preferred set of defaults when CUDA and OpenMP are enabled. If you use a thread-parallel host execution space, we prefer Kokkos' OpenMP backend, as this ensures compatibility of Kokkos' threads with the application's direct use of OpenMP threads. Kokkos cannot promise that its Threads backend will not conflict with the application's direct use of operating system threads.
+
 :sup:`2` The two device-id mapping strategies are:
 - random: select a random device from available.
 - mpi_rank: select device based on a round robin assignment of local MPI ranks. Works with OpenMPI, MVAPICH, SLURM, and derived implementations. Support for MPICH was added in Kokkos 4.0


### PR DESCRIPTION
Two superscripts were missing a backslash-escaped whitespace (see https://documatt.com/restructuredtext-reference/element/superscript.html) to be correctly displayed. Add a newline between the blocks explaining the superscripts for readability.