### PR TITLE
Re-add 2x missing CMake IMPL_ flags to the Wiki

### DIFF
--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -222,7 +222,7 @@ Backend-specific options
       * Disable atomics when no host parallel nor device backend is enabled for Serial only builds (since Kokkos 4.3)
       * ``OFF``
     * * ``Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC``
-      * Enable ``cudaMallocAsync`` (requires CUDA Toolkit 11.2). This optimization may
+      * Enable ``cudaMallocAsync`` (requires CUDA Toolkit version 11.2 or higher). This optimization may
 	improve performance in applications with multiple CUDA streams per device, but it
 	is known to be incompatible with MPI distributions built on older versions of UCX
 	and many Cray MPICH instances. See `kokkos/kokkos#7353 <https://github.com/kokkos/kokkos/pull/7353>`_

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -238,7 +238,7 @@ Backend-specific options
 
 Any CMake keyword containing `IMPL` can fundamentally alter the underlying implementation
 of Kokkos on a given backend. It is encouraged not to set these unless the user knows what
-they are doing can accept the behavior changing without warning.
+they are doing and can accept the behavior changing without warning.
 
 
 Development

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -221,9 +221,16 @@ Backend-specific options
     * * ``Kokkos_ENABLE_ATOMICS_BYPASS``
       * Disable atomics when no host parallel nor device backend is enabled for Serial only builds (since Kokkos 4.3)
       * ``OFF``
-       
-
+    * * ``Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC``
+      * Enable ``cudaMallocAsync`` (requires CUDA Toolkit 11.2). This optimization may
+	improve performance in applications with multiple CUDA streams per device, but it
+	is known to be incompatible with MPI distributions built on older versions of UCX
+	and many Cray MPICH instances. See `kokkos/kokkos#7353 <https://github.com/kokkos/kokkos/pull/7353>`_
+      * ``ON``       
+	
 ``Kokkos_ENABLE_CUDA_LAMBDA`` default value is ``OFF`` until 3.7 and ``ON`` since 4.0
+
+``Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC`` default value is ``OFF`` until 4.2, and ``ON`` until 4.5
 
 Development
 -----------

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -10,14 +10,13 @@ CMake Keywords
    Recall that to set a keyword in CMake you used the syntax ``-Dkeyword_name=value``.
 
 .. note::
-   You may use the ``ccmake`` curses GUI to browse the complete list of
-   available CMake options and their current settings. It may be more current to your
-   Kokkos version than this Wiki's list.
-
-.. warning::
-   Any CMake keyword containing `IMPL_` can fundamentally alter the underlying implementation
-   of Kokkos on a given backend. It is encouraged not to set these unless the user knows what
-   they are doing and can accept the behavior changing without warning.
+   The ``ccmake`` graphical user interface offers a convenient way to explore
+   available CMake options and their current values. It may be more up to date
+   with the Kokkos version that you are using.
+   **A word of warning:** variables with names containing ``IMPL`` are private
+   implementation detailis. Avoid modifying these unless you have a deep
+   understanding of their implications and are aware that they might change
+   without notice.
    
 
 This page is organized in four sections:
@@ -216,6 +215,13 @@ Backend-specific options
       * Use unified memory (UM) by default for CUDA
       * ``OFF``
 
+    * * ``Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC``
+      * Use ``cudaMallocAsync`` (requires CUDA Toolkit version 11.2 or higher). This
+	optimization may improve performance in applications with multiple CUDA streams per device, but it
+	is known to be incompatible with MPI distributions built on older versions of UCX
+	and many Cray MPICH instances. See `known issues <known-issues.html#cuda>`_.
+      * (see below)
+
     * * ``Kokkos_ENABLE_HIP_MULTIPLE_KERNEL_INSTANTIATIONS``
       * Instantiate multiple kernels at compile time - improve performance but increase compile time
       * ``OFF``
@@ -227,12 +233,6 @@ Backend-specific options
     * * ``Kokkos_ENABLE_ATOMICS_BYPASS``
       * Disable atomics when no host parallel nor device backend is enabled for Serial only builds (since Kokkos 4.3)
       * ``OFF``
-    * * ``Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC``
-      * Enable ``cudaMallocAsync`` (requires CUDA Toolkit version 11.2 or higher). This
-	optimization may improve performance in applications with multiple CUDA streams per device, but it
-	is known to be incompatible with MPI distributions built on older versions of UCX
-	and many Cray MPICH instances. See `known issues <known-issues.html#cuda>`_.
-      * ``ON``
 	
     * * ``Kokkos_ENABLE_IMPL_HPX_ASYNC_DISPATCH``
       * Enable asynchronous dispatch for the HPX backend
@@ -241,7 +241,7 @@ Backend-specific options
 	
 ``Kokkos_ENABLE_CUDA_LAMBDA`` default value is ``OFF`` until 3.7 and ``ON`` since 4.0
 
-``Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC`` default value is ``OFF`` until 4.2, and ``ON`` until 4.5
+``Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC`` default value is ``OFF`` except in 4.2, 4.3, and 4.4
 
 
 

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -236,6 +236,9 @@ Backend-specific options
 
 ``Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC`` default value is ``OFF`` until 4.2, and ``ON`` until 4.5
 
+Any CMake keywords containing `IMPL` can fundamentally alter the underlying implementation
+of Kokkos on a given backend. It is encouraged not to set these unless the user knows what
+they are doing can accept the behavior changing without warning.
 
 
 Development

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -228,19 +228,21 @@ Backend-specific options
       * Disable atomics when no host parallel nor device backend is enabled for Serial only builds (since Kokkos 4.3)
       * ``OFF``
     * * ``Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC``
-      * Enable ``cudaMallocAsync`` (requires CUDA Toolkit version 11.2 or higher). This optimization may
-      improve performance in applications with multiple CUDA streams per device, but it
-      is known to be incompatible with MPI distributions built on older versions of UCX
-      and many Cray MPICH instances. See `known issues <known-issues.rst#cuda>`_.
+      * Enable ``cudaMallocAsync`` (requires CUDA Toolkit version 11.2 or higher). This
+	optimization may improve performance in applications with multiple CUDA streams per device, but it
+	is known to be incompatible with MPI distributions built on older versions of UCX
+	and many Cray MPICH instances. See `known issues <known-issues.html#cuda>`_.
       * ``ON``
 	
     * * ``Kokkos_ENABLE_IMPL_HPX_ASYNC_DISPATCH``
       * Enable asynchronous dispatch for the HPX backend
       * ``ON``
+
 	
 ``Kokkos_ENABLE_CUDA_LAMBDA`` default value is ``OFF`` until 3.7 and ``ON`` since 4.0
 
 ``Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC`` default value is ``OFF`` until 4.2, and ``ON`` until 4.5
+
 
 
 Development

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -14,7 +14,7 @@ CMake Keywords
    available CMake options and their current values. It may be more up to date
    with the Kokkos version that you are using.
    **A word of warning:** variables with names containing ``IMPL`` are private
-   implementation detailis. Avoid modifying these unless you have a deep
+   implementation details. Avoid modifying these unless you have a deep
    understanding of their implications and are aware that they might change
    without notice.
    

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -236,7 +236,7 @@ Backend-specific options
 
 ``Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC`` default value is ``OFF`` until 4.2, and ``ON`` until 4.5
 
-Any CMake keywords containing `IMPL` can fundamentally alter the underlying implementation
+Any CMake keyword containing `IMPL` can fundamentally alter the underlying implementation
 of Kokkos on a given backend. It is encouraged not to set these unless the user knows what
 they are doing can accept the behavior changing without warning.
 

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -10,7 +10,7 @@ CMake Keywords
    Recall that to set a keyword in CMake you used the syntax ``-Dkeyword_name=value``.
 
 .. note::
-   It is recommended to use the ``ccmake`` curses GUI to browse the complete list of
+   You may use the ``ccmake`` curses GUI to browse the complete list of
    available CMake options and their current settings. It may be more current to your
    Kokkos version than this Wiki's list.
 

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -231,7 +231,7 @@ Backend-specific options
       * Enable ``cudaMallocAsync`` (requires CUDA Toolkit version 11.2 or higher). This optimization may
       improve performance in applications with multiple CUDA streams per device, but it
       is known to be incompatible with MPI distributions built on older versions of UCX
-      and many Cray MPICH instances. See `kokkos/kokkos#7353 <https://github.com/kokkos/kokkos/pull/7353>`_
+      and many Cray MPICH instances. See `known issues <known-issues.rst#cuda>`_.
       * ``ON``
 	
     * * ``Kokkos_ENABLE_IMPL_HPX_ASYNC_DISPATCH``

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -223,9 +223,9 @@ Backend-specific options
       * ``OFF``
     * * ``Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC``
       * Enable ``cudaMallocAsync`` (requires CUDA Toolkit version 11.2 or higher). This optimization may
-	improve performance in applications with multiple CUDA streams per device, but it
-	is known to be incompatible with MPI distributions built on older versions of UCX
-	and many Cray MPICH instances. See `kokkos/kokkos#7353 <https://github.com/kokkos/kokkos/pull/7353>`_
+      improve performance in applications with multiple CUDA streams per device, but it
+      is known to be incompatible with MPI distributions built on older versions of UCX
+      and many Cray MPICH instances. See `kokkos/kokkos#7353 <https://github.com/kokkos/kokkos/pull/7353>`_
       * ``ON``
 	
     * * ``Kokkos_ENABLE_IMPL_HPX_ASYNC_DISPATCH``

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -9,6 +9,10 @@ CMake Keywords
 
    Recall that to set a keyword in CMake you used the syntax ``-Dkeyword_name=value``.
 
+.. note::
+   It is recommended to use the ``ccmake`` curses GUI to browse the complete list of
+   available CMake options and their current settings. It may be more current to the
+   Kokkos version than this Wiki's list.
 
 This page is organized in four sections:
 

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -226,11 +226,17 @@ Backend-specific options
 	improve performance in applications with multiple CUDA streams per device, but it
 	is known to be incompatible with MPI distributions built on older versions of UCX
 	and many Cray MPICH instances. See `kokkos/kokkos#7353 <https://github.com/kokkos/kokkos/pull/7353>`_
-      * ``ON``       
+      * ``ON``
+	
+    * * ``Kokkos_ENABLE_IMPL_HPX_ASYNC_DISPATCH``
+      * Enable asynchronous dispatch for the HPX backend
+      * ``ON``
 	
 ``Kokkos_ENABLE_CUDA_LAMBDA`` default value is ``OFF`` until 3.7 and ``ON`` since 4.0
 
 ``Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC`` default value is ``OFF`` until 4.2, and ``ON`` until 4.5
+
+
 
 Development
 -----------

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -11,7 +11,7 @@ CMake Keywords
 
 .. note::
    It is recommended to use the ``ccmake`` curses GUI to browse the complete list of
-   available CMake options and their current settings. It may be more current to the
+   available CMake options and their current settings. It may be more current to your
    Kokkos version than this Wiki's list.
 
 This page is organized in four sections:

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -14,6 +14,12 @@ CMake Keywords
    available CMake options and their current settings. It may be more current to your
    Kokkos version than this Wiki's list.
 
+.. warning::
+   Any CMake keyword containing `IMPL_` can fundamentally alter the underlying implementation
+   of Kokkos on a given backend. It is encouraged not to set these unless the user knows what
+   they are doing and can accept the behavior changing without warning.
+   
+
 This page is organized in four sections:
 
 - :ref:`keywords_backends`
@@ -235,10 +241,6 @@ Backend-specific options
 ``Kokkos_ENABLE_CUDA_LAMBDA`` default value is ``OFF`` until 3.7 and ``ON`` since 4.0
 
 ``Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC`` default value is ``OFF`` until 4.2, and ``ON`` until 4.5
-
-Any CMake keyword containing `IMPL` can fundamentally alter the underlying implementation
-of Kokkos on a given backend. It is encouraged not to set these unless the user knows what
-they are doing and can accept the behavior changing without warning.
 
 
 Development


### PR DESCRIPTION
Following a discussion with @masterleinad over Slack.

The `BUILD.md` in the Kokkos source repo used to list (all?) `Kokkos_` prefixed CMake options, until April 2023 when it started to refer readers to the Wiki page: https://github.com/kokkos/kokkos/commit/83873a62bb4d6ce47ec39e7775300b7ecdddfe73#diff-40f60e1037245d7b8a98a7325d53890a717da9979adeb54a61a795c4ba07f9c9R114

Both `Kokkos_ENABLE_IMPL_HPX_ASYNC_DISPATCH` and `Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC` weren't carried over to the Wiki at the time. The latter is especially confusing, given its changing default settings and issues with Cray MPICH on NERSC Perlmutter, ALCF Polaris, and LANL Venado, etc. https://github.com/kokkos/kokkos/pull/7353

I have re-added them, plus added two other helpful CMake comments that @masterleinad had relayed to ALCF folks recently. 

- [ ] Also update https://kokkos.org/kokkos-core-wiki/known-issues.html#cuda and add a mention of the Cray MPICH issues with async malloc on CUDA?

I manually diff'd the pre-April 2023 `BUILD.md` and the current Wiki page, and found several other flags that also didnt make the transition. Not sure if all of them were removed or deprecated, but here they are:
```
* Kokkos_ENABLE_IMPL_HPX_ASYNC_DISPATCH
    * Whether HPX supports asynchronous dispatch
    * BOOL Default: ON
* Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC
    * Whether to enable CudaMallocAsync (requires CUDA Toolkit 11.2). This is an experimental performance feature and currently has issue when using with UCX. See https://github.com/kokkos/kokkos/issues/4228 for more details.
    * BOOL Default: OFF

* Kokkos_ENABLE_PROFILING_LOAD_PRINT
    * Whether to print information about which profiling tools gotloaded
    * BOOL Default: OFF

* Kokkos_ENABLE_LIBNUMA
    * Whether to enable the LIBNUMA library
    * BOOL Default: Off
* Kokkos_ENABLE_MEMKIND
    * Whether to enable the MEMKIND library
    * BOOL Default: Off
* Kokkos_ENABLE_LIBRT
    * Whether to enable the LIBRT library
    * BOOL Default: Off

* Kokkos_LIBNUMA_DIR or LIBNUMA_ROOT
    * Location of LIBNUMA install prefix
    * PATH Default:
* Kokkos_MEMKIND_DIR or MEMKIND_ROOT
    * Location of MEMKIND install prefix
    * PATH Default:
* Kokkos_LIBRT_DIR or LIBRT_ROOT
    * Location of LIBRT install prefix
    * PATH Default:
```