### PR TITLE
conf: make the year always up-to-date

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,6 +12,7 @@
 #
 import os
 import sys
+import datetime
 sys.path.append(os.path.abspath("./_ext"))
 sys.path.insert(0, os.path.abspath('.'))
 
@@ -21,7 +22,7 @@ sys.path.insert(0, os.path.abspath('.'))
 master_doc = "index"
 
 project = 'Kokkos'
-copyright = '2024, National Technology & Engineering Solutions of Sandia, LLC (NTESS)'
+copyright = f'{datetime.datetime.now().year}, National Technology & Engineering Solutions of Sandia, LLC (NTESS)'
 author = 'lots of people'
 
 # The full version, including alpha/beta/rc tags


### PR DESCRIPTION
This PR ensures that the year in the copyright footnote is the year the documentation was generated for the last time.