### PR TITLE
Fix inconsistency in ``team_member.reduce`` sample code snippet

### DIFF
--- a/docs/source/ProgrammingGuide/HierarchicalParallelism.md
+++ b/docs/source/ProgrammingGuide/HierarchicalParallelism.md
@@ -78,7 +78,7 @@ parallel_for (policy, KOKKOS_LAMBDA (member_type team_member) {
             team_member.team_rank ();
     // Calculate the sum of the global thread ids of this team
     int team_sum = k;
-    team_member.team_reduce(Sum<int>(team_sum));
+    team_member.team_reduce(Sum<int, typename ExecutionSpace::memory_space>(team_sum));
     // Atomically add the value to a global value
     a() += team_sum;
   });

--- a/docs/source/ProgrammingGuide/HierarchicalParallelism.md
+++ b/docs/source/ProgrammingGuide/HierarchicalParallelism.md
@@ -64,6 +64,8 @@ Kokkos::TeamPolicy<SomeTag, ExecutionSpace>
 The team policy's `member_type` provides the necessary functionality to use teams within a parallel kernel. It allows access to thread identifiers such as the league rank and size, and the team rank and size. It also provides team-synchronous actions such as team barriers, reductions and scans.
 
 ```c++
+using Kokkos::atomic_add;
+using Kokkos::PerTeam;
 using Kokkos::Sum;
 using Kokkos::TeamPolicy;
 using Kokkos::parallel_for;
@@ -76,11 +78,15 @@ parallel_for (policy, KOKKOS_LAMBDA (member_type team_member) {
     // Calculate a global thread id
     int k = team_member.league_rank () * team_member.team_size () +
             team_member.team_rank ();
+
     // Calculate the sum of the global thread ids of this team
     int team_sum = k;
     team_member.team_reduce(Sum<int, typename ExecutionSpace::memory_space>(team_sum));
-    // Atomically add the value to a global value
-    a() += team_sum;
+
+    // Atomically add the computed sum to a global value
+    Kokkos::single (PerTeam (team_member), [=] () {
+      atomic_add(&global_value(), team_sum);
+    });
   });
 ```
 

--- a/docs/source/ProgrammingGuide/HierarchicalParallelism.md
+++ b/docs/source/ProgrammingGuide/HierarchicalParallelism.md
@@ -64,6 +64,7 @@ Kokkos::TeamPolicy<SomeTag, ExecutionSpace>
 The team policy's `member_type` provides the necessary functionality to use teams within a parallel kernel. It allows access to thread identifiers such as the league rank and size, and the team rank and size. It also provides team-synchronous actions such as team barriers, reductions and scans.
 
 ```c++
+using Kokkos::Sum;
 using Kokkos::TeamPolicy;
 using Kokkos::parallel_for;
 
@@ -73,12 +74,13 @@ TeamPolicy<ExecutionSpace> policy (league_size, Kokkos::AUTO() );
 // Launch a kernel
 parallel_for (policy, KOKKOS_LAMBDA (member_type team_member) {
     // Calculate a global thread id
-     int k = team_member.league_rank () * team_member.team_size () +
+    int k = team_member.league_rank () * team_member.team_size () +
             team_member.team_rank ();
     // Calculate the sum of the global thread ids of this team
-     int team_sum = team_member.reduce (k);
-     // Atomically add the value to a global value
-     a() += team_sum;
+    int team_sum = k;
+    team_member.team_reduce(Sum<int>(team_sum));
+    // Atomically add the value to a global value
+    a() += team_sum;
   });
 ```
 


### PR DESCRIPTION
This commit modifies the snippet illustrating how to use a method of the ``member_type`` type to trigger a reduction. There were 3 adjustments:
1. The name of the triggered method was invalid: the `TeamHandleConcept` concept doesn't specify a ``reduce`` method. I adjusted the name to instead reference the [`team_reduce` method](https://kokkos.org/kokkos-core-wiki/API/core/policies/TeamHandleConcept.html#_CPPv4I0ENK17TeamHandleConcept11team_reduceEvRK11ReducerType). (maybe the way it was written was correct at some point in an earlier version?)
2. Consequently, I also needed to adjust how the reduction was called
3. I fixed some inconsistent indentation within the snippet


There were 2 areas where I was a little uncertain on what to do:
- I couldn't tell if whether it was idiomatic to include the `using Kokkos::Sum;` statement. Let me know if I should remove it
- I was tempted to rewrite ``a() += team_sum;`` as the following snippet (inspired by the [other code-snippet in the subsection](https://kokkos.org/kokkos-core-wiki/ProgrammingGuide/HierarchicalParallelism.html#basic-kernels)), but I decided to ask before doing that
  ```c++
  if( team_member.team_rank() == 0 ) {
    a() += team_sum;
  }
  ```