### PR TITLE
Add Sifive Unmatched option

### DIFF
--- a/docs/source/get-started/configuration-guide.rst
+++ b/docs/source/get-started/configuration-guide.rst
@@ -529,7 +529,7 @@ If cross-compiling, or if you want to be specific, the CPU architecture can be p
       - Milk-V Pioneer
       - (since Kokkos 4.3)
 
-    * - ``KOKKOS_ARCH_RISCV_U74MC``
+    * - ``Kokkos_ARCH_RISCV_U74MC``
       - U74MC/RISC-V ISA
       - SiFive Unmatched
       - (since Kokkos 4.7)

--- a/docs/source/get-started/configuration-guide.rst
+++ b/docs/source/get-started/configuration-guide.rst
@@ -531,7 +531,7 @@ If cross-compiling, or if you want to be specific, the CPU architecture can be p
 
     * - ``KOKKOS_ARCH_RISCV_U74MC``
       - U74MC/RISC-V ISA
-      - Sifive Unmatched
+      - SiFive Unmatched
       - (since Kokkos 4.7)
 
 GPU Architectures

--- a/docs/source/get-started/configuration-guide.rst
+++ b/docs/source/get-started/configuration-guide.rst
@@ -529,6 +529,10 @@ If cross-compiling, or if you want to be specific, the CPU architecture can be p
       - Milk-V Pioneer
       - (since Kokkos 4.3)
 
+    * - ``KOKKOS_ARCH_RISCV_U74MC``
+      - U74MC/RISC-V ISA
+      - Sifive Unmatched
+      - (since Kokkos 4.7)
 
 GPU Architectures
 -----------------


### PR DESCRIPTION
Document the option  `KOKKOS_ARCH_RISCV_U74MC` to build Kokkos on Sifive Unmatched boards