### PR TITLE
Add initial MultiGPU documentation

### DIFF
--- a/docs/source/API/core-index.rst
+++ b/docs/source/API/core-index.rst
@@ -22,7 +22,7 @@ Core API
    * - `Task-Parallelism <core/Task-Parallelism.html>`__
      - Creating and dispatching Task Graphs.
    * - `MultiGPU Support <core/MultiGPUSupport.html>`__
-     - Launching kernels on multiple GPU nodes from host.
+     - Launching kernels on multiple GPUs from one process.
    * - `Atomics <core/atomics.html>`__
      - Atomics
    * - `Numerics <core/Numerics.html>`__

--- a/docs/source/API/core-index.rst
+++ b/docs/source/API/core-index.rst
@@ -21,6 +21,8 @@ Core API
      - Description of Memory and Execution Spaces.
    * - `Task-Parallelism <core/Task-Parallelism.html>`__
      - Creating and dispatching Task Graphs.
+   * - `MultiGPU Support <core/MultiGPUSupport.html>`__
+     - Launching kernels on multiple GPU nodes from host.
    * - `Atomics <core/atomics.html>`__
      - Atomics
    * - `Numerics <core/Numerics.html>`__
@@ -51,6 +53,7 @@ Core API
    ./core/Execution-Policies
    ./core/Spaces
    ./core/Task-Parallelism
+   ./core/MultiGPUSupport
    ./core/atomics
    ./core/Numerics
    ./core/c_style_memory_management

--- a/docs/source/API/core/MultiGPUSupport.rst
+++ b/docs/source/API/core/MultiGPUSupport.rst
@@ -151,4 +151,4 @@ Example:
 Notes
 -----
 
-- A `tutorial <https://github.com/kokkos/kokkos-tutorials/tree/main/Exercises/multi_gpu_cuda>`_ for using multi-gpu on CUDA is available.
+- A `tutorial <https://github.com/kokkos/kokkos-tutorials/tree/main/Exercises/multi_gpu_cuda>`_ for using multi-GPU on CUDA is available.

--- a/docs/source/API/core/MultiGPUSupport.rst
+++ b/docs/source/API/core/MultiGPUSupport.rst
@@ -18,7 +18,9 @@ CUDA
 
 For CUDA backend, the user creates a ``cudaStream_t`` object and passes it to the ``Kokkos::Cuda`` constructor.
 
-.. note:: The user is expected to manage the lifetime of the stream. The related execution space needs to be destroyed before destroying the stream.
+.. note:: The lifetime of all Kokkos objects related to the stream (e.g., the execution space) needs to end before the stream itself is invalidated
+          via ``cudaStreamDestroy``. This can be done by adding a scope around such objects, as is done below.
+
 
 .. code-block:: cpp
 
@@ -53,7 +55,8 @@ HIP
 
 For the HIP backend, like with CUDA, the user creates a ``hipStream_t`` object and passes it to the ``Kokkos::HIP`` constructor.
 
-.. note:: The user is expected to manage the lifetime of the stream. The related execution space needs to be destroyed before destroying the stream.
+.. note:: The lifetime of all Kokkos objects related to the stream (e.g., the execution space) needs to end before the stream itself is invalidated
+          via ``cudaStreamDestroy``. This can be done by adding a scope around such objects, as is done below.
 
 .. warning:: Multi-GPU only supported for ROCm 5.6 and later. Because of the lack of HIP API functions for querying a
              stream's device before ROCm 5.6, constructing a ``Kokkos::HIP`` instance on a non-default device isn't

--- a/docs/source/API/core/MultiGPUSupport.rst
+++ b/docs/source/API/core/MultiGPUSupport.rst
@@ -127,8 +127,7 @@ Example:
 
 .. code-block:: cpp
 
-    using ExecutionSpace = decltype(exec_space);
-    Kokkos::View<int*, ExecutionSpace> V(Kokkos::view_alloc("V", exec_space), 10);
+    Kokkos::View<int*> V(Kokkos::view_alloc("V", exec_space), 10);
 
 Launching Kernels
 ~~~~~~~~~~~~~~~~~

--- a/docs/source/API/core/MultiGPUSupport.rst
+++ b/docs/source/API/core/MultiGPUSupport.rst
@@ -1,0 +1,117 @@
+.. role:: cppkokkos(code)
+    :language: cppkokkos
+
+Multi-GPU Support
+=================
+
+Kokkos has support for launching kernels on multiple GPU devices within a single node from host on a single MPI rank for the Cuda, HIP, and SYCL backends.
+
+Using this feature requires knowledge of backend specific API calls for setting devices, creating streams, and (potentially)
+allocating device specific data.
+
+Basic Usage
+-----------
+
+For allocating and launching kernels on a chosen device, the user is responsible for creating device specific streams to pass to backend constructor.
+Once these are created, they can be passed as any other execution space instance to create policies, allocated managed views, asynchronous deep copies, etc. For creating unmanaged
+views, the user must manually allocate device specific memory to pass to the view constructor.
+
+Contructing Execution Space
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Cuda
+^^^^
+
+.. code-block:: cpp
+
+    // Query number of devices available
+    int n_devices;
+    cudaGetDeviceCount(&n_devices);
+
+    // Choose some 0 <= N < n_devices
+    int N = ...;
+
+    // Create stream on device N
+    cudaStream_t stream;
+    cudaSetDevice(N);
+    cudaStreamCreate(&stream);
+
+    // Scope execution space to ensure stream
+    // is destroyed *after* execution space
+    {
+      // Create execution space
+      Kokkos::Cuda exec_space(stream);
+
+      // Use execution space
+      /* ... */
+    }
+
+    // Destroying stream after use
+    cudaSetDevice(N);
+    cudaStreamDestroy(stream);
+
+HIP
+^^^
+
+.. warning:: Multi-GPU only supported for rocm 5.6 and later. Because of the lack of HIP API functions for querying a stream's device
+             in pre rocm 5.6, constructing a ``Kokkos::HIP`` instance on the non-default device will not be able to throw an error,
+             problems will just likely arise downstream.
+
+
+.. code-block:: cpp
+
+    // Query number of devices available
+    int n_devices;
+    hipGetDeviceCount(&n_devices);
+
+    // Choose some 0 <= N < n_devices
+    int N = ...;
+
+    // Create stream on device N
+    hipStream_t stream;
+    hipSetDevice(N);
+    hipStreamCreate(&stream);
+
+    // Scope execution space to ensure stream
+    // is destroyed *after* execution space
+    {
+      // Create execution space
+      Kokkos::HIP exec_space(stream);
+
+      // Use execution space
+      /* ... */
+    }
+
+    // Destroying stream after use
+    hipSetDevice(N);
+    hipStreamDestroy(stream);
+
+SYCL
+^^^^
+
+.. code-block:: cpp
+
+    // Get list of devices available
+    std::vector<sycl::device> gpu_devices =
+      sycl::device::get_devices(sycl::info::device_type::gpu);
+
+    // Choose some 0 <= N < gpu_devices.size()
+    int N = ...;
+
+    // Create a queue on device N.
+    // Note: Kokkos requires SYCL queues to be "in_order"
+    sycl::queue queue{gpu_devices[N], sycl::property::queue::in_order()};
+
+    // Create execution space
+    Kokkos::SYCL exec_space(queue);
+
+    // Use execution space
+    /* ... */
+
+Notes
+-----
+
+- For ``parallel_reduce(..., const ReducerArgument&... reducer)``, it is important to pass rank-0 views for the ``reducer`` arguments
+  instead of scalar types. Scalar reductions imply a fence on all execution spaces.
+- When passing a stream to an execution space constructor, the user is expected the manage the lifetime of the stream. Only after the
+  execution space is destroyed can the user safely destroy the stream.

--- a/docs/source/API/core/MultiGPUSupport.rst
+++ b/docs/source/API/core/MultiGPUSupport.rst
@@ -127,7 +127,8 @@ Example:
 
 .. code-block:: cpp
 
-    Kokkos::View<int*> V(Kokkos::view_alloc("V", exec_space), 10);
+    using ExecutionSpace = decltype(exec_space);
+    Kokkos::View<int*, typename ExecutionSpace::memory_space> V(Kokkos::view_alloc("V", exec_space), 10);
 
 Launching Kernels
 ~~~~~~~~~~~~~~~~~

--- a/docs/source/API/core/MultiGPUSupport.rst
+++ b/docs/source/API/core/MultiGPUSupport.rst
@@ -56,7 +56,7 @@ HIP
 For the HIP backend, like with CUDA, the user creates a ``hipStream_t`` object and passes it to the ``Kokkos::HIP`` constructor.
 
 .. note:: The lifetime of all Kokkos objects related to the stream (e.g., the execution space) needs to end before the stream itself is invalidated
-          via ``cudaStreamDestroy``. This can be done by adding a scope around such objects, as is done below.
+          via ``hipStreamDestroy``. This can be done by adding a scope around such objects, as is done below.
 
 .. warning:: Multi-GPU only supported for ROCm 5.6 and later. Because of the lack of HIP API functions for querying a
              stream's device before ROCm 5.6, constructing a ``Kokkos::HIP`` instance on a non-default device isn't
@@ -119,7 +119,8 @@ Using Kokkos Methods
 --------------------
 
 Once an execution space has been created on the chosen device, the execution space must be passed to all Kokkos methods
-intended to be used on the chosen device. If no execution space is passed, Kokkos will use `DefaultExecutionSpace`.
+intended to be used on the chosen device. If no execution space is passed, Kokkos will use the default execution space
+instance associated with the device with which Kokkos was initialized.
 
 Allocating Managed Views
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Multi GPU was not yet documented, seems like we needed something for this.

There is much more that could be added
- timings
- show how to alloc unmanaged views
- show how to use the execution space for view alloc, policy creation, fencing
- link the tutorial?

Let me know your thoughts.