### PR TITLE
Add descriptions for tile size getters in MDRangePolicy

### DIFF
--- a/docs/source/API/core/policies/MDRangePolicy.rst
+++ b/docs/source/API/core/policies/MDRangePolicy.rst
@@ -121,7 +121,7 @@ Member Functions
 ^^^^^^^^^^^^^^^^
 .. cppkokkos:function:: tile_type tile_size_recommended() const
 
-    * Returns a ``Kokkos::Array<array_index_type, rank>`` type containing per-rank tile sizes that ``MDRangePolicy`` interally uses by default. The default tile sizes are static and are set based on specified backend.
+    * Returns a ``Kokkos::Array<array_index_type, rank>`` type containing per-rank tile sizes that ``MDRangePolicy`` interally uses by default. The default tile sizes are static and are set based on the specified backend.
 
 .. cppkokkos:function:: int max_total_tile_size() const
 

--- a/docs/source/API/core/policies/MDRangePolicy.rst
+++ b/docs/source/API/core/policies/MDRangePolicy.rst
@@ -117,6 +117,16 @@ CTAD Constructors (since 4.3)
    MDRangePolicy pa4(ses, abegin, aend);
    MDRangePolicy pa5(ses, abegin, aend, atiling);
 
+Member Functions
+^^^^^^^^^^^^^^^^
+.. cppkokkos:function:: tile_type tile_size_recommended() const
+
+    * Returns a ``Kokkos::Array<array_index_type, rank>`` type containing per-rank tile sizes that ``MDRangePolicy`` interally uses by default. The default tile sizes are static and are set based on specified backend.
+
+.. cppkokkos:function:: int max_total_tile_size() const
+
+    * Returns a value that represents the upper limit for the product of all tile sizes.
+
 Notes
 ^^^^^
 

--- a/docs/source/API/core/policies/MDRangePolicy.rst
+++ b/docs/source/API/core/policies/MDRangePolicy.rst
@@ -123,9 +123,13 @@ Member Functions
 
     * Returns a ``Kokkos::Array<array_index_type, rank>`` type containing per-rank tile sizes that ``MDRangePolicy`` internally uses by default. The default tile sizes are static and are set based on the specified backend.
 
+    .. note:: ``tile_size_recommended()`` available since Kokkos 4.5
+
 .. cppkokkos:function:: int max_total_tile_size() const
 
     * Returns a value that represents the upper limit for the product of all tile sizes.
+
+    .. note:: ``max_total_tile_size()`` available since Kokkos 4.5
 
 Notes
 ^^^^^

--- a/docs/source/API/core/policies/MDRangePolicy.rst
+++ b/docs/source/API/core/policies/MDRangePolicy.rst
@@ -121,7 +121,7 @@ Member Functions
 ^^^^^^^^^^^^^^^^
 .. cppkokkos:function:: tile_type tile_size_recommended() const
 
-    * Returns a ``Kokkos::Array<array_index_type, rank>`` type containing per-rank tile sizes that ``MDRangePolicy`` interally uses by default. The default tile sizes are static and are set based on the specified backend.
+    * Returns a ``Kokkos::Array<array_index_type, rank>`` type containing per-rank tile sizes that ``MDRangePolicy`` internally uses by default. The default tile sizes are static and are set based on the specified backend.
 
 .. cppkokkos:function:: int max_total_tile_size() const
 


### PR DESCRIPTION
Related to https://github.com/kokkos/kokkos/pull/6839.

Added descriptions for `tile_size_recommended()` and `max_total_tile_size()` in `MDRangePolicy`.