### PR TITLE
Add example code referenced in issue #452 

### DIFF
--- a/docs/source/API/core/builtinreducers/MinLoc.rst
+++ b/docs/source/API/core/builtinreducers/MinLoc.rst
@@ -108,3 +108,44 @@ Additional Information
 * Requires: ``Index`` has ``operator =`` defined. ``Kokkos::reduction_identity<Index>::min()`` is a valid expression.
 
 * In order to use MinLoc with a custom type of either ``Scalar`` or ``Index``, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined. See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details
+
+Example
+-------
+
+.. code-block:: cpp
+
+				#include <Kokkos_Core.hpp>
+
+				struct Idx3D_t {
+				int value[3];
+				int& operator[] (int i) { return value[i]; }
+				const int& operator[] (int i) const { return value[i]; }
+				};
+
+				template<>
+				struct Kokkos::reduction_identity<Idx3D_t> {
+				static constexpr Idx3D_t min() { return {0,0,0}; }
+				};
+
+				int main(int argc, char* argv[]) {
+				    Kokkos::initialize(argc, argv);
+				    {
+				    Kokkos::View<double***> a("A",5,5,5);
+				    Kokkos::deep_copy(a,10);
+				    a(2,3,1) = 5;
+				    using MinLoc_t = Kokkos::MinLoc<double, Idx3D_t>;
+				    using MinLocVal_t = typename MinLoc_t::value_type;
+				    MinLocVal_t result;
+				    Kokkos::parallel_reduce(Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0,0,0},{5,5,5}),
+				    KOKKOS_LAMBDA(int i, int j, int k, MinLocVal_t& val) {
+				    if(a(i,j,k)<val.val) {
+				    val.val = a(i,j,k);
+				    val.loc[0] = i;
+				    val.loc[1] = j;
+				    val.loc[2] = k;
+				    }
+				    },MinLoc_t(result));
+				    printf("%lf %i %i %i\n",result.val,result.loc[0],result.loc[1],result.loc[2]);
+				    }
+				    Kokkos::finalize();
+				    }

--- a/docs/source/API/core/builtinreducers/MinLoc.rst
+++ b/docs/source/API/core/builtinreducers/MinLoc.rst
@@ -114,58 +114,38 @@ Example
 
 .. code-block:: cpp
 
-	#include <Kokkos_Core.hpp>
-	struct Idx3D_t {
-	  int value[3];
-	  int& operator[](int i) { return value[i]; }
-	  const int& operator[](int i) const { return value[i]; }
-	};
-	template <>
-	struct Kokkos::reduction_identity<Idx3D_t> {
-	  static constexpr Idx3D_t min() { return {0, 0, 0}; }
-	};
-	int main(int argc, char* argv[]) {
-	  Kokkos::initialize(argc, argv);
-	  {
-	    Kokkos::View<double***> a("A", 5, 5, 5);
-	    Kokkos::deep_copy(a, 10);
-	    a(2, 3, 1)        = 5;
-	    using MinLoc_t    = Kokkos::MinLoc<double, Idx3D_t>;
-	    using MinLocVal_t = typename MinLoc_t::value_type;
-	    MinLocVal_t result;
-	    Kokkos::parallel_reduce(
-		Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {5, 5, 5}),
-		KOKKOS_LAMBDA(int i, int j, int k, MinLocVal_t& val) {
-		  if (a(i, j, k) < val.val) {
-		    val.val    = a(i, j, k);
-		    val.loc[0] = i;
-		    val.loc[1] = j;
-		    val.loc[2] = k;
-		  }
-		},
-		MinLoc_t(result));
-	    printf("%lf %i %i %i\n", result.val, result.loc[0], result.loc[1],
-		   result.loc[2]);
-	  }
-	  Kokkos::finalize();
-	}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  #include <Kokkos_Core.hpp>
+  struct Idx3D_t {
+    int value[3];
+    int& operator[](int i) { return value[i]; }
+    const int& operator[](int i) const { return value[i]; }
+  };
+  template <>
+  struct Kokkos::reduction_identity<Idx3D_t> {
+    static constexpr Idx3D_t min() { return {0, 0, 0}; }
+  };
+  int main(int argc, char* argv[]) {
+    Kokkos::initialize(argc, argv);
+    {
+      Kokkos::View<double***> a("A", 5, 5, 5);
+      Kokkos::deep_copy(a, 10);
+      a(2, 3, 1)        = 5;
+      using MinLoc_t    = Kokkos::MinLoc<double, Idx3D_t>;
+      using MinLocVal_t = typename MinLoc_t::value_type;
+      MinLocVal_t result;
+      Kokkos::parallel_reduce(
+          Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {5, 5, 5}),
+          KOKKOS_LAMBDA(int i, int j, int k, MinLocVal_t& val) {
+            if (a(i, j, k) < val.val) {
+              val.val    = a(i, j, k);
+              val.loc[0] = i;
+              val.loc[1] = j;
+              val.loc[2] = k;
+            }
+          },
+          MinLoc_t(result));
+      printf("%lf %i %i %i\n", result.val, result.loc[0], result.loc[1],
+             result.loc[2]);
+    }
+    Kokkos::finalize();
+  }

--- a/docs/source/API/core/builtinreducers/MinLoc.rst
+++ b/docs/source/API/core/builtinreducers/MinLoc.rst
@@ -114,38 +114,38 @@ Example
 
 .. code-block:: cpp
 
-				#include <Kokkos_Core.hpp>
+    #include <Kokkos_Core.hpp>
 
-				struct Idx3D_t {
-				int value[3];
-				int& operator[] (int i) { return value[i]; }
-				const int& operator[] (int i) const { return value[i]; }
-				};
+    struct Idx3D_t {
+    int value[3];
+    int& operator[] (int i) { return value[i]; }
+    const int& operator[] (int i) const { return value[i]; }
+    };
 
-				template<>
-				struct Kokkos::reduction_identity<Idx3D_t> {
-				static constexpr Idx3D_t min() { return {0,0,0}; }
-				};
+    template<>
+    struct Kokkos::reduction_identity<Idx3D_t> {
+    static constexpr Idx3D_t min() { return {0,0,0}; }
+    };
 
-				int main(int argc, char* argv[]) {
-				    Kokkos::initialize(argc, argv);
-				    {
-				    Kokkos::View<double***> a("A",5,5,5);
-				    Kokkos::deep_copy(a,10);
-				    a(2,3,1) = 5;
-				    using MinLoc_t = Kokkos::MinLoc<double, Idx3D_t>;
-				    using MinLocVal_t = typename MinLoc_t::value_type;
-				    MinLocVal_t result;
-				    Kokkos::parallel_reduce(Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0,0,0},{5,5,5}),
-				    KOKKOS_LAMBDA(int i, int j, int k, MinLocVal_t& val) {
-				    if(a(i,j,k)<val.val) {
-				    val.val = a(i,j,k);
-				    val.loc[0] = i;
-				    val.loc[1] = j;
-				    val.loc[2] = k;
-				    }
-				    },MinLoc_t(result));
-				    printf("%lf %i %i %i\n",result.val,result.loc[0],result.loc[1],result.loc[2]);
-				    }
-				    Kokkos::finalize();
-				    }
+    int main(int argc, char* argv[]) {
+        Kokkos::initialize(argc, argv);
+        {
+        Kokkos::View<double***> a("A",5,5,5);
+        Kokkos::deep_copy(a,10);
+        a(2,3,1) = 5;
+        using MinLoc_t = Kokkos::MinLoc<double, Idx3D_t>;
+        using MinLocVal_t = typename MinLoc_t::value_type;
+        MinLocVal_t result;
+        Kokkos::parallel_reduce(Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0,0,0},{5,5,5}),
+        KOKKOS_LAMBDA(int i, int j, int k, MinLocVal_t& val) {
+        if(a(i,j,k)<val.val) {
+            val.val = a(i,j,k);
+            val.loc[0] = i;
+            val.loc[1] = j;
+            val.loc[2] = k;
+        }
+        },MinLoc_t(result));
+        printf("%lf %i %i %i\n",result.val,result.loc[0],result.loc[1],result.loc[2]);
+        }
+        Kokkos::finalize();
+    }

--- a/docs/source/API/core/builtinreducers/MinLoc.rst
+++ b/docs/source/API/core/builtinreducers/MinLoc.rst
@@ -114,38 +114,58 @@ Example
 
 .. code-block:: cpp
 
-    #include <Kokkos_Core.hpp>
+	#include <Kokkos_Core.hpp>
+	struct Idx3D_t {
+	  int value[3];
+	  int& operator[](int i) { return value[i]; }
+	  const int& operator[](int i) const { return value[i]; }
+	};
+	template <>
+	struct Kokkos::reduction_identity<Idx3D_t> {
+	  static constexpr Idx3D_t min() { return {0, 0, 0}; }
+	};
+	int main(int argc, char* argv[]) {
+	  Kokkos::initialize(argc, argv);
+	  {
+	    Kokkos::View<double***> a("A", 5, 5, 5);
+	    Kokkos::deep_copy(a, 10);
+	    a(2, 3, 1)        = 5;
+	    using MinLoc_t    = Kokkos::MinLoc<double, Idx3D_t>;
+	    using MinLocVal_t = typename MinLoc_t::value_type;
+	    MinLocVal_t result;
+	    Kokkos::parallel_reduce(
+		Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {5, 5, 5}),
+		KOKKOS_LAMBDA(int i, int j, int k, MinLocVal_t& val) {
+		  if (a(i, j, k) < val.val) {
+		    val.val    = a(i, j, k);
+		    val.loc[0] = i;
+		    val.loc[1] = j;
+		    val.loc[2] = k;
+		  }
+		},
+		MinLoc_t(result));
+	    printf("%lf %i %i %i\n", result.val, result.loc[0], result.loc[1],
+		   result.loc[2]);
+	  }
+	  Kokkos::finalize();
+	}
 
-    struct Idx3D_t {
-    int value[3];
-    int& operator[] (int i) { return value[i]; }
-    const int& operator[] (int i) const { return value[i]; }
-    };
 
-    template<>
-    struct Kokkos::reduction_identity<Idx3D_t> {
-    static constexpr Idx3D_t min() { return {0,0,0}; }
-    };
 
-    int main(int argc, char* argv[]) {
-        Kokkos::initialize(argc, argv);
-        {
-        Kokkos::View<double***> a("A",5,5,5);
-        Kokkos::deep_copy(a,10);
-        a(2,3,1) = 5;
-        using MinLoc_t = Kokkos::MinLoc<double, Idx3D_t>;
-        using MinLocVal_t = typename MinLoc_t::value_type;
-        MinLocVal_t result;
-        Kokkos::parallel_reduce(Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0,0,0},{5,5,5}),
-        KOKKOS_LAMBDA(int i, int j, int k, MinLocVal_t& val) {
-        if(a(i,j,k)<val.val) {
-            val.val = a(i,j,k);
-            val.loc[0] = i;
-            val.loc[1] = j;
-            val.loc[2] = k;
-        }
-        },MinLoc_t(result));
-        printf("%lf %i %i %i\n",result.val,result.loc[0],result.loc[1],result.loc[2]);
-        }
-        Kokkos::finalize();
-    }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
This PR adds example code from Compiler Explorer to `MinLoc` built-in reducer.