### PR TITLE
Document atomic_assign

### DIFF
--- a/docs/source/API/core/atomics.rst
+++ b/docs/source/API/core/atomics.rst
@@ -4,11 +4,12 @@ Atomics
 .. toctree::
    :maxdepth: 1
 
+   ./atomics/atomic_load
+   ./atomics/atomic_store
+   ./atomics/atomic_exchange
    ./atomics/atomic_compare_exchange
    ./atomics/atomic_compare_exchange_strong
-   ./atomics/atomic_exchange
+   ./atomics/atomic_assign
    ./atomics/atomic_fetch_op
-   ./atomics/atomic_load
    ./atomics/atomic_op
    ./atomics/atomic_op_fetch
-   ./atomics/atomic_store

--- a/docs/source/API/core/atomics/atomic_assign.rst
+++ b/docs/source/API/core/atomics/atomic_assign.rst
@@ -1,0 +1,37 @@
+``atomic_assign``
+=================
+
+.. warning::
+   Deprecated since Kokkos 4.5,
+   use `atomic_store <atomic_store.html>`_ instead.
+
+.. role:: cppkokkos(code)
+    :language: cppkokkos
+
+Defined in header ``<Kokkos_Atomic.hpp>`` which is included from ``<Kokkos_Core.hpp>``
+
+Usage
+-----
+
+.. code-block:: cpp
+
+    atomic_assign(&obj, desired);
+    //     ^^^^^^
+    // deprecated since Kokkos 4.5,
+    // use atomic_store(&obj, desired) instead
+
+Atomically replaces the current value of ``obj`` with ``desired``.
+
+Description
+-----------
+
+.. cppkokkos:function:: template<class T> void atomic_assign(T* ptr, std::type_identity_t<T> val);
+
+   Atomically writes ``val`` into ``*ptr``.
+
+   ``{ *ptr = val; }``
+
+   :param ptr: address of the object whose value is to be replaced
+   :param val: the value to store in the referenced object
+   :returns: (nothing)
+

--- a/docs/source/API/core/atomics/atomic_exchange.rst
+++ b/docs/source/API/core/atomics/atomic_exchange.rst
@@ -13,7 +13,7 @@ Usage
 
    auto old = atomic_exchange(&obj, desired);
 
-Atomically replaces the value of ``obj`` with ``desired`` and returs the value before the call.
+Atomically replaces the value of ``obj`` with ``desired`` and returns the value before the call.
 
 Description
 -----------


### PR DESCRIPTION
Mention atomic_assign which is deprecated in 4.5
Fix typo reported in https://github.com/kokkos/kokkos-core-wiki/pull/594#discussion_r1828471947