### PR TITLE
Fixes memory traits example.

### DIFF
--- a/docs/source/API/core/view/view.rst
+++ b/docs/source/API/core/view/view.rst
@@ -87,6 +87,8 @@ and ``MemoryTraits`` are specified, ``MemorySpace`` must come before ``MemoryTra
 
   - ``Restrict``: There is no aliasing of the view by other data structures in the current scope.
 
+ Example usage: ``Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>``
+
 Public Class Members
 --------------------
 

--- a/docs/source/ProgrammingGuide/Interoperability.md
+++ b/docs/source/ProgrammingGuide/Interoperability.md
@@ -127,9 +127,10 @@ Alternatively one can create a view which directly references the external alloc
 ```c++
 void MyKokkosFunction(int* a, const double* b, int n, int m) {
   // Define the host execution space and the view types
-  typedef View<int*, DefaultHostExecutionSpace, Unmanaged> t_1d_view;
+  typedef View<int*, DefaultHostExecutionSpace, MemoryTraits<Unmanaged>> t_1d_view;
   typedef View<double**[3],LayoutRight, DefaultHostExecutionSpace,
-               Unmanaged> t_3d_view;
+               MemoryTraits<Unmanaged>> t_3d_view;
+  // Unmanaged views cannot have labels
 
   // Create a 1D view of the external allocation
   t_1d_view d_a(a,n);


### PR DESCRIPTION
The issue is in the interoperability page an unmanaged view is given the syntax `View<..., Unmanaged>` where the correct syntax is `View<..., MemoryTraits<Unmanaged>>`.

I have also added an example so that the memory traits is easier to use, depicting the usage as bit flags rather than template tags to ease any confusion.

This threw me a little bit, it is in other places in the documentation so not a major issue but would be nice if it were correct here