### PR TITLE
Update concept for execution space instances

### DIFF
--- a/docs/source/API/core/KokkosConcepts.rst
+++ b/docs/source/API/core/KokkosConcepts.rst
@@ -102,8 +102,7 @@ and ``OpenMPTarget``, the current state of the Kokkos |ExecutionSpaceTwo|_ conce
 
     template <typename Ex>
     concept ExecutionSpace =
-        Regular<Ex> &&
-        Destructible<Ex> &&
+        std::regular<Ex> &&
         // Member type requirements:
         requires() {
             typename Ex::execution_space;

--- a/docs/source/API/core/KokkosConcepts.rst
+++ b/docs/source/API/core/KokkosConcepts.rst
@@ -102,7 +102,7 @@ and ``OpenMPTarget``, the current state of the Kokkos |ExecutionSpaceTwo|_ conce
 
     template <typename Ex>
     concept ExecutionSpace =
-        SemiRegular<Ex> &&
+        Regular<Ex> &&
         Destructible<Ex> &&
         // Member type requirements:
         requires() {

--- a/docs/source/API/core/KokkosConcepts.rst
+++ b/docs/source/API/core/KokkosConcepts.rst
@@ -121,6 +121,7 @@ and ``OpenMPTarget``, the current state of the Kokkos |ExecutionSpaceTwo|_ conce
         // Required methods:
         requires(Ex ex, std::string str, std::ostream& ostr, bool detail) {
             { ex.fence(str) };
+            { ex.fence() };
             { ex.name() } -> const char*;
             { ex.concurrency() } -> int;
             { ex.print_configuration(ostr) };

--- a/docs/source/API/core/KokkosConcepts.rst
+++ b/docs/source/API/core/KokkosConcepts.rst
@@ -121,7 +121,6 @@ and ``OpenMPTarget``, the current state of the Kokkos |ExecutionSpaceTwo|_ conce
         } &&
         // Required methods:
         requires(Ex ex, std::ostream& ostr, bool detail) {
-            { ex.in_parallel() } -> bool;
             { ex.fence() };
             { ex.name() } -> const char*;
             { ex.print_configuration(ostr) };

--- a/docs/source/API/core/KokkosConcepts.rst
+++ b/docs/source/API/core/KokkosConcepts.rst
@@ -102,8 +102,7 @@ and ``OpenMPTarget``, the current state of the Kokkos |ExecutionSpaceTwo|_ conce
 
     template <typename Ex>
     concept ExecutionSpace =
-        CopyConstructible<Ex> &&
-        DefaultConstructible<Ex> &&
+        SemiRegular<Ex> &&
         Destructible<Ex> &&
         // Member type requirements:
         requires() {
@@ -120,9 +119,10 @@ and ``OpenMPTarget``, the current state of the Kokkos |ExecutionSpaceTwo|_ conce
             typename Ex::device_type;
         } &&
         // Required methods:
-        requires(Ex ex, std::ostream& ostr, bool detail) {
-            { ex.fence() };
+        requires(Ex ex, std::string str, std::ostream& ostr, bool detail) {
+            { ex.fence(str) };
             { ex.name() } -> const char*;
+            { ex.concurrency() } -> int;
             { ex.print_configuration(ostr) };
             { ex.print_configuration(ostr, detail) };
         } &&
@@ -213,14 +213,6 @@ There are other places where we're providing partial specializations using concr
 such as ``Impl::TeamPolicyInternal``. These also qualify as "requirements" on an ``ExecutionSpace``,
 just like ``Impl::ParallelFor<...>``. In many of these cases, it would be nice if we could refactor
 some things to use a less "all-or-nothing" approach to customization than partial class template specialization.
-
-Design Thoughts
-~~~~~~~~~~~~~~~
-
-The first thing that comes to mind is that ``CopyConstructible<T> && DefaultConstructible<T> && Destructible<T>``
-is very close to ``SemiRegular<T>``; all we need to do is add ``operator==()``.
-
-TODO more here
 
 The ``MemorySpace`` Concept
 ---------------------------

--- a/docs/source/API/core/KokkosConcepts.rst
+++ b/docs/source/API/core/KokkosConcepts.rst
@@ -207,23 +207,6 @@ Support for ``UniqueToken`` adds the following requirements:
         && CopyConstructible<Experimental::UniqueToken<Ex, Experimental::UniqueTokenScope::Global>>
         && DefaultConstructible<Experimental::UniqueToken<Ex, Experimental::UniqueTokenScope::Global>>;
 
-An Additional Concept for ``DeviceExecutionSpace``?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-All the device execution spaces, in their current state, have two extra member functions,
-``sleep()`` and ``wake()``.  It's unclear whether this is intended to be general,
-but if it is, there is an additional concept in the hierarchy:
-
-.. code-block:: cpp
-
-    template <typename Ex>
-    concept DeviceExecutionSpace =
-        ExecutionSpace<Ex> &&
-        requires(Ex ex) {
-            { ex.sleep() };
-            { ex.wake() };
-        }
-
 Some *de facto* Requirements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/API/core/execution_spaces.rst
+++ b/docs/source/API/core/execution_spaces.rst
@@ -210,9 +210,9 @@ and an instance of that type ``ex``, Kokkos guarantees the following expressions
 
 .. code-block:: cpp
 
-    ex.fence();
+    ex.fence(str);
 
-*Effects:* Upon return, all parallel patterns executed on the instance ``ex`` are guaranteed to have completed, and their effects are guaranteed visible to the calling thread.
+*Effects:* Upon return, all parallel patterns executed on the instance ``ex`` are guaranteed to have completed, and their effects are guaranteed visible to the calling thread. ``str`` is reported to Kokkos Tools.
 *Returns:* Nothing.
 *Note:* This *cannot* be called from within a parallel pattern.  Doing so will lead to unspecified effects (i.e., it might work, but only for some execution spaces, so be extra careful not to do it).
 

--- a/docs/source/API/core/execution_spaces.rst
+++ b/docs/source/API/core/execution_spaces.rst
@@ -212,7 +212,7 @@ and an instance of that type ``ex``, Kokkos guarantees the following expressions
 
     ex.fence(str);
 
-*Effects:* Upon return, all parallel patterns executed on the instance ``ex`` are guaranteed to have completed, and their effects are guaranteed visible to the calling thread. ``str`` is reported to Kokkos Tools.
+*Effects:* Upon return, all parallel patterns executed on the instance ``ex`` are guaranteed to have completed, and their effects are guaranteed visible to the calling thread. The optiopnal ``str`` argument allows customizing the event reported to Kokkos Tools.
 *Returns:* Nothing.
 *Note:* This *cannot* be called from within a parallel pattern.  Doing so will lead to unspecified effects (i.e., it might work, but only for some execution spaces, so be extra careful not to do it).
 
@@ -276,6 +276,7 @@ Synopsis
         int concurrency() const;
 
         void fence(const std::string&) const;
+        void fence() const;
 
         friend bool operator==(const execution_space& lhs, const execution_space& rhs);
     };
@@ -319,7 +320,7 @@ Functions
 
 * ``int concurrency() const;`` *Returns* the maximum amount of concurrently executing work items in a parallel setting, i.e. the maximum number of threads utilized by an execution space instance.
 
-* ``void fence(const std::string&) const;`` *Effects:* Upon return, all parallel patterns executed on the instance |ExecutionSpaceConcept|_ are guaranteed to have completed, and their effects are guaranteed visible to the calling thread. *Note:* This *cannot* be called from within a parallel pattern. Doing so will lead to unspecified effects (i.e., it might work, but only for some execution spaces, so be extra careful not to do it). The argument will be reported to Kokkos Tools.
+* ``void fence(const std::string& label) const;`` *Effects:* Upon return, all parallel patterns executed on the instance |ExecutionSpaceConcept|_ are guaranteed to have completed, and their effects are guaranteed visible to the calling thread. *Note:* This *cannot* be called from within a parallel pattern. Doing so will lead to unspecified effects (i.e., it might work, but only for some execution spaces, so be extra careful not to do it). The optional ``label`` argument allows customizing the event reported to Kokkos Tools.
 
 * ``void print_configuration(std::ostream ostr) const;``: *Effects:* Outputs the configuration of ``ex`` to the given ``std::ostream``. *Note:* This *cannot* be called from within a parallel pattern.
 

--- a/docs/source/API/core/execution_spaces.rst
+++ b/docs/source/API/core/execution_spaces.rst
@@ -275,7 +275,7 @@ Synopsis
 
         int concurrency() const;
 
-        void fence() const;
+        void fence(const std::string&) const;
 
         friend bool operator==(const execution_space& lhs, const execution_space& rhs);
     };
@@ -317,7 +317,9 @@ Functions
 
 * ``const char* name() const;``: *Returns* the label of the execution space instance.
 
-* ``void fence() const;`` *Effects:* Upon return, all parallel patterns executed on the instance |ExecutionSpaceConcept|_ are guaranteed to have completed, and their effects are guaranteed visible to the calling thread. *Note:* This *cannot* be called from within a parallel pattern. Doing so will lead to unspecified effects (i.e., it might work, but only for some execution spaces, so be extra careful not to do it).
+* ``int concurrency() const;`` *Returns* the maximum amount of concurrently executing work items in a parallel setting, i.e. the maximum number of threads utilized by an execution space instance.
+
+* ``void fence(const std::string&) const;`` *Effects:* Upon return, all parallel patterns executed on the instance |ExecutionSpaceConcept|_ are guaranteed to have completed, and their effects are guaranteed visible to the calling thread. *Note:* This *cannot* be called from within a parallel pattern. Doing so will lead to unspecified effects (i.e., it might work, but only for some execution spaces, so be extra careful not to do it). The argument will be reported to Kokkos Tools.
 
 * ``void print_configuration(std::ostream ostr) const;``: *Effects:* Outputs the configuration of ``ex`` to the given ``std::ostream``. *Note:* This *cannot* be called from within a parallel pattern.
 

--- a/docs/source/API/core/execution_spaces.rst
+++ b/docs/source/API/core/execution_spaces.rst
@@ -212,7 +212,7 @@ and an instance of that type ``ex``, Kokkos guarantees the following expressions
 
     ex.fence(str);
 
-*Effects:* Upon return, all parallel patterns executed on the instance ``ex`` are guaranteed to have completed, and their effects are guaranteed visible to the calling thread. The optiopnal ``str`` argument allows customizing the event reported to Kokkos Tools.
+*Effects:* Upon return, all parallel patterns and deep_copy calls executed on the instance ``ex`` are guaranteed to have completed, and their effects are guaranteed visible to the calling thread. The optiopnal ``str`` argument allows customizing the event reported to Kokkos Tools.
 *Returns:* Nothing.
 *Note:* This *cannot* be called from within a parallel pattern.  Doing so will lead to unspecified effects (i.e., it might work, but only for some execution spaces, so be extra careful not to do it).
 

--- a/docs/source/API/core/execution_spaces.rst
+++ b/docs/source/API/core/execution_spaces.rst
@@ -320,7 +320,7 @@ Functions
 
 * ``int concurrency() const;`` *Returns* the maximum amount of concurrently executing work items in a parallel setting, i.e. the maximum number of threads utilized by an execution space instance.
 
-* ``void fence(const std::string& label) const;`` *Effects:* Upon return, all parallel patterns executed on the instance |ExecutionSpaceConcept|_ are guaranteed to have completed, and their effects are guaranteed visible to the calling thread. *Note:* This *cannot* be called from within a parallel pattern. Doing so will lead to unspecified effects (i.e., it might work, but only for some execution spaces, so be extra careful not to do it). The optional ``label`` argument allows customizing the event reported to Kokkos Tools.
+* ``void fence(const std::string& label = unspecified-default-value) const;`` *Effects:* Upon return, all parallel patterns executed on the instance |ExecutionSpaceConcept|_ are guaranteed to have completed, and their effects are guaranteed visible to the calling thread. *Note:* This *cannot* be called from within a parallel pattern. Doing so will lead to unspecified effects (i.e., it might work, but only for some execution spaces, so be extra careful not to do it). The optional ``label`` argument allows customizing the event reported to Kokkos Tools.
 
 * ``void print_configuration(std::ostream ostr) const;``: *Effects:* Outputs the configuration of ``ex`` to the given ``std::ostream``. *Note:* This *cannot* be called from within a parallel pattern.
 

--- a/docs/source/API/core/execution_spaces.rst
+++ b/docs/source/API/core/execution_spaces.rst
@@ -210,13 +210,6 @@ and an instance of that type ``ex``, Kokkos guarantees the following expressions
 
 .. code-block:: cpp
 
-    ex.in_parallel();
-
-*Returns:* a value convertible to ``bool`` indicating whether or not the caller is executing as part of a Kokkos parallel pattern.
-*Note:* as currently implemented, there is no guarantee that ``true`` means the caller is necessarily executing as part of a pattern on the particular instance ``ex``; just *some* instance of ``Ex``. This may be strengthened in the future.
-
-.. code-block:: cpp
-
     ex.fence();
 
 *Effects:* Upon return, all parallel patterns executed on the instance ``ex`` are guaranteed to have completed, and their effects are guaranteed visible to the calling thread.
@@ -280,7 +273,6 @@ Synopsis
         void print_configuration(std::ostream ostr&) const;
         void print_configuration(std::ostream ostr&, bool details) const;
 
-        bool in_parallel() const;
         int concurrency() const;
 
         void fence() const;
@@ -324,10 +316,6 @@ Functions
 ~~~~~~~~~
 
 * ``const char* name() const;``: *Returns* the label of the execution space instance.
-
-* ``bool in_parallel() const;``: *Returns* a value convertible to ``bool`` indicating whether the caller is executing as part of a Kokkos parallel pattern. *Note:* as currently implemented, there is no guarantee that ``true`` means the caller is necessarily executing as part of a pattern on the particular instance |ExecutionSpaceConcept|_; just *some* instance of |ExecutionSpaceConcept|_. This may be strengthened in the future.
-
-* ``int concurrency() const;`` *Returns* the maximum amount of concurrently executing work items in a parallel setting, i.e. the maximum number of threads utilized by an execution space instance.
 
 * ``void fence() const;`` *Effects:* Upon return, all parallel patterns executed on the instance |ExecutionSpaceConcept|_ are guaranteed to have completed, and their effects are guaranteed visible to the calling thread. *Note:* This *cannot* be called from within a parallel pattern. Doing so will lead to unspecified effects (i.e., it might work, but only for some execution spaces, so be extra careful not to do it).
 


### PR DESCRIPTION
Related to https://github.com/kokkos/kokkos/issues/7319.
- in_parallel is deprecated
- execution spaces are regular now
- wake and sleep don't exist anymore
- we missed concurrency