### PR TITLE
Improve ProgramminGuide/View

### DIFF
--- a/docs/source/ProgrammingGuide/View.rst
+++ b/docs/source/ProgrammingGuide/View.rst
@@ -415,13 +415,11 @@ The following is the accessibility matrix for execution and memory spaces:
 
 .. csv-table::
 
-  ,Serial, OpenMP, Threads, Cuda, HIP,
-  HostSpace,           :octicon:`check` , :octicon:`check` , :octicon:`check` , :octicon:`x`     , :octicon:`x` ,
-  CudaSpace,           :octicon:`x`     , :octicon:`x`     , :octicon:`x`     , :octicon:`check` , :octicon:`x` ,
-  CudaUVMSpace,        :octicon:`check` , :octicon:`check` , :octicon:`check` , :octicon:`check` , :octicon:`x` ,
-  CudaHostPinnedSpace, :octicon:`check` , :octicon:`check` , :octicon:`check` , :octicon:`check` , :octicon:`x` ,
-  HIPSpace,            :octicon:`x`     , :octicon:`x`     , :octicon:`x`     , :octicon:`x`     , :octicon:`check` ,
-  HIPHostPinnedSpace,  :octicon:`check` , :octicon:`check` , :octicon:`check` , :octicon:`x`     , :octicon:`check` ,
+  ,Serial, OpenMP, Threads, Cuda
+  HostSpace,           :octicon:`check` , :octicon:`check` , :octicon:`check` , :octicon:`x`     ,
+  CudaSpace,           :octicon:`x`     , :octicon:`x`     , :octicon:`x`     , :octicon:`check` ,
+  CudaUVMSpace,        :octicon:`check` , :octicon:`check` , :octicon:`check` , :octicon:`check` ,
+  CudaHostPinnedSpace, :octicon:`check` , :octicon:`check` , :octicon:`check` , :octicon:`check` ,
 
 This relationship can be queried via the `SpaceAccessibility` class:
 

--- a/docs/source/ProgrammingGuide/View.rst
+++ b/docs/source/ProgrammingGuide/View.rst
@@ -416,12 +416,12 @@ The following is the accessibility matrix for execution and memory spaces:
 .. csv-table::
 
   ,Serial, OpenMP, Threads, Cuda, HIP,
-  HostSpace,           x , x , x ,   ,  ,
-  CudaSpace,             ,   ,   , x ,  ,
-  CudaUVMSpace,        x , x , x , x ,  ,
-  CudaHostPinnedSpace, x , x , x , x ,  ,
-  HIPSpace,              ,   ,   ,  , x ,
-  HIPHostPinnedSpace,  x , x , x ,  , x ,
+  HostSpace,           :octicon:`check` , :octicon:`check` , :octicon:`check` , :octicon:`x`     , :octicon:`x` ,
+  CudaSpace,           :octicon:`x`     , :octicon:`x`     , :octicon:`x`     , :octicon:`check` , :octicon:`x` ,
+  CudaUVMSpace,        :octicon:`check` , :octicon:`check` , :octicon:`check` , :octicon:`check` , :octicon:`x` ,
+  CudaHostPinnedSpace, :octicon:`check` , :octicon:`check` , :octicon:`check` , :octicon:`check` , :octicon:`x` ,
+  HIPSpace,            :octicon:`x`     , :octicon:`x`     , :octicon:`x`     , :octicon:`x`     , :octicon:`check` ,
+  HIPHostPinnedSpace,  :octicon:`check` , :octicon:`check` , :octicon:`check` , :octicon:`x`     , :octicon:`check` ,
 
 This relationship can be queried via the `SpaceAccessibility` class:
 

--- a/docs/source/ProgrammingGuide/View.rst
+++ b/docs/source/ProgrammingGuide/View.rst
@@ -534,7 +534,7 @@ A user is in most cases also allowed to obtain a pointer to a specific element v
     someLibraryFunction(&x(3));
   }
 
-This is only valid if a Views reference type is an `lvalue`. That property can be queried statically at compile time from the view through its `reference_is_lvalue` member.
+This is only valid if a Views reference type is an `lvalue`. That property can be queried statically at compile time from the view through its `reference_type_is_lvalue` member.
 
 
 6.5 Access traits


### PR DESCRIPTION
- `reference_is_lvalue` should be `reference_type_is_lvalue`
- use `octicon` for the accessibilty table to improve appearance
- remove HIP from the table since Cuda is used as an example and it doesn't make sense to ask for accessibility between a Cuda execution space and HIP memory spaces since they can't be available at the same time anyway. 