### PR TITLE
Add a note about the indices conversion checks in RangePolicy

### DIFF
--- a/docs/source/API/core/policies/RangePolicy.rst
+++ b/docs/source/API/core/policies/RangePolicy.rst
@@ -120,19 +120,19 @@ Constructors
 
    Default Constructor uninitialized policy.
 
-.. cppkokkos:function:: RangePolicy(int64_t begin, int64_t end)
+.. cppkokkos:function:: RangePolicy(IndexType begin, IndexType end)
 
    Provide a start and end index.
 
-.. cppkokkos:function:: RangePolicy(int64_t begin, int64_t end, ChunkSize chunk_size)
+.. cppkokkos:function:: RangePolicy(IndexType begin, IndexType end, ChunkSize chunk_size)
 
    Provide a start and end index as well as a ``ChunkSize``.
 
-.. cppkokkos:function:: RangePolicy(const ExecutionSpace& space, int64_t begin, int64_t end)
+.. cppkokkos:function:: RangePolicy(const ExecutionSpace& space, IndexType begin, IndexType end)
 
    Provide a start and end index and an ``ExecutionSpace`` instance to use as the execution resource.
 
-.. cppkokkos:function:: RangePolicy(const ExecutionSpace& space, int64_t begin, int64_t end, ChunkSize chunk_size)
+.. cppkokkos:function:: RangePolicy(const ExecutionSpace& space, IndexType begin, IndexType end, ChunkSize chunk_size)
 
    Provide a start and end index and an ``ExecutionSpace`` instance to use as the execution resource, as well as a ``ChunkSize``.
 
@@ -141,6 +141,7 @@ Preconditions:
 
 * The start index must not be greater than the end index.
 * The actual constructors are templated so we can check that they are converted to ``index_type`` safely (see `#6754 <https://github.com/kokkos/kokkos/pull/6754>`_).
+   * The conversion safety check is only performed if ``index_type`` is convertible to the start and end index types.
 
 CTAD Constructors (since 4.3):
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Changed argument index types from `int64_t` to `IndexType` to better describe what's really in the implementation, which is templated type that is required to be convertible to `IndexType`.
It's already noted that the internal `IndexType` will be defaulted to `int64_t` if not specified.

Also added a note about changed behavior in conversion safety check when roundtrip convertibility is not provided (from https://github.com/kokkos/kokkos/pull/7172).