### PR TITLE
Aid in msvc building

### DIFF
--- a/docs/source/ProgrammingGuide/Compiling.md
+++ b/docs/source/ProgrammingGuide/Compiling.md
@@ -50,7 +50,7 @@ The target_link_libraries command will find and include all the necessary pre-pr
 ```
 -DKokkos_ROOT=<Kokkos Install Directory>/lib64/cmake/Kokkos
 ```
-If compiling with something other than g++, your application should use a compiler that is consistent with that used to build the Kokkos package.  This is especially true when using nvcc_wrapper.
+Your application should use a compiler that is consistent with that used to build the Kokkos package.  This is especially true when using nvcc_wrapper.
 ```
 -DCMAKE_CXX_COMPILER=<Kokkos Install Directory>/bin/nvcc_wrapper
 ```

--- a/docs/source/get-started/building-from-source.rst
+++ b/docs/source/get-started/building-from-source.rst
@@ -157,7 +157,7 @@ These options are generally useful for any CMake project:
   * ``SYCL``: Intel GPUs
     
   Example: ``-DKokkos_ENABLE_CUDA=ON``
-  Note that ``-DKokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON`` is required when building with cuda and MSVC/CL
+  Note that ``-DKokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON`` is required when building with CUDA and MSVC on Windows.
 
 
 

--- a/docs/source/get-started/building-from-source.rst
+++ b/docs/source/get-started/building-from-source.rst
@@ -157,7 +157,7 @@ These options are generally useful for any CMake project:
   * ``SYCL``: Intel GPUs
     
   Example: ``-DKokkos_ENABLE_CUDA=ON``
-
+  Note that ``-DKokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON`` is required when building with cuda and MSVC/CL
 
 
 


### PR DESCRIPTION
There was confusion by me and someone else who raised an issue trying to use `nvcc_wrapper` on windows. 

I think the wording of the `nvcc_wrapper` section in `Compiling.md` give the wrong impression. I have changed said wording (though I think it could be better) and added a note in `building_from_source.rst` so that what to do on windows can be seen easier.

I would also suggest adding something to the tutorials for windows/MSVC compilation. My current solution is not portable.

Thanks