### PR TITLE
Request Clang Formatting for Contributions to Main Project & Documentation Examples

### DIFF
--- a/docs/source/developer-guides/prs-and-reviews.rst
+++ b/docs/source/developer-guides/prs-and-reviews.rst
@@ -38,7 +38,7 @@ Public Interfaces
 Internal Implementation
 -----------------------
 
-- Format proposed code using clang utility, "clang-format -i," to be consistent with the Kokkos code base
+- Format proposed code using clang utility, "clang-format -i," for consistency with the Kokkos code base
 - is there unnecessary code duplication
   - in particular: is code that can be shared across backends shared?
 - did it go in the right sub-part of Kokkos (core, algorithms, containers etc.)

--- a/docs/source/developer-guides/prs-and-reviews.rst
+++ b/docs/source/developer-guides/prs-and-reviews.rst
@@ -38,7 +38,7 @@ Public Interfaces
 Internal Implementation
 -----------------------
 
-- is the implementation style consistent with the rest of Kokkos
+- Format proposed code using clang utility, "clang-format -i," to be consistent with the Kokkos code base
 - is there unnecessary code duplication
   - in particular: is code that can be shared across backends shared?
 - did it go in the right sub-part of Kokkos (core, algorithms, containers etc.)

--- a/docs/source/templates/class_api.rst
+++ b/docs/source/templates/class_api.rst
@@ -161,7 +161,7 @@ Examples
 
   Prefer working and compilable examples to prose descriptions (such as "Usage").
 
-  Example code should be formatted (in a separate temporary file) using the clang compiler "clang-format -i" utility, and subsequently transferred to documentation entry. 
+  Example code should be formatted (in a separate temporary file) using the clang compiler "clang-format -i" utility, and subsequently transferred to documentation entry.
 
 .. code-block:: cpp
 

--- a/docs/source/templates/class_api.rst
+++ b/docs/source/templates/class_api.rst
@@ -161,6 +161,8 @@ Examples
 
   Prefer working and compilable examples to prose descriptions (such as "Usage").
 
+  Example code should be formatted (in a separate temporary file) using the clang compiler "clang-format -i" utility, and subsequently transferred to documentation entry. 
+
 .. code-block:: cpp
 
   #include <Kokkos_Core.hpp>


### PR DESCRIPTION
Formatting requirements are not documented.  This PR aims to provide concrete guidance on code formatting vs. general (or no) statements about indentation.  The outstanding question is whether a specific version of `clang-format` would be needed -- a particular version could be a bit of a challenge for external contributors.