### PR TITLE
Say where one can find out what clang-version we use

### DIFF
--- a/docs/source/testing-and-issue-tracking/Testing-Processes.md
+++ b/docs/source/testing-and-issue-tracking/Testing-Processes.md
@@ -33,7 +33,9 @@ These test configurations (sparsely) cover the cross product of hardware platfor
 compilers (e.g. GCC, Clang, NVC++), C++ standards (17-23), Kokkos backends (e.g. Cuda, OpenMP, and HIP) and Kokkos
 configuration options (e.g. Debug, Relocatable Device Code).
 
-The clang-format style file is `kokkos/.clang-format`.
+The clang-format style file is `kokkos/.clang-format`. The clang-format version
+to use is specified as a comment in the header of the `.clang-format`
+configuration file.
 
 Only the primary Kokkos maintainers can merge pull requests, they have the responsibility to judge whether conducted reviews meet the desired thoroughness.
 


### PR DESCRIPTION
Partial fix for kokkos/kokkos#7177