### PR TITLE
update simd documentation for kokkos 4.6

### DIFF
--- a/docs/source/API/simd/simd.md
+++ b/docs/source/API/simd/simd.md
@@ -33,7 +33,7 @@ The second template parameter `Abi` is one of the pre-defined ABI types in the n
 ### Typedefs
 
  *  `value_type`: Equal to `T`
- *  `reference`: This type should be convertible to `value_type` and `value_type` should be assignable to `reference`. It may be a plain reference or it may be an implementation-defined type that calls vector intrinsics to extract or fill in one vector lane.
+ *  `reference`: This type should be convertible to `value_type` and `value_type` should be assignable to `reference`. It may be a plain reference or it may be an implementation-defined type that calls vector intrinsics to extract or fill in one vector lane. (removed in Kokkos 4.6)
  *  `mask_type`: Equal to `simd_mask<T, Abi>`
  *  `abi_type`: Equal to `Abi`
 
@@ -59,8 +59,8 @@ The second template parameter `Abi` is one of the pre-defined ABI types in the n
   * `Kokkos::Experimental::element_aligned_tag` is a type alias for `decltype(simd_flag_default)` and `Kokkos::Experimental::vector_aligned_tag` is a type alias for `decltype(simd_flag_aligned)`.
 
 ### Value Access Methods
-  * `reference operator[](std::size_t)`: returns a reference to vector value `i` that can be modified.
   * `value_type operator[](std::size_t) const`: returns the vector value `i`.
+  * `reference operator[](std::size_t)`: returns a reference to vector value `i` that can be modified. (removed in Kokkos 4.6)
 
 ### Arithmetic Operators
   * `simd simd::operator-() const`
@@ -72,10 +72,14 @@ The second template parameter `Abi` is one of the pre-defined ABI types in the n
   * `simd operator>>(const simd& lhs, int rhs)`
   * `simd operator<<(const simd& lhs, const simd& rhs)`
   * `simd operator<<(const simd& lhs, int rhs)`
+
+### Compound Assignment Operators
   * `simd operator+=(simd& lhs, const simd& rhs)`
   * `simd operator-=(simd& lhs, const simd& rhs)`
   * `simd operator*=(simd& lhs, const simd& rhs)`
   * `simd operator/=(simd& lhs, const simd& rhs)`
+  * `simd operator>>=(simd& lhs, const simd& rhs)`
+  * `simd operator<<=(simd& lhs, const simd& rhs)`
 
 ### Comparison Operators
   * `mask_type operator==(const simd& lhs, const simd& rhs)`
@@ -94,6 +98,14 @@ The second template parameter `Abi` is one of the pre-defined ABI types in the n
 ### Min/Max Functions
   * `simd Kokkos::min(const simd& lhs, const simd& rhs)`
   * `simd Kokkos::max(const simd& lhs, const simd& rhs)`
+
+### Reductions 
+  * `T Kokkos::Experimental::reduce(const simd& lhs, const simd_mask& mask)`
+  * `T Kokkos::Experimental::reduce(const simd& lhs, Op binary_op)`
+  * `T Kokkos::Experimental::reduce_min(const simd& lhs, const simd_mask& mask)`
+  * `T Kokkos::Experimental::reduce_min(const simd& lhs)`
+  * `T Kokkos::Experimental::reduce_max(const simd& lhs, const simd_mask& mask)`
+  * `T Kokkos::Experimental::reduce_max(const simd& lhs)`
 
 ### `<cmath>` Functions
   * `simd Kokkos::abs(const simd& lhs)`
@@ -147,13 +159,13 @@ The second template parameter `Abi` is one of the pre-defined ABI types in the n
 int main(int argc, char* argv[]) {
   Kokkos::initialize(argc,argv);
   {
-  using simd_type = Kokkos::Experimental::simd<double>;
-  simd_type a([] (std::size_t i) { return 0.1 * i; });
-  simd_type b(2.0);
-  simd_type c = Kokkos::sqrt(a * a + b * b);
-  for (std::size_t i = 0; i < simd_type::size(); ++i) {
-    printf("[%zu] = %g\n", i, c[i]);
-  }
+    using simd_type = Kokkos::Experimental::simd<double>;
+    simd_type a([] (std::size_t i) { return 0.1 * i; });
+    simd_type b(2.0);
+    simd_type c = Kokkos::sqrt(a * a + b * b);
+    for (std::size_t i = 0; i < simd_type::size(); ++i) {
+      printf("[%zu] = %g\n", i, c[i]);
+    }
   }
   Kokkos::finalize();
 }

--- a/docs/source/API/simd/simd_mask.md
+++ b/docs/source/API/simd/simd_mask.md
@@ -33,7 +33,7 @@ The second template parameter `Abi` is one of the pre-defined ABI types in the n
 ### Typedefs
 
  *  `value_type`: Equal to `bool`
- *  `reference`: This type should be convertible to `bool` and `bool` should be assignable to `reference`. It may be a plain reference or it may be a special class that calls vector intrinsics to extract or fill in one mask bit.
+ *  `reference`: This type should be convertible to `bool` and `bool` should be assignable to `reference`. It may be a plain reference or it may be a special class that calls vector intrinsics to extract or fill in one mask bit. (removed in Kokkos 4.6)
  *  `simd_type`: Equal to `simd<T, Abi>`
  *  `abi_type`: Equal to `Abi`
 
@@ -48,17 +48,31 @@ The second template parameter `Abi` is one of the pre-defined ABI types in the n
   * `template <class G> simd_mask(G&& gen)`: Generator constructor. The generator `gen` should be a callable type (e.g. functor) that can accept `std::integral_constant<std::size_t, i>()` as an argument and return something convertible to `bool`. Vector mask value `i` will be initialized to the value of `gen(std::integral_constant<std::size_t, i>())`.
 
 ### Value Access Methods
-  * `reference operator[](std::size_t)`: returns a reference to mask value `i` that can be modified.
   * `bool operator[](std::size_t) const`: returns the mask value `i`.
+  * `reference operator[](std::size_t)`: returns a reference to mask value `i` that can be modified. (removed in Kokkos 4.6)
 
 ### Boolean Operators
   * `simd_mask simd_mask::operator!() const`
   * `simd_mask operator&&(const simd_mask& lhs, const simd_mask& rhs)`
   * `simd_mask operator||(const simd_mask& lhs, const simd_mask& rhs)`
 
+### Bitwise Operators
+  * `simd_mask operator&(const simd_mask& lhs, const simd_mask& rhs)`
+  * `simd_mask operator|(const simd_mask& lhs, const simd_mask& rhs)`
+  * `simd_mask operator^(const simd_mask& lhs, const simd_mask& rhs)`
+
+### Compound Assignment Operators
+  * `simd_mask operator&=(simd_mask& lhs, const simd_mask& rhs)`
+  * `simd_mask operator|=(simd_mask& lhs, const simd_mask& rhs)`
+  * `simd_mask operator^=(simd_mask& lhs, const simd_mask& rhs)`
+
 ### Comparison Operators
   * `simd_mask operator==(const simd_mask& lhs, const simd_mask& rhs)`
   * `simd_mask operator!=(const simd_mask& lhs, const simd_mask& rhs)`
+  * `simd_mask operator>=(const simd_mask& lhs, const simd_mask& rhs)`
+  * `simd_mask operator<=(const simd_mask& lhs, const simd_mask& rhs)`
+  * `simd_mask operator>(const simd_mask& lhs, const simd_mask& rhs)`
+  * `simd_mask operator<(const simd_mask& lhs, const simd_mask& rhs)`
 
 ### Reductions
   * `bool all_of(const simd_mask&)`: returns true iff all of the vector values in the mask are true
@@ -78,13 +92,13 @@ The second template parameter `Abi` is one of the pre-defined ABI types in the n
 int main(int argc, char* argv[]) {
   Kokkos::initialize(argc,argv);
   {
-  using mask_type = Kokkos::Experimental::simd_mask<double>;
-  mask_type a([] (std::size_t i) { return i == 0; });
-  mask_type b([] (std::size_t i) { return i == 1; });
-  mask_type c([] (std::size_t i) { return i == 0 || i == 1; });
-  if (all_of(c == (a || b))) {
-    printf("Kokkos simd_mask works as expected!");
-  }
+    using mask_type = Kokkos::Experimental::simd_mask<double>;
+    mask_type a([] (std::size_t i) { return i == 0; });
+    mask_type b([] (std::size_t i) { return i == 1; });
+    mask_type c([] (std::size_t i) { return i == 0 || i == 1; });
+    if (all_of(c == (a || b))) {
+      printf("Kokkos simd_mask works as expected!");
+    }
   }
   Kokkos::finalize();
 }

--- a/docs/source/API/simd/simd_mask.md
+++ b/docs/source/API/simd/simd_mask.md
@@ -61,11 +61,6 @@ The second template parameter `Abi` is one of the pre-defined ABI types in the n
   * `simd_mask operator|(const simd_mask& lhs, const simd_mask& rhs)`
   * `simd_mask operator^(const simd_mask& lhs, const simd_mask& rhs)`
 
-### Compound Assignment Operators
-  * `simd_mask operator&=(simd_mask& lhs, const simd_mask& rhs)`
-  * `simd_mask operator|=(simd_mask& lhs, const simd_mask& rhs)`
-  * `simd_mask operator^=(simd_mask& lhs, const simd_mask& rhs)`
-
 ### Comparison Operators
   * `simd_mask operator==(const simd_mask& lhs, const simd_mask& rhs)`
   * `simd_mask operator!=(const simd_mask& lhs, const simd_mask& rhs)`

--- a/docs/source/API/simd/where_expression.md
+++ b/docs/source/API/simd/where_expression.md
@@ -54,13 +54,13 @@ Where expression objects are only constructed by calling the non-member method `
 int main(int argc, char* argv[]) {
   Kokkos::initialize(argc,argv);
   {
-  using simd_type = Kokkos::Experimental::simd<double>;
-  // the first value in vector a will be negative after this
-  simd_type a([] (std::size_t i) { return 1.0 * i - 1.0; });
-  // we can use where expressions to set negative values to 0.0
-  where(a < 0.0, a) = 0.0;
-  // now it might be safer to call a function with domain limitations
-  auto b = Kokkos::sqrt(a);
+    using simd_type = Kokkos::Experimental::simd<double>;
+    // the first value in vector a will be negative after this
+    simd_type a([] (std::size_t i) { return 1.0 * i - 1.0; });
+    // we can use where expressions to set negative values to 0.0
+    where(a < 0.0, a) = 0.0;
+    // now it might be safer to call a function with domain limitations
+    auto b = Kokkos::sqrt(a);
   }
   Kokkos::finalize();
 }


### PR DESCRIPTION
Updated simd documentations

- Added notes indicating removal of `reference` and subscript operators returning references
- Added compound assignment operators and reduction functions
- Modified examples to use correct simd types and simd flags
- Removed all occurrences of `native_simd` and `native_simd_mask`