### PR TITLE
Mention Kokkos::Threads

### DIFF
--- a/docs/source/API/core/execution_spaces.rst
+++ b/docs/source/API/core/execution_spaces.rst
@@ -80,6 +80,13 @@ generically as an execution space. For details, see |DocExecutionSpaceConcept|_.
 feature of the OpenMP runtime system. Except in rare instances, it should not be used directly, but instead
 should be used generically as an execution space. For details, see |DocExecutionSpaceConcept|_.
 
+``Kokkos::Threads``
+------------------
+
+``Kokkos::Threads`` is an |ExecutionSpaceConceptType|_ representing parallel execution with std::threads.
+Except in rare instances, it should not be used directly, but instead should be used
+generically as an execution space. For details, see |DocExecutionSpaceConcept|_.
+
 ``Kokkos::Serial``
 ------------------
 

--- a/docs/source/API/core/execution_spaces.rst
+++ b/docs/source/API/core/execution_spaces.rst
@@ -81,7 +81,7 @@ feature of the OpenMP runtime system. Except in rare instances, it should not be
 should be used generically as an execution space. For details, see |DocExecutionSpaceConcept|_.
 
 ``Kokkos::Threads``
-------------------
+-------------------
 
 ``Kokkos::Threads`` is an |ExecutionSpaceConceptType|_ representing parallel execution with std::threads.
 Except in rare instances, it should not be used directly, but instead should be used


### PR DESCRIPTION
the page https://kokkos.org/kokkos-core-wiki/API/core/execution_spaces.html

doesn't mention `Kokkos::Threads`

yet `Threads` is referenced from https://kokkos.org/kokkos-core-wiki/API/core/Execution-Policies.html