### PR TITLE
core(view): warn about the implications of without initializing

### DIFF
--- a/docs/source/ProgrammingGuide/View.rst
+++ b/docs/source/ProgrammingGuide/View.rst
@@ -97,7 +97,9 @@ Finally, note that virtual functions are technically allowed, but calling them i
 6.2.3 Can I make a View of Views?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-NOVICES: THE ANSWER FOR YOU IS "NO."  PLEASE SKIP THIS SECTION.  
+.. warning::
+
+  NOVICES: THE ANSWER FOR YOU IS "NO."  PLEASE SKIP THIS SECTION.  
 
 A "View of Views" is a special case of View, where the type of each entry is itself a View. It is possible to make this, but before you try, please see below.
 

--- a/docs/source/ProgrammingGuide/View.rst
+++ b/docs/source/ProgrammingGuide/View.rst
@@ -460,6 +460,14 @@ in a way that reflects how first-touch affinity to threads is desired.
 Typically it is sufficient to use the parallel iteration index as the index of the location in the
 view to write to.
 
+.. warning::
+
+  :cppkokkos:`WithoutInitialization` implies that the destructor of each element of the :cppkokkos:`View` **will not be called**.
+  For instance, if the :cppkokkos:`View`'s value type is not trivially destructible,
+  you **should not use** :cppkokkos:`WithoutInitialization` unless you are taking care of calling the destructor manually before the :cppkokkos:`View` deallocates its memory.
+
+  The mental model is that whenever placement new is used to call the constructor, the destructor also isn't called before the memory is deallocated but it needs to be called manually.
+
 6.4.3 Deep copy and HostMirror
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This PR describes what `Kokkos::WithoutInitialization` implies.