### PR TITLE
Add options for downstream builds

### DIFF
--- a/docs/source/building.md
+++ b/docs/source/building.md
@@ -52,8 +52,14 @@ which activates the OpenMP backend. All the options controlling device backends,
 ## Advanced Build Options
 
 Kokkos allows projects to specify if they want Kokkos to set the `CXX` compiler in a way that allows the build system to work independent of the used backend.
-This is controlled via the options `Kokkos_GLOBAL_COMPILATION` and  `Kokkos_FORCE_COMPILER_LAUNCHER` described in the [CMake Keywords](../keywords).
-Additionally there are minimal working examples in the `example` folder.
+This is controlled via the options `Kokkos_GLOBAL_COMPILATION` and  `Kokkos_FORCE_COMPILER_LAUNCHER` that have to be set before `find_package(Kokkos)` is called.
+
+|   | Description | Default |
+|---|-------------|---------|
+| `Kokkos_GLOBAL_COMPILATION` | Set compiler to the CXX compiler Kokkos needs for the whole project | `ON` |
+| `Kokkos_FORCE_COMPILER_LAUNCHER` | Use the `kokkos_compiler_launcher` script on all targets in the project. Redirects cpp files in targets that link to Kokkos to the CXX compiler Kokkos needs and to the respective CMake detected compiler otherwise | `OFF` |
+
+Minimal working examples can be found in the `example` folder.
 
 ## Known Issues<a name="KnownIssues"></a>
 

--- a/docs/source/building.md
+++ b/docs/source/building.md
@@ -54,10 +54,10 @@ which activates the OpenMP backend. All the options controlling device backends,
 Kokkos allows projects to specify if they want Kokkos to set the `CXX` compiler in a way that allows the build system to work independent of the used backend.
 This is controlled via the options `Kokkos_GLOBAL_COMPILATION` and  `Kokkos_FORCE_COMPILER_LAUNCHER` that have to be set before `find_package(Kokkos)` is called.
 
-|   | Description | Default |
-|---|-------------|---------|
-| `Kokkos_GLOBAL_COMPILATION` | Set compiler to the CXX compiler Kokkos needs for the whole project | `ON` |
-| `Kokkos_FORCE_COMPILER_LAUNCHER` | Use the `kokkos_compiler_launcher` script on all targets in the project. Redirects cpp files in targets that link to Kokkos to the CXX compiler Kokkos needs and to the respective CMake detected compiler otherwise | `OFF` |
+|   | Description | Default | Info |
+|---|-------------|---------|------|
+| `Kokkos_GLOBAL_COMPILATION` | Set compiler to the CXX compiler Kokkos needs for the whole project | `ON` | (Since Kokkos 4.5) |
+| `Kokkos_FORCE_COMPILER_LAUNCHER` | Use the `kokkos_compiler_launcher` script on all targets in the project. Redirects cpp files in targets that link to Kokkos to the CXX compiler Kokkos needs and to the respective CMake detected compiler otherwise | `OFF` | (Since Kokkos 4.5) |
 
 Minimal working examples can be found in the `example` folder.
 

--- a/docs/source/building.md
+++ b/docs/source/building.md
@@ -49,6 +49,11 @@ There are numerous device backends, options, and architecture-specific optimizat
 ````
 which activates the OpenMP backend. All the options controlling device backends, options, architectures, and third-party libraries (TPLs) are given in [CMake Keywords](../keywords).
 
+## Advanced Build Options
+
+Kokkos allows projects to specify if they want Kokkos to set the `CXX` compiler in a way that allows the build system to work independent of the used backend.
+This is controlled via the options `Kokkos_GLOBAL_COMPILATION` and  `Kokkos_FORCE_COMPILER_LAUNCHER` described in the [CMake Keywords](../keywords).
+Additionally there are minimal working examples in the `example` folder.
 
 ## Known Issues<a name="KnownIssues"></a>
 

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -163,6 +163,14 @@ General options
       * Aggressively vectorize loops
       * ``OFF``
 
+    * * ``Kokkos_GLOBAL_COMPILATION``
+      * Set compiler to the CXX compiler Kokkos needs for the whole project
+      * ``ON``
+
+    * * ``Kokkos_FORCE_COMPILER_LAUNCHER``
+      * Use the kokkos_compiler_launcher script on all targets in the project. Redirects files in targets that link to Kokkos to the CXX compiler Kokkos needs.
+      * ``OFF``
+
 Debugging
 ---------
 .. list-table::

--- a/docs/source/keywords.rst
+++ b/docs/source/keywords.rst
@@ -163,14 +163,6 @@ General options
       * Aggressively vectorize loops
       * ``OFF``
 
-    * * ``Kokkos_GLOBAL_COMPILATION``
-      * Set compiler to the CXX compiler Kokkos needs for the whole project
-      * ``ON``
-
-    * * ``Kokkos_FORCE_COMPILER_LAUNCHER``
-      * Use the kokkos_compiler_launcher script on all targets in the project. Redirects files in targets that link to Kokkos to the CXX compiler Kokkos needs.
-      * ``OFF``
-
 Debugging
 ---------
 .. list-table::


### PR DESCRIPTION
Adds the options `Kokkos_GLOBAL_COMPILATION` and `Kokkos_FORCE_COMPILER_LAUNCHER` and gives a short hint that they exist.

Documentation for https://github.com/kokkos/kokkos/pull/7581