### PR TITLE
Add General CMake Build Option

### DIFF
--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -161,6 +161,7 @@ General options
       * ``OFF``
 
     * * ``Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE``
+      * Use native CMake language support
       * Analogous to CUDA/HIP as CMake language
       * ``OFF``
  

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -160,6 +160,10 @@ General options
       * Aggressively vectorize loops
       * ``OFF``
 
+    * * ``Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE``
+      * Analogous to CUDA/HIP as CMake language
+      * ``OFF``
+ 
 Debugging
 ---------
 .. list-table::


### PR DESCRIPTION
Proposing adding CMake build option (`Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE`) to the list of general options