### PR TITLE
Add note about ChunkSize explicit constructor since 4.4

### DIFF
--- a/docs/source/API/core/policies/RangePolicy.rst
+++ b/docs/source/API/core/policies/RangePolicy.rst
@@ -30,7 +30,7 @@ Synopsis
 .. code-block:: cpp
 
     struct Kokkos::ChunkSize {
-        ChunkSize(int value_);
+        explicit ChunkSize(int value_);
     };
 
     template<class ... Args>
@@ -95,7 +95,7 @@ Public Class Members
 Constructors
 ~~~~~~~~~~~~
 
-.. cppkokkos:function:: ChunkSize(int value_)
+.. cppkokkos:function:: explicit ChunkSize(int value_)
 
    Provide a hint for optimal chunk-size to be used during scheduling.
    For the SYCL backend, the workgroup size used in a ``parallel_for`` kernel can be set via this passed to ``RangePolicy``.

--- a/docs/source/API/core/policies/RangePolicy.rst
+++ b/docs/source/API/core/policies/RangePolicy.rst
@@ -100,6 +100,8 @@ Constructors
    Provide a hint for optimal chunk-size to be used during scheduling.
    For the SYCL backend, the workgroup size used in a ``parallel_for`` kernel can be set via this passed to ``RangePolicy``.
 
+   .. note:: ``ChunkSize`` constructor ``explicit`` since Kokkos 4.4
+
 .. cppkokkos:function:: RangePolicy()
 
    Default Constructor uninitialized policy.


### PR DESCRIPTION
I chose to use a "note", but I'm happy to switch to a "warning" or bold text (done other places) or other suggestions. 