### PR TITLE
Allow writing contents when deploying

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -26,6 +26,7 @@ jobs:
         working-directory: ${{ env.docs-directory }}
         run: |
           make html
+      # .nojekyll file is needed for GitHub Pages to know it's getting a ready webpage
       # and there is no need to generate anything
       - name: Generate nojekyll file
         working-directory: ${{ env.docs-directory }}/generated_docs

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -11,6 +11,8 @@ jobs:
     env:
       docs-directory: /home/runner/work/kokkos-core-wiki/kokkos-core-wiki/docs
       python-version: '3.10'
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -6,13 +6,11 @@ on:
   pull_request:
 
 jobs:
-  build-and-deploy-docs:
+  build:
     runs-on: ubuntu-latest
     env:
       docs-directory: /home/runner/work/kokkos-core-wiki/kokkos-core-wiki/docs
       python-version: '3.10'
-    permissions:
-      contents: write
 
     steps:
       - uses: actions/checkout@v3
@@ -28,21 +26,34 @@ jobs:
         working-directory: ${{ env.docs-directory }}
         run: |
           make html
-      - name: Archive documentation
-        uses: actions/upload-artifact@v4
-        with:
-          name: documentation.tar.gz
-          path: ${{ env.docs-directory }}/generated_docs
-      # .nojekyll file is needed for GitHub Pages to know it's getting a ready webpage
       # and there is no need to generate anything
       - name: Generate nojekyll file
         working-directory: ${{ env.docs-directory }}/generated_docs
         run: touch .nojekyll
-      # This action moves the content of `generated_docs` to the `deploy-doc-site` branch
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: site
+          path: ${{ env.docs-directory }}/generated_docs
+
+  deploy-docs:
+    if: ${{ github.ref == 'refs/heads/main' }}
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: site
+          path: generated_docs
       - name: Deploy docs
-        if: ${{ github.ref == 'refs/heads/main' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: deploy-doc-site
-          folder: ${{ env.docs-directory }}/generated_docs
+          folder: generated_docs
           clean: true


### PR DESCRIPTION
Alternative to https://github.com/kokkos/kokkos-core-wiki/pull/623. Fixes deplotibng, also see https://github.com/JamesIves/github-pages-deploy-action?tab=readme-ov-file#getting-started-airplane. The `GITHUB_TOKEN` used only has read permissions and we have to explicitly grant write permissions in this workflow.