### PR TITLE
favor link to common template arguments page over copy of the table in many `ExecutionPolicies`

### DIFF
--- a/docs/source/API/core/policies/MDRangePolicy.rst
+++ b/docs/source/API/core/policies/MDRangePolicy.rst
@@ -29,25 +29,10 @@ Interface
 Parameters
 ----------
 
-Common Arguments for all Execution Policies
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+General Template Aguments
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Execution Policies generally accept compile time arguments via template parameters and runtime parameters via constructor arguments or setter functions.
-* Template arguments can be given in arbitrary order.
-
-+----------------+----------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Argument       | Options                                                                    | Purpose                                                                                                                                                 |
-+================+============================================================================+=========================================================================================================================================================+
-| ExecutionSpace |  ``Serial``, ``OpenMP``, ``Threads``, ``Cuda``, ``HIP``, ``SYCL``, ``HPX`` | Specify the Execution Space to execute the kernel in. Defaults to ``Kokkos::DefaultExecutionSpace``.                                                    |
-+----------------+----------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Schedule       | ``Schedule<Dynamic>``, ``Schedule<Static>``                                | Specify scheduling policy for work items. ``Dynamic`` scheduling is implemented through a work stealing queue. Default is machine and backend specific. |
-+----------------+----------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
-| IndexType      | ``IndexType<int>``                                                         | Specify integer type to be used for traversing the iteration space. Defaults to ``int64_t``.                                                            |
-+----------------+----------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
-| LaunchBounds   | ``LaunchBounds<MaxThreads, MinBlocks>``                                    | Specifies hints to to the compiler about CUDA/HIP launch bounds.                                                                                        |
-+----------------+----------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
-| WorkTag        | ``SomeClass``                                                              | Specify the work tag type used to call the functor operator. Any arbitrary type defaults to ``void``.                                                   |
-+----------------+----------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+Valid template arguments for ``MDRangePolicy`` are described `here <../Execution-Policies.html#common-arguments-for-all-execution-policies>`_
 
 Required Arguments Specific to MDRangePolicy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/API/core/policies/NestedPolicies.rst
+++ b/docs/source/API/core/policies/NestedPolicies.rst
@@ -38,7 +38,7 @@ List
 General Template Aguments
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Valid template arguments for are described `here <../Execution-Policies.html#common-arguments-for-all-execution-policies>`_
+Valid template arguments are described `here <../Execution-Policies.html#common-arguments-for-all-execution-policies>`_
 
 Usage
 ~~~~~

--- a/docs/source/API/core/policies/NestedPolicies.rst
+++ b/docs/source/API/core/policies/NestedPolicies.rst
@@ -35,6 +35,11 @@ List
 
 |
 
+General Template Aguments
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Valid template arguments for are described `here <../Execution-Policies.html#common-arguments-for-all-execution-policies>`_
+
 Usage
 ~~~~~
 

--- a/docs/source/API/core/policies/RangePolicy.rst
+++ b/docs/source/API/core/policies/RangePolicy.rst
@@ -84,26 +84,10 @@ Synopsis
 Parameters
 ----------
 
-Common Arguments for all Execution Policies
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+General Template Aguments
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Execution Policies generally accept compile time arguments via template parameters and runtime parameters via constructor arguments or setter functions.
-
-* Template arguments can be given in arbitrary order.
-
-+-------------------+---------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Argument          | Options                                                                   | Purpose                                                                                                                                                 |
-+===================+===========================================================================+=========================================================================================================================================================+
-| ExecutionSpace    | ``Serial``, ``OpenMP``, ``Threads``, ``Cuda``, ``HIP``, ``SYCL``, ``HPX`` | Specify the Execution Space to execute the kernel in. Defaults to ``Kokkos::DefaultExecutionSpace``.                                                    |
-+-------------------+---------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Schedule          | ``Schedule<Dynamic>``, ``Schedule<Static>``                               | Specify scheduling policy for work items. ``Dynamic`` scheduling is implemented through a work stealing queue. Default is machine and backend specific. |
-+-------------------+---------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
-| IndexType         | ``IndexType<int>``                                                        | Specify integer type to be used for traversing the iteration space. Defaults to ``int64_t``.                                                            |
-+-------------------+---------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
-| LaunchBounds      | ``LaunchBounds<MaxThreads, MinBlocks>``                                   | Specifies hints to to the compiler about CUDA/HIP launch bounds.                                                                                        |
-+-------------------+---------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
-| WorkTag           | ``SomeClass``                                                             | Specify the work tag type used to call the functor operator. Any arbitrary type defaults to ``void``.                                                   |
-+-------------------+---------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+Valid template arguments for ``RangePolicy`` are described `here <../Execution-Policies.html#common-arguments-for-all-execution-policies>`_
 
 Public Class Members
 --------------------


### PR DESCRIPTION
It just makes more sense to not repeat ourselves I think...
Came up in the wake of #552 