### PR TITLE
Fix two broken links in the cmake keywords page

### DIFF
--- a/docs/source/get-started/configuration-guide.rst
+++ b/docs/source/get-started/configuration-guide.rst
@@ -211,7 +211,7 @@ Backend-specific options
       * Enable relocatable device code (RDC) for CUDA
       * ``OFF``
 
-    * * ``Kokkos_ENABLE_CUDA_UVM`` :red:`[Deprecated since 4.0]` see `Transition to alternatives <usecases/Moving_from_EnableUVM_to_SharedSpace.html>`_
+    * * ``Kokkos_ENABLE_CUDA_UVM`` :red:`[Deprecated since 4.0]` see `Transition to alternatives <../usecases/Moving_from_EnableUVM_to_SharedSpace.html>`_
       * Use unified memory (UM) by default for CUDA
       * ``OFF``
 
@@ -219,7 +219,7 @@ Backend-specific options
       * Use ``cudaMallocAsync`` (requires CUDA Toolkit version 11.2 or higher). This
 	optimization may improve performance in applications with multiple CUDA streams per device, but it
 	is known to be incompatible with MPI distributions built on older versions of UCX
-	and many Cray MPICH instances. See `known issues <known-issues.html#cuda>`_.
+	and many Cray MPICH instances. See `known issues <../known-issues.html#cuda>`_.
       * (see below)
 
     * * ``Kokkos_ENABLE_HIP_MULTIPLE_KERNEL_INSTANTIATIONS``


### PR DESCRIPTION
This PR fixes two broken links in the CMake keywords page