### PR TITLE
Add RISC-V architectures

### DIFF
--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -507,7 +507,7 @@ If cross-compiling, or if you want to be specific, the CPU architecture can be p
       - Notes
     
     * - ``KOKKOS_ARCH_RISCV_RVA22V``
-      -  RVA22V/RISC-V ISA
+      - RVA22V/RISC-V ISA
       - SpacemiT K1
       - (since Kokkos 4.5)
       

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -506,12 +506,12 @@ If cross-compiling, or if you want to be specific, the CPU architecture can be p
       - Examples 
       - Notes
     
-    * - ``KOKKOS_ARCH_RISCV_RVA22V``
+    * - ``Kokkos_ARCH_RISCV_RVA22V``
       - RVA22V/RISC-V ISA
       - SpacemiT K1
       - (since Kokkos 4.5)
       
-    * - ``KOKKOS_ARCH_RISCV_SG2042``
+    * - ``Kokkos_ARCH_RISCV_SG2042``
       -  SG2042/RISC-V ISA
       -  Milk-V Pioneer
       - (since Kokkos 4.3)

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -502,15 +502,18 @@ If cross-compiling, or if you want to be specific, the CPU architecture can be p
     
     * - CMake keyword
       - Architecture/Instruction set
-      - Examples   
+      - Examples 
+      - Notes
     
     * - ``KOKKOS_ARCH_RISCV_RVA22V``
       -  RVA22V/RISC-V ISA
       -
+      - (since Kokkos 4.5.0)
       
     * - ``KOKKOS_ARCH_RISCV_SG2042``
       -  SG2042/RISC-V ISA
-      -   
+      -  
+      - (since Kokkos 4.3.0)
 
 GPU Architectures
 -----------------

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -487,6 +487,7 @@ If cross-compiling, or if you want to be specific, the CPU architecture can be p
     * - ``Kokkos_ARCH_KNL``
       - Knights Landing/x86-64
       - 31S1P @ Tianhe-2
+
     * - ``Kokkos_ARCH_KNC``
       - Knights Corner/x86-64
       -

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -431,7 +431,12 @@ CPU architectures
     * * ``Kokkos_ARCH_ZEN3``
       * Optimize for Zen3 architecture
       * ``OFF``
-
+    * * ``KOKKOS_ARCH_RISCV_RVA22V``
+      * Optimize for RISC-V_RVA22V architecture
+      * ``OFF``
+    * * ``KOKKOS_ARCH_RISCV_SG2042``
+      * Optimize for RISC-V_SG2042  architecture
+      * ``OFF``
 
 GPU Architectures
 -----------------

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -512,8 +512,8 @@ If cross-compiling, or if you want to be specific, the CPU architecture can be p
       - (since Kokkos 4.5)
       
     * - ``Kokkos_ARCH_RISCV_SG2042``
-      -  SG2042/RISC-V ISA
-      -  Milk-V Pioneer
+      - SG2042/RISC-V ISA
+      - Milk-V Pioneer
       - (since Kokkos 4.3)
 
 GPU Architectures

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -497,7 +497,7 @@ If cross-compiling, or if you want to be specific, the CPU architecture can be p
       -
       
  .. list-table:: RISC-V CPU architectures
-    :widths: 30 30 30
+    :widths: 30 30 30 30
     :header-rows: 1
     :align: left
     
@@ -508,13 +508,13 @@ If cross-compiling, or if you want to be specific, the CPU architecture can be p
     
     * - ``KOKKOS_ARCH_RISCV_RVA22V``
       -  RVA22V/RISC-V ISA
-      -
-      - (since Kokkos 4.5.0)
+      - SpacemiT K1
+      - (since Kokkos 4.5)
       
     * - ``KOKKOS_ARCH_RISCV_SG2042``
       -  SG2042/RISC-V ISA
-      -  
-      - (since Kokkos 4.3.0)
+      -  Milk-V Pioneer
+      - (since Kokkos 4.3)
 
 GPU Architectures
 -----------------


### PR DESCRIPTION
Add the two recently added RISC-V architectures to Kokkos.