### PR TITLE
std::string as returntype of view.label()

### DIFF
--- a/docs/source/API/core/view/view.rst
+++ b/docs/source/API/core/view/view.rst
@@ -513,7 +513,7 @@ Other
 
    Returns the current reference count of the underlying allocation.
 
-.. cppkokkos:function:: const char* label() const;
+.. cppkokkos:function:: std::string label() const;
 
    Returns the label of the View.
 

--- a/docs/source/API/core/view/view.rst
+++ b/docs/source/API/core/view/view.rst
@@ -513,7 +513,7 @@ Other
 
    Returns the current reference count of the underlying allocation.
 
-.. cppkokkos:function:: std::string label() const;
+.. cppkokkos:function:: const std::string label() const;
 
    Returns the label of the View.
 


### PR DESCRIPTION
spotted it when looking at:

https://github.com/kokkos/kokkos/blob/e0d99fdd79909779f17009fc030d7221520f7feb/core/src/Kokkos_View.hpp#L1379