### PR TITLE
Mark CUDA_LAMBDA as deprecated and get rid of CUDA_LDG_INTRINSIC

### DIFF
--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -199,13 +199,9 @@ Backend-specific options
       * Activate experimental relaxed constexpr functions
       * ``OFF``
 
-    * * ``Kokkos_ENABLE_CUDA_LAMBDA``
+    * * ``Kokkos_ENABLE_CUDA_LAMBDA`` :red:`[Deprecated since 4.1]`
       * Activate experimental lambda features
       * (see below)
-
-    * * ``Kokkos_ENABLE_CUDA_LDG_INTRINSIC``
-      * Use CUDA LDG intrinsics
-      * ``OFF``
 
     * * ``Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE``
       * Enable relocatable device code (RDC) for CUDA


### PR DESCRIPTION
CUDA_LDG_INTRINSIC has no effect since 2019 and the option is deprecated since 4.0
I think it is better to just remove it form the list