### PR TITLE
Update public headers

### DIFF
--- a/docs/source/API/core/view/layoutLeft.rst
+++ b/docs/source/API/core/view/layoutLeft.rst
@@ -4,7 +4,7 @@
 .. role:: cppkokkos(code)
    :language: cppkokkos
 
-Header File: ``<Kokkos_Layout.hpp>``
+Header File: ``<Kokkos_Core.hpp>``
 
 Usage
 -----

--- a/docs/source/API/core/view/layoutRight.rst
+++ b/docs/source/API/core/view/layoutRight.rst
@@ -4,7 +4,7 @@
 .. role:: cppkokkos(code)
    :language: cppkokkos
 
-Header File: ``<Kokkos_Layout.hpp>``
+Header File: ``<Kokkos_Core.hpp>``
 
 Usage
 -----

--- a/docs/source/API/core/view/layoutStride.rst
+++ b/docs/source/API/core/view/layoutStride.rst
@@ -4,7 +4,7 @@
 .. role:: cppkokkos(code)
     :language: cppkokkos
 
-Header File: ``<Kokkos_Layout.hpp>``
+Header File: ``<Kokkos_Core.hpp>``
 
 Usage
 -----

--- a/docs/source/API/core/view/view_alloc.rst
+++ b/docs/source/API/core/view/view_alloc.rst
@@ -4,7 +4,7 @@
 .. role:: cppkokkos(code)
    :language: cppkokkos
 
-Header File: ``<Kokkos_View.hpp>``
+Header File: ``<Kokkos_Core.hpp>``
 
 Usage
 -----


### PR DESCRIPTION
Following discussion https://github.com/kokkos/kokkos/pull/7320#issuecomment-2353200996, as of Kokkos 4.4, `Kokkos_View.hpp` and `Kokkos_Layout.hpp` are not public headers.