### PR TITLE
Correct ScatterViews template parameters order

### DIFF
--- a/docs/source/API/containers/ScatterView.rst
+++ b/docs/source/API/containers/ScatterView.rst
@@ -8,7 +8,7 @@ Header File: ``<Kokkos_ScatterView.hpp>``
 
 .. warning::
 
-   Currently ``ScatterView`` is still in the namespace ``Kokkos::Experimental``
+   ``ScatterView`` is still in the namespace ``Kokkos::Experimental``
 
 
 .. _parallelReduce: ../core/parallel-dispatch/parallel_reduce.html
@@ -30,7 +30,7 @@ Header File: ``<Kokkos_ScatterView.hpp>``
 Usage
 -----
 
-A Kokkos ScatterView serves as an interface for a standard Kokkos::|View|_ and allow access to it either via Atomic or Data Replication based scatter algorithms, choosing the strategy that should be the fastest for the ScatterView Execution Space.
+A Kokkos ScatterView serves as an interface for a standard Kokkos::|View|_ implementing a scatter-add pattern either via atomics or data replication.
 
 The best option to create a ScatterView is to make a call to the free function Kokkos::Experimental::|create_scatter_view|_.
 

--- a/docs/source/API/containers/ScatterView.rst
+++ b/docs/source/API/containers/ScatterView.rst
@@ -10,10 +10,62 @@ Header File: ``<Kokkos_ScatterView.hpp>``
 
 .. |parallelReduce| replace:: :cpp:func:`parallel_reduce`
 
+.. _View: ../core/view/view.html
+
+.. |View| replace:: ``View``
+
+Usage
+-----
+A Kokkos ScatterView wraps a standard Kokkos::|View|_ and allow access to it either via Atomic or Data Replication based scatter algorithms, choosing the strategy that should be the fastest for the ScatterView Execution Space.
+
+Construction of a ScatterView can be expensive, so you should try to reuse the same one if possible, in which case, you should call ``reset()`` between uses.
+
+ScatterView can not be addressed directly: each thread inside a parallel region needs to make a call to ``access()`` and access the underlying View through the return value of ``access()``.
+
+Following the parallel region, a call to the free function ``contribute`` should be made to perform the final reduction.
+
+It is part of the Experimental namespace.
+
+Interface
+---------
+.. code-block:: cpp
+
+    template <typename DataType [, typename Layout [, typename ExecSpace [, typename Op [, typename Duplication [, typename Contribution]]]]]>
+    class ScatterView
+
+Parameters
+~~~~~~~~~~
+Template parameters other than ``DataType`` are optional, but if one is specified, preceding ones must also be specified.
+That means for example that ``Op`` can be omitted but if it is specified, ``Layout`` and ``ExecSpace`` must also be specified.
+
+* ``DataType``:
+  Works the same as a |View|_'s DataType.
+
+* ``Layout``:
+
+* ``ExecSpace``: Defaults to ``Kokkos::DefaultExecutionSpace``
+
+* ``Op``:
+  Can take the values:
+
+  - ``Kokkos::Experimental::ScatterSum``: performs a Sum.
+
+  - ``Kokkos::Experimental::ScatterProd``: performs a Multiplication.
+
+  - ``Kokkos::Experimental::ScatterMin``: takes the min.
+
+  - ``Kokkos::Experimental::ScatterMax``: takes the max.
+
+* ``Duplication``:
+  Whether to duplicate the grid or not; defaults to ``Kokkos::Experimental::ScatterDuplicated``, other option is ``Kokkos::Experimental::ScatterNonDuplicated``.
+
+* ``Contribution``:
+  Whether to contribute to use atomics; defaults to ``Kokkos::Experimental::ScatterAtomics``, other option is ``Kokkoss::Experimental::ScatterNonAtomic``.
+
 Description
 -----------
 
-.. cppkokkos:class:: template <typename DataType, int Op, typename ExecSpace, typename Layout, int contribution> ScatterView
+.. cppkokkos:class:: template <typename DataType, typename Layout, typename ExecSpace, typename Op, typename Duplication, typename Contribution> ScatterView
 
     .. rubric:: Public Member Variables
 

--- a/docs/source/API/containers/ScatterView.rst
+++ b/docs/source/API/containers/ScatterView.rst
@@ -71,7 +71,7 @@ That means for example that ``Operation`` can be omitted but if it is specified,
 * ``Contribution``:
   Whether to contribute to use atomics; defaults to ``Kokkos::Experimental::ScatterAtomics``, other option is ``Kokkoss::Experimental::ScatterNonAtomic``.
 
-Creating a ScatterView with non default ``Operation``, ``Duplication`` or ``Contribution`` using this interface can become complicated, because you need to explicit the exact type for ``DataType``, ``Layout`` and ``ExecSpace``. This is why it is advised that you instead use the function Kokkos::Experimental::|create_scatter_view|_.
+Creating a ScatterView with non default ``Operation``, ``Duplication`` or ``Contribution`` using this interface can become complicated, because you need to specify the exact type for ``DataType``, ``Layout`` and ``ExecSpace``. This is why it is advised that you instead use the function Kokkos::Experimental::|create_scatter_view|_.
 
 Description
 -----------

--- a/docs/source/API/containers/ScatterView.rst
+++ b/docs/source/API/containers/ScatterView.rst
@@ -32,8 +32,6 @@ Usage
 
 A Kokkos ScatterView serves as an interface for a standard Kokkos::|View|_ implementing a scatter-add pattern either via atomics or data replication.
 
-The best option to create a ScatterView is to make a call to the free function Kokkos::Experimental::|create_scatter_view|_.
-
 Construction of a ScatterView can be expensive, so you should try to reuse the same one if possible, in which case, you should call |reset|_ between uses.
 
 ScatterView can not be addressed directly: each thread inside a parallel region needs to make a call to |access|_ and access the underlying View through the return value of |access|_.


### PR DESCRIPTION
Trying to instantiate a ScatterView while specifying its template parameters didn't work as written in the doc.
You can check it here: https://godbolt.org/z/Me1jKezjq

Also added a small description on how to use ScatterView and a description for each template parameter (copied from the cheatsheet).
All of this descriptions may be wrong and need to be checked by someone more familiar with ScatterViews.