### PR TITLE
Add more explanations on cudaMallocAsync

### DIFF
--- a/docs/source/known-issues.rst
+++ b/docs/source/known-issues.rst
@@ -21,10 +21,11 @@ CUDA
 
      -DKokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC=OFF
 
-  A technical explanation of why disabling this policy is helpful for making some MPI implementations work, especially in low-level layers
+  A technical explanation of why disabling this policy is helpful for making some MPI implementations work, especially in their low-level layers
   like UCX, is partly due to the fact that `cudaMallocAsync` uses `cudaMemPool_t,` and the default memory pool
   does not support interprocess communication (IPC) without tweaking (https://developer.nvidia.com/blog/using-cuda-stream-ordered-memory-allocator-part-2/#interprocess_communication_support).
   The user should set up the default memory pool to properly support IPC (https://developer.nvidia.com/blog/using-cuda-stream-ordered-memory-allocator-part-2/#library_composability).
+  
   Therefore, from version 4.5, the default behavior for Kokkos is to preventively disable `cudaMallocAsync.`
 
 


### PR DESCRIPTION
In kokkos/kokkos#7353, we have disabled the default use of `cudaMallocAsync`.

This PR adds some explanations in the known issues section, and how to disable it on previous releases.