### PR TITLE
Document `Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE`

### DIFF
--- a/docs/source/get-started/configuration-guide.rst
+++ b/docs/source/get-started/configuration-guide.rst
@@ -243,7 +243,7 @@ Backend-specific options
       * ``ON``
 
     * * ``Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE``
-      * Build with the CMake language feature (HIP, CUDA only)
+      * Build with the CMake language feature (CUDA or HIP only)
       * ``OFF``
 
 

--- a/docs/source/get-started/configuration-guide.rst
+++ b/docs/source/get-started/configuration-guide.rst
@@ -247,7 +247,6 @@ Backend-specific options
       * ``OFF``
 
 
-
 ``Kokkos_ENABLE_CUDA_LAMBDA`` default value is ``OFF`` until 3.7 and ``ON`` since 4.0
 
 ``Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC`` default value is ``OFF`` except in 4.2, 4.3, and 4.4

--- a/docs/source/get-started/configuration-guide.rst
+++ b/docs/source/get-started/configuration-guide.rst
@@ -243,7 +243,7 @@ Backend-specific options
       * ``ON``
 
     * * ``Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE``
-      * Build with the CMake language feature (CUDA or HIP only). For info see `known issues <../known-issues.html>`_
+      * Build with the CMake language feature (CUDA or HIP only). For info see `language issues <../known-issues.html>`_
       * ``OFF``
 
 

--- a/docs/source/get-started/configuration-guide.rst
+++ b/docs/source/get-started/configuration-guide.rst
@@ -163,10 +163,6 @@ General options
       * Aggressively vectorize loops
       * ``OFF``
 
-    * * ``Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE``
-      * Build with the CMake language feature (HIP, CUDA only)
-      * ``OFF``
-
 Debugging
 ---------
 .. list-table::
@@ -245,6 +241,11 @@ Backend-specific options
     * * ``Kokkos_ENABLE_IMPL_HPX_ASYNC_DISPATCH``
       * Enable asynchronous dispatch for the HPX backend
       * ``ON``
+
+    * * ``Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE``
+      * Build with the CMake language feature (HIP, CUDA only)
+      * ``OFF``
+
 
 
 ``Kokkos_ENABLE_CUDA_LAMBDA`` default value is ``OFF`` until 3.7 and ``ON`` since 4.0

--- a/docs/source/get-started/configuration-guide.rst
+++ b/docs/source/get-started/configuration-guide.rst
@@ -163,6 +163,10 @@ General options
       * Aggressively vectorize loops
       * ``OFF``
 
+    * * ``Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE``
+      * Build with the CMake language feature (HIP, CUDA only)
+      * ``OFF``
+
 Debugging
 ---------
 .. list-table::

--- a/docs/source/get-started/configuration-guide.rst
+++ b/docs/source/get-started/configuration-guide.rst
@@ -243,7 +243,7 @@ Backend-specific options
       * ``ON``
 
     * * ``Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE``
-      * Build with the CMake language feature (CUDA or HIP only)
+      * Build with the CMake language feature (CUDA or HIP only). For info see `known issues <../known-issues.html>`_
       * ``OFF``
 
 

--- a/docs/source/known-issues.rst
+++ b/docs/source/known-issues.rst
@@ -8,13 +8,13 @@ Known issues
 Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE
 =======================================
 
-- Building with the CMake language feature can cause problems in downstream libraries/applications.
- CMake uses the file endings to determine the language a file should be compiled with. Since Kokkos files are named `cpp` and `hpp`, they are associated with `CXX` in CMake.
-  This implies that source and header files that use Kokkos might need to be redefined to be treated as another language. Otherwise, the language is detected based on the file endings. This might lead to files not being able to compile (e.g. using Kokkos in a `.cpp` file instead of a `.cu` file leads to CMake detecting `CXX` instead of `CUDA`).
-  Without specifying the language the compilation might fail depending on the capabilities of the `CXX` compiler to compile device code.
-  Furthermore, the architecture needs to be specified for every target in accordance with what `Kokkos_ARCH_...` is set and not with `CMAKE_<LANG>_ARCHITECTURES`. This also implies only one architecture can be active.
+Building with the CMake language feature can cause problems in downstream libraries/applications.
+CMake uses the file endings to determine the language a file should be compiled with. Since Kokkos files are named `cpp` and `hpp`, they are associated with `CXX` in CMake.
+This implies that source and header files that use Kokkos might need to be redefined to be treated as another language. Otherwise, the language is detected based on the file endings. This might lead to files not being able to compile (e.g. using Kokkos in a `.cpp` file instead of a `.cu` file leads to CMake detecting `CXX` instead of `CUDA`).
+Without specifying the language the compilation might fail depending on the capabilities of the `CXX` compiler to compile device code.
+Furthermore, the architecture needs to be specified for every target in accordance with what `Kokkos_ARCH_...` is set and not with `CMAKE_<LANG>_ARCHITECTURES`. This also implies only one architecture can be active.
 
-  An example for marking the files accordingly can be found in `example/build_cmake_installed_kk_as_language`
+An example for marking the files accordingly can be found in `example/build_cmake_installed_kk_as_language`
 
 CUDA
 ====

--- a/docs/source/known-issues.rst
+++ b/docs/source/known-issues.rst
@@ -31,6 +31,7 @@ CUDA
 - CUDA 11.0 through 11.2 are not compatible with glibc 2.34 librt stubs. That issue is related to how the CMake package handles linking with librt. For more information please look at issue `#7512 <https://github.com/kokkos/kokkos/issues/7512>`_.
 
 - Building an application that uses Kokkos with Microsoft Visual Studio and the `Cuda` backend enabled, requires the use of the CMake language feature, see :ref:`keywords_enable_backend_specific_options`.
+  An example for marking the files accordingly can be found in `example/build_cmake_installed_kk_as_language`
 
 HIP
 ===

--- a/docs/source/known-issues.rst
+++ b/docs/source/known-issues.rst
@@ -12,7 +12,7 @@ Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE
  CMake uses the file endings to determine the language a file should be compiled with. Since Kokkos files are named `cpp` and `hpp`, they are associated with `CXX` in CMake.
   This implies that source and header files that use Kokkos might need to be redefined to be treated as another language. Otherwise, the language is detected based on the file endings. This might lead to files not being able to compile (e.g. using Kokkos in a `.cpp` file instead of a `.cu` file leads to CMake detecting `CXX` instead of `CUDA`).
   Without specifying the language the compilation might fail depending on the capabilities of the `CXX` compiler to compile device code.
-  Furhtermore, the architecture needs to be specified for every target in accordance with what `Kokkos_ARCH_...` is set and not with `CMAKE_<LANG>_ARCHITECTURES`. This also implies only one architecture can be active.
+  Furthermore, the architecture needs to be specified for every target in accordance with what `Kokkos_ARCH_...` is set and not with `CMAKE_<LANG>_ARCHITECTURES`. This also implies only one architecture can be active.
 
   An example for marking the files accordingly can be found in `example/build_cmake_installed_kk_as_language`
 

--- a/docs/source/known-issues.rst
+++ b/docs/source/known-issues.rst
@@ -25,11 +25,12 @@ CUDA
   like UCX, is partly due to the fact that `cudaMallocAsync` uses `cudaMemPool_t,` and the default memory pool
   does not support interprocess communication (IPC) without tweaking (https://developer.nvidia.com/blog/using-cuda-stream-ordered-memory-allocator-part-2/#interprocess_communication_support).
   The user should set up the default memory pool to properly support IPC (https://developer.nvidia.com/blog/using-cuda-stream-ordered-memory-allocator-part-2/#library_composability).
-  
+
   Therefore, from version 4.5, the default behavior for Kokkos is to preventively disable `cudaMallocAsync.`
 
 - CUDA 11.0 through 11.2 are not compatible with glibc 2.34 librt stubs. That issue is related to how the CMake package handles linking with librt. For more information please look at issue `#7512 <https://github.com/kokkos/kokkos/issues/7512>`_.
 
+- Building an application that uses Kokkos with Microsoft Visual Studio and the `Cuda` backend enabled, requires the use of the CMake language feature, see :ref:`keywords_enable_options`.
 
 HIP
 ===

--- a/docs/source/known-issues.rst
+++ b/docs/source/known-issues.rst
@@ -4,6 +4,18 @@ Known issues
 .. role:: cpp(code)
     :language: cpp
 
+
+Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE
+=======================================
+
+- Building with the CMake language feature can cause problems in downstream libraries/applications.
+ CMake uses the file endings to determine the language a file should be compiled with. Since Kokkos files are named `cpp` and `hpp`, they are associated with `CXX` in CMake.
+  This implies that source and header files that use Kokkos might need to be redefined to be treated as another language. Otherwise, the language is detected based on the file endings. This might lead to files not being able to compile (e.g. using Kokkos in a `.cpp` file instead of a `.cu` file leads to CMake detecting `CXX` instead of `CUDA`).
+  Without specifying the language the compilation might fail depending on the capabilities of the `CXX` compiler to compile device code.
+  Furhtermore, the architecture needs to be specified for every target in accordance with what `Kokkos_ARCH_...` is set and not with `CMAKE_<LANG>_ARCHITECTURES`. This also implies only one architecture can be active.
+
+  An example for marking the files accordingly can be found in `example/build_cmake_installed_kk_as_language`
+
 CUDA
 ====
 
@@ -31,7 +43,6 @@ CUDA
 - CUDA 11.0 through 11.2 are not compatible with glibc 2.34 librt stubs. That issue is related to how the CMake package handles linking with librt. For more information please look at issue `#7512 <https://github.com/kokkos/kokkos/issues/7512>`_.
 
 - Building an application that uses Kokkos with Microsoft Visual Studio and the `Cuda` backend enabled, requires the use of the CMake language feature, see :ref:`keywords_enable_backend_specific_options`.
-  An example for marking the files accordingly can be found in `example/build_cmake_installed_kk_as_language`
 
 HIP
 ===

--- a/docs/source/known-issues.rst
+++ b/docs/source/known-issues.rst
@@ -30,7 +30,7 @@ CUDA
 
 - CUDA 11.0 through 11.2 are not compatible with glibc 2.34 librt stubs. That issue is related to how the CMake package handles linking with librt. For more information please look at issue `#7512 <https://github.com/kokkos/kokkos/issues/7512>`_.
 
-- Building an application that uses Kokkos with Microsoft Visual Studio and the `Cuda` backend enabled, requires the use of the CMake language feature, see :ref:`keywords_enable_options`.
+- Building an application that uses Kokkos with Microsoft Visual Studio and the `Cuda` backend enabled, requires the use of the CMake language feature, see :ref:`keywords_enable_backend_specific_options`.
 
 HIP
 ===


### PR DESCRIPTION
~Some documentation for Kokkos requiring to be built with the CMake language feature. Since `kokkos_compilation` since `kokkos_compilation` is broken see [here](https://github.com/kokkos/kokkos/issues/7144) for a momentary fix.~

~[7582](https://github.com/kokkos/kokkos/pull/7582) is a related refactor of the build system but is independent of this PR~

Stripped everything except adding the build option and a hint for msvc. fixes https://github.com/kokkos/kokkos-core-wiki/issues/661