### PR TITLE
List backend-specific `IndexType` for `ExecutionPolicy`

### DIFF
--- a/docs/source/API/core/Execution-Policies.rst
+++ b/docs/source/API/core/Execution-Policies.rst
@@ -82,7 +82,7 @@ Execution Policies generally accept compile time arguments via template paramete
 
     * * IndexType
       * ``IndexType<int>``
-      * Specify integer type to be used for traversing the iteration space. Defaults to ``int64_t``.
+      * Specify integer type to be used for traversing the iteration space. Defaults to the ``size_type`` of `MemorySpaceConcept <memory_spaces.html#typedefs>`__.
 
     * * LaunchBounds
       * ``LaunchBounds<MaxThreads, MinBlocks>``

--- a/docs/source/API/core/Execution-Policies.rst
+++ b/docs/source/API/core/Execution-Policies.rst
@@ -81,8 +81,8 @@ Execution Policies generally accept compile time arguments via template paramete
       * Specify scheduling policy for work items. ``Dynamic`` scheduling is implemented through a work stealing queue. Default is machine and backend specific.
 
     * * IndexType
-      * ``IndexType<int>``
-      * Specify integer type to be used for traversing the iteration space. Defaults to the ``size_type`` of `ExecutionSpaceConcept <execution_spaces.html#typedefs>`__.
+      * e.g. ``IndexType<int>``
+      * Specify integer type to be used for traversing the iteration space. Defaults to the ``size_type`` of `ExecutionSpaceConcept <execution_spaces.html#typedefs>`__. Can affect the performance depending on the backend.
 
     * * LaunchBounds
       * ``LaunchBounds<MaxThreads, MinBlocks>``

--- a/docs/source/API/core/Execution-Policies.rst
+++ b/docs/source/API/core/Execution-Policies.rst
@@ -82,7 +82,7 @@ Execution Policies generally accept compile time arguments via template paramete
 
     * * IndexType
       * ``IndexType<int>``
-      * Specify integer type to be used for traversing the iteration space. Defaults to the ``size_type`` of `MemorySpaceConcept <memory_spaces.html#typedefs>`__.
+      * Specify integer type to be used for traversing the iteration space. Defaults to the ``size_type`` of `ExecutionSpaceConcept <execution_spaces.html#typedefs>`__.
 
     * * LaunchBounds
       * ``LaunchBounds<MaxThreads, MinBlocks>``

--- a/docs/source/API/core/execution_spaces.rst
+++ b/docs/source/API/core/execution_spaces.rst
@@ -271,6 +271,7 @@ Synopsis
         typedef Device<execution_space, memory_space> device_type;
         typedef ... scratch_memory_space;
         typedef ... array_layout;
+        typedef ... size_type;
 
         ExecutionSpaceConcept();
         ExecutionSpaceConcept(const ExecutionSpaceConcept& src);
@@ -309,6 +310,27 @@ Typedefs
 * ``array_layout``: The default ``ArrayLayout`` recommended for use with ``View`` types accessed from |ExecutionSpaceConcept|_.
 
 * ``scratch_memory_space``: The ``ScratchMemorySpace`` that parallel patterns will use for allocation of scratch memory (for instance, as requested by a |KokkosTeamPolicy|_)
+
+* ``size_type``: The default integer type associated with this space. Used as preferred type for indexing.
+
+.. list-table::
+ :widths: 25 25
+ :header-rows: 1
+
+ * - Space
+   - ``size_type``
+ * - ``Cuda``
+   - ``unsigned int``
+ * - ``HIP``
+   - ``unsigned int``
+ * - ``SYCL``
+   - ``int``
+ * - ``OpenaACC``
+   - ``size_t``
+ * - ``OpenMPTarget``
+   - ``unsigned int``
+ * - All host spaces
+   - ``size_t``
 
 Constructors
 ~~~~~~~~~~~~

--- a/docs/source/API/core/execution_spaces.rst
+++ b/docs/source/API/core/execution_spaces.rst
@@ -325,7 +325,7 @@ Typedefs
    - ``unsigned int``
  * - ``SYCL``
    - ``int``
- * - ``OpenaACC``
+ * - ``OpenACC``
    - ``size_t``
  * - ``OpenMPTarget``
    - ``unsigned int``

--- a/docs/source/API/core/execution_spaces.rst
+++ b/docs/source/API/core/execution_spaces.rst
@@ -311,26 +311,7 @@ Typedefs
 
 * ``scratch_memory_space``: The ``ScratchMemorySpace`` that parallel patterns will use for allocation of scratch memory (for instance, as requested by a |KokkosTeamPolicy|_)
 
-* ``size_type``: The default integer type associated with this space. Used as preferred type for indexing.
-
-.. list-table::
- :widths: 25 25
- :header-rows: 1
-
- * - Space
-   - ``size_type``
- * - ``Cuda``
-   - ``unsigned int``
- * - ``HIP``
-   - ``unsigned int``
- * - ``SYCL``
-   - ``int``
- * - ``OpenACC``
-   - ``size_t``
- * - ``OpenMPTarget``
-   - ``unsigned int``
- * - All host spaces
-   - ``size_t``
+* ``size_type``: The default integer type associated with this space. Signed or unsigned, 32 or 64 bit integer type, used as preferred type for indexing.
 
 Constructors
 ~~~~~~~~~~~~


### PR DESCRIPTION
In a discussion on slack it came up, that the `IndexType` of `ExecutionPolicy` does not always default to `int64_t` as stated in the documentation.

From looking at the implementation it defaults to the `size_type` of the `MemorySpace` that is associated with the `ExecutionSpace` given to the `ExecutionPolicy`. Therefore, this PR adds a table with the backend-specific `size_type` to the `MemorySpace` page and adds a link to it in the common arguments page of the `ExecutionPolicy` page.