### PR TITLE
refactor view documentation

### DIFF
--- a/docs/source/API/core/execution_spaces.rst
+++ b/docs/source/API/core/execution_spaces.rst
@@ -1,3 +1,5 @@
+.. _api-execution-spaces:
+
 Execution Spaces
 ================
 

--- a/docs/source/API/core/memory_spaces.rst
+++ b/docs/source/API/core/memory_spaces.rst
@@ -1,3 +1,5 @@
+.. _api-memory-spaces:
+
 Memory Spaces
 =============
 

--- a/docs/source/API/core/view/create_mirror.rst
+++ b/docs/source/API/core/view/create_mirror.rst
@@ -36,7 +36,7 @@ Description
 
 .. _View: view.html
 
-.. |View| replace:: :cpp:func:`View`
+.. |View| replace:: :cpp:class:`View`
 
 .. _ExecutionSpaceConcept: ../execution_spaces.html#executionspaceconcept
 

--- a/docs/source/API/core/view/view.rst
+++ b/docs/source/API/core/view/view.rst
@@ -53,9 +53,9 @@ Header File: ``<Kokkos_Core.hpp>``
    
    :tparam MemorySpace: Controls the storage location of the View.
 
-      If omitted the default memory space of the default execution space is used (i.e. :cpp:expr:`Kokkos::DefaultExecutionSpace::memory_space`)
+      If omitted the default memory space of the default execution space is used (i.e. :cpp:expr:`DefaultExecutionSpace::memory_space`)
 
-   :tparam MemoryTraits: Sets access properties via enum parameters for the templated :cpp:expr:`Kokkos::MemoryTraits<>` class.
+   :tparam MemoryTraits: Sets access properties via enum parameters for the templated :cpp:class:`MemoryTraits\<>` class.
 
       Possible template parameters are bit-combinations of the following flags:
 
@@ -65,7 +65,7 @@ Header File: ``<Kokkos_Core.hpp>``
          If the view is also :cpp:`const` this will trigger special load operations on GPUs (i.e. texture fetches).
       - ``Restrict``: There is no aliasing of the view by other data structures in the current scope.
 
-      Example usage: ``Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>``
+      Example usage: :cpp:`MemoryTraits<Unmanaged | RandomAccess>`
 
    .. rubric:: Public Constants:
    
@@ -589,7 +589,7 @@ Header File: ``<Kokkos_Core.hpp>``
 
       :returns: an mdspan with extents and a layout converted from the :cpp:class:`View`'s *natural mdspan*.
 
-   .. cpp:function:: template <class OtherAccessorType = Kokkos::default_accessor<typename traits::value_type>> constexpr auto to_mdspan(const OtherAccessorType& other_accessor = OtherAccessorType{})
+   .. cpp:function:: template <class OtherAccessorType = default_accessor<typename traits::value_type>> constexpr auto to_mdspan(const OtherAccessorType& other_accessor = OtherAccessorType{})
 
       :tparam OtherAccessor: the target mdspan accessor
 

--- a/docs/source/API/core/view/view.rst
+++ b/docs/source/API/core/view/view.rst
@@ -164,7 +164,7 @@ Header File: ``<Kokkos_Core.hpp>``
       pointer to :cpp:type:`value_type`.
 
 
-   .. rubric:: Other
+   .. rubric:: Other Types
 
    .. cpp:type:: array_layout
 
@@ -187,20 +187,24 @@ Header File: ``<Kokkos_Core.hpp>``
 
    .. cpp:function:: View()
 
-      Default Constructor. No allocations are made, no reference counting happens. All extents are zero and its data pointer is NULL.
+      Default Constructor. No allocations are made, no reference counting happens. All extents are zero and its data pointer is :cpp:`nullptr`.
 
-   .. cpp:function:: View( const View<DT, Prop...>& rhs)
+   .. cpp:function:: template<class DT, class... Prop> View( const View<DT, Prop...>& rhs)
 
       Copy constructor with compatible view. Follows View assignment rules.
 
-   .. cpp:function:: View( View&& rhs)
+      .. seealso:: :ref:`api-view-assignment`
+
+   .. cpp:function:: View(View&& rhs)
 
       Move constructor
 
-   .. cpp:function:: View( const std::string& name, const IntType& ... extents)
+   .. cpp:function:: template<class IntType> View( const std::string& name, const IntType& ... extents)
 
       Standard allocating constructor. The initialization is executed on the default
       instance of the execution space corresponding to ``MemorySpace`` and fences it.
+
+      :tparam IntType: an integral type
 
       :param name: a user provided label, which is used for profiling and debugging purposes. Names are not required to be unique,
 
@@ -304,7 +308,12 @@ Header File: ``<Kokkos_Core.hpp>``
 
    .. cpp:function:: View( const View<DT, Prop...>& rhs, Args ... args)
 
-      Subview constructor. See ``subview`` function for arguments.
+      :param rhs: the :cpp:class:`View` to take a subview of
+      :param args...: the subview slices as specified in :cpp:func:`subview`
+
+      Subview constructor.
+
+      .. seealso:: :cpp:func:`subview`
 
    .. cpp:function:: explicit(traits::is_managed) View( const NATURAL_MDSPAN_TYPE& mds )
 
@@ -401,199 +410,196 @@ Header File: ``<Kokkos_Core.hpp>``
       It may also break code that was using the type of :cpp:func:`rank`.
       Furthermore, it appears that MSVC has issues with the implicit conversion to :cpp:`size_t` in certain constexpr contexts. Calling :cpp:func:`rank()` or :cpp:func:`rank_dynamic()` will work in those cases.
 
-.. cpp:function:: constexpr array_layout layout() const
+   .. cpp:function:: constexpr array_layout layout() const
 
-   :return: the layout object that can be used to to construct other views with the same dimensions.
+      :return: the layout object that can be used to to construct other views with the same dimensions.
 
-.. cpp:function:: template<class iType> constexpr size_t extent( const iType& dim) const
+   .. cpp:function:: template<class iType> constexpr size_t extent( const iType& dim) const
 
-   :tparam iType: an integral type
-   :param dim: the dimension to get the extent of
-   :return: the extent of dimension :cpp:any:`dim`
+      :tparam iType: an integral type
+      :param dim: the dimension to get the extent of
+      :return: the extent of dimension :cpp:any:`dim`
 
-   **Preconditions**
+      **Preconditions**
 
-   - :cpp:any:`dim` must be smaller than :cpp:func:`rank`.
+      - :cpp:any:`dim` must be smaller than :cpp:func:`rank`.
 
-.. cpp:function:: template<class iType> constexpr int extent_int( const iType& dim) const
+   .. cpp:function:: template<class iType> constexpr int extent_int( const iType& dim) const
 
-   :tparam iType: an integral type
-   :param dim: the dimension to get the extent of
-   :return: the extent of dimension :cpp:any:`dim` as an :cpp:`int`
+      :tparam iType: an integral type
+      :param dim: the dimension to get the extent of
+      :return: the extent of dimension :cpp:any:`dim` as an :cpp:`int`
 
-   Compared to :cpp:func:`extent` this function can be
-   useful on architectures where :cpp:`int` operations are more efficient than :cpp:`size_t`.
-   It also may eliminate the need for type casts in applications which
-   otherwise perform all index operations with :cpp:`int`.
+      Compared to :cpp:func:`extent` this function can be
+      useful on architectures where :cpp:`int` operations are more efficient than :cpp:`size_t`.
+      It also may eliminate the need for type casts in applications which
+      otherwise perform all index operations with :cpp:`int`.
 
-   **Preconditions**
+      **Preconditions**
 
-   - :cpp:any:`dim` must be smaller than :cpp:func:`rank`.
+      - :cpp:any:`dim` must be smaller than :cpp:func:`rank`.
 
-.. cpp:function:: template<class iType> constexpr size_t stride(const iType& dim) const
+   .. cpp:function:: template<class iType> constexpr size_t stride(const iType& dim) const
 
-   :tparam iType: an integral type
-   :param dim: the dimension to get the stride of
-   :return: the stride of dimension :cpp:any:`dim`
+      :tparam iType: an integral type
+      :param dim: the dimension to get the stride of
+      :return: the stride of dimension :cpp:any:`dim`
 
-   Example: :cpp:expr:`a.stride(3) == (&a(i0,i1,i2,i3+1,i4)-&a(i0,i1,i2,i3,i4))`
+      Example: :cpp:expr:`a.stride(3) == (&a(i0,i1,i2,i3+1,i4)-&a(i0,i1,i2,i3,i4))`
 
-   **Preconditions**
+      **Preconditions**
 
-   - :cpp:any:`dim` must be smaller than :cpp:func:`rank`.
+      - :cpp:any:`dim` must be smaller than :cpp:func:`rank`.
 
-.. cpp:function:: constexpr size_t stride_0() const
+   .. cpp:function:: constexpr size_t stride_0() const
 
-   :return: the stride of dimension 0.
+      :return: the stride of dimension 0.
 
-.. cpp:function:: constexpr size_t stride_1() const
+   .. cpp:function:: constexpr size_t stride_1() const
 
-   :return: the stride of dimension 1.
+      :return: the stride of dimension 1.
 
-.. cpp:function:: constexpr size_t stride_2() const
+   .. cpp:function:: constexpr size_t stride_2() const
 
-   :return: the stride of dimension 2.
+      :return: the stride of dimension 2.
 
-.. cpp:function:: constexpr size_t stride_3() const
+   .. cpp:function:: constexpr size_t stride_3() const
 
-   :return: the stride of dimension 3.
+      :return: the stride of dimension 3.
 
-.. cpp:function:: constexpr size_t stride_4() const
+   .. cpp:function:: constexpr size_t stride_4() const
 
-   :return: the stride of dimension 4.
+      :return: the stride of dimension 4.
 
-.. cpp:function:: constexpr size_t stride_5() const
+   .. cpp:function:: constexpr size_t stride_5() const
 
-   :return: the stride of dimension 5.
+      :return: the stride of dimension 5.
 
-.. cpp:function:: constexpr size_t stride_6() const
+   .. cpp:function:: constexpr size_t stride_6() const
 
-   :return: the stride of dimension 6.
+      :return: the stride of dimension 6.
 
-.. cpp:function:: constexpr size_t stride_7() const
+   .. cpp:function:: constexpr size_t stride_7() const
 
-   :return: the stride of dimension 7.
+      :return: the stride of dimension 7.
 
-.. cpp:function:: template<class iType> void stride(iType* strides) const
+   .. cpp:function:: template<class iType> void stride(iType* strides) const
 
-   :tparam iType: an integral type
-   :param strides: the output array of length :cpp:expr:`rank() + 1`
+      :tparam iType: an integral type
+      :param strides: the output array of length :cpp:expr:`rank() + 1`
 
-   Sets :cpp:expr:`strides[r]` to :cpp:expr:`stride(r)` for all :math:`r` with :math:`0 \le r \lt \texttt{rank()}`.
-   Sets :cpp:expr:`strides[rank()]` to :cpp:func:`span()`.
+      Sets :cpp:expr:`strides[r]` to :cpp:expr:`stride(r)` for all :math:`r` with :math:`0 \le r \lt \texttt{rank()}`.
+      Sets :cpp:expr:`strides[rank()]` to :cpp:func:`span()`.
 
-   **Preconditions**
+      **Preconditions**
 
-   - :cpp:any:`strides` must be an array of length :cpp:expr:`rank() + 1`
+      - :cpp:any:`strides` must be an array of length :cpp:expr:`rank() + 1`
 
-.. cpp:function:: constexpr size_t span() const
+   .. cpp:function:: constexpr size_t span() const
 
-   :return: the size of the span of memory between the element with the lowest and highest address
+      :return: the size of the span of memory between the element with the lowest and highest address
 
-   Obtains the memory span in elements between the element with the
-   lowest and the highest address. This can be larger than the product
-   of extents due to padding, and or non-contiguous data layout as for example :cpp:struct:`LayoutStride` allows.
+      Obtains the memory span in elements between the element with the
+      lowest and the highest address. This can be larger than the product
+      of extents due to padding, and or non-contiguous data layout as for example :cpp:struct:`LayoutStride` allows.
 
-.. cpp:function:: constexpr size_t size() const
+   .. cpp:function:: constexpr size_t size() const
 
-   :return: the product of extents, i.e. the logical number of elements in the :cpp:class:`View`.
+      :return: the product of extents, i.e. the logical number of elements in the :cpp:class:`View`.
 
-.. cpp:function:: constexpr pointer_type data() const
+   .. cpp:function:: constexpr pointer_type data() const
 
-   :return: the pointer to the underlying data allocation.
+      :return: the pointer to the underlying data allocation.
 
-   .. warning::
-   
-      Calling any function that manipulates the behavior of the memory (e.g. ``memAdvise``) on memory managed by Kokkos results in undefined behavior.
+      .. warning::
+      
+         Calling any function that manipulates the behavior of the memory (e.g. ``memAdvise``) on memory managed by Kokkos results in undefined behavior.
 
-.. cpp:function:: bool span_is_contiguous() const
+   .. cpp:function:: bool span_is_contiguous() const
 
-   :return: whether the span is contiguous (i.e. whether every memory location between in span belongs to the index space covered by the :cpp:class:`View`).
+      :return: whether the span is contiguous (i.e. whether every memory location between in span belongs to the index space covered by the :cpp:class:`View`).
 
-.. cpp:function:: static constexpr size_t required_allocation_size(size_t N0=0, size_t N1=0, \
-			size_t N2=0, size_t N3=0, \
-			size_t N4=0, size_t N5=0, \
-			size_t N6=0, size_t N7=0, size_t N8 = 0);
-   
-   :param N0, N1, N2, N3, N4, N5, N6, N7, N8: the dimensions to query
-   :return: the number of bytes necessary for an unmanaged :cpp:class:`View` of the provided dimensions.
-   
-   **Requirements**
-   
-   - :cpp:expr:`array_layout::is_regular == true`.
+   .. cpp:function:: static constexpr size_t required_allocation_size(size_t N0=0, size_t N1=0, \
+            size_t N2=0, size_t N3=0, \
+            size_t N4=0, size_t N5=0, \
+            size_t N6=0, size_t N7=0, size_t N8 = 0);
+      
+      :param N0, N1, N2, N3, N4, N5, N6, N7, N8: the dimensions to query
+      :return: the number of bytes necessary for an unmanaged :cpp:class:`View` of the provided dimensions.
+      
+      **Requirements**
+      
+      - :cpp:expr:`array_layout::is_regular == true`.
 
-.. cpp:function:: static constexpr size_t required_allocation_size(const array_layout& layout);
+   .. cpp:function:: static constexpr size_t required_allocation_size(const array_layout& layout);
 
-   :param layout: the layout to query
-   :return: the number of bytes necessary for an unmanaged :cpp:class:`View` of the provided layout.
+      :param layout: the layout to query
+      :return: the number of bytes necessary for an unmanaged :cpp:class:`View` of the provided layout.
 
-Other
-~~~~~
+   .. rubric:: Other Utility Methods
 
-.. cpp:function:: int use_count() const;
+   .. cpp:function:: int use_count() const;
 
-   Returns the current reference count of the underlying allocation.
+      :return: the current reference count of the underlying allocation.
 
-.. cpp:function:: const std::string label() const;
+   .. cpp:function:: const std::string label() const;
 
-   Returns the label of the View.
+      :return: the label of the View.
 
-.. cpp:function:: const bool is_assignable(const View<DT, Prop...>& rhs);
+   .. cpp:function:: const bool is_assignable(const View<DT, Prop...>& rhs);
 
-   Returns true if the View can be assigned to rhs.  See below for assignment rules.
+      :return: true if the View can be assigned to rhs.
 
-.. cpp:function:: void assign_data(pointer_type arg_data);
+      .. seealso:: :ref:`api-view-assignment`
 
-   Decrement reference count of previously assigned data and set the underlying pointer to arg_data.
-   Note that the effective result of this operation is that the view
-   is now an unmanaged view; thus, the deallocation of memory associated with
-   arg_data is not linked in anyway to the deallocation of the view.
+   .. cpp:function:: void assign_data(pointer_type arg_data);
 
-.. cpp:function:: constexpr bool is_allocated() const;
+      :param arg_data: the pointer to set the underlying :cpp:class:`View` data pointer to
 
-   Returns true if the view points to a valid memory location.
-   This function works for both managed and unmanaged views.
-   With the unmanaged view, there is no guarantee that referenced
-   address is valid, only that it is a non-null pointer.
+      Decrement reference count of previously assigned data and set the underlying pointer to arg_data.
+      Note that the effective result of this operation is that the view is now an unmanaged view; thus, the deallocation of memory associated with arg_data is not linked in anyway to the deallocation of the view.
 
-Conversion to mdspan
-~~~~~~~~~~~~~~~~~~~~
+   .. cpp:function:: constexpr bool is_allocated() const;
 
-.. cpp:function:: template <class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessor> constexpr operator mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>()
+      :return: true if the view points to a valid memory location.
 
-   :tparam OtherElementType: the target mdspan element type
-   :tparam OtherExtents: the target mdspan extents
-   :tparam OtherLayoutPolicy: the target mdspan layout
-   :tparam OtherAccessor: the target mdspan accessor
+      This function works for both managed and unmanaged views.
+      With the unmanaged view, there is no guarantee that referenced address is valid, only that it is a non-null pointer.
 
-   :constraints: :cpp:class:`View`\ 's :ref:`natural mdspan <api-view-natural-mdspans>` must be assignable to :cpp:`mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>`
+   .. rubric:: Conversion to mdspan
 
-   :returns: an mdspan with extents and a layout converted from the :cpp:class:`View`'s *natural mdspan*.
+   .. cpp:function:: template <class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessor> constexpr operator mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>()
 
-.. cpp:function:: template <class OtherAccessorType = Kokkos::default_accessor<typename traits::value_type>> constexpr auto to_mdspan(const OtherAccessorType& other_accessor = OtherAccessorType{})
+      :tparam OtherElementType: the target mdspan element type
+      :tparam OtherExtents: the target mdspan extents
+      :tparam OtherLayoutPolicy: the target mdspan layout
+      :tparam OtherAccessor: the target mdspan accessor
 
-   :tparam OtherAccessor: the target mdspan accessor
+      :constraints: :cpp:class:`View`\ 's :ref:`natural mdspan <api-view-natural-mdspans>` must be assignable to :cpp:`mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>`
 
-   :constraints: :cpp:`typename OtherAccessorType::data_handle_type` must be assignable to :cpp:`value_type*`
+      :returns: an mdspan with extents and a layout converted from the :cpp:class:`View`'s *natural mdspan*.
 
-   :returns: :cpp:class:`View`\ 's :ref:`natural mdspan <api-view-natural-mdspans>`, but with an accessor policy constructed from :cpp:any:`other_accessor`
+   .. cpp:function:: template <class OtherAccessorType = Kokkos::default_accessor<typename traits::value_type>> constexpr auto to_mdspan(const OtherAccessorType& other_accessor = OtherAccessorType{})
 
+      :tparam OtherAccessor: the target mdspan accessor
 
-NonMember Functions
--------------------
+      :constraints: :cpp:`typename OtherAccessorType::data_handle_type` must be assignable to :cpp:`value_type*`
+
+      :returns: :cpp:class:`View`\ 's :ref:`natural mdspan <api-view-natural-mdspans>`, but with an accessor policy constructed from :cpp:any:`other_accessor`
+
+
+Non-Member Functions
+--------------------
 
 .. cpp:function:: template<class ViewDst, class ViewSrc> bool operator==(ViewDst, ViewSrc);
 
-   Returns true if ``value_type``, ``array_layout``, ``memory_space``, ``rank``, ``data()`` and ``extent(r)``, for ``0<=r<rank``, match.
+   :return: :cpp:`true` if :cpp:type:`~View::value_type`, :cpp:type:`~View::array_layout`, :cpp:type:`~View::memory_space`, :cpp:func:`~View::rank()`, :cpp:func:`~View::data()` and :cpp:expr:`extent(r)`, for :math:`0 \le r \lt \texttt{rank()}`, match.
 
 .. cpp:function:: template<class ViewDst, class ViewSrc> bool operator!=(ViewDst, ViewSrc);
 
    Returns true if any of ``value_type``, ``array_layout``, ``memory_space``, ``rank``, ``data()`` and ``extent(r)``, for ``0<=r<rank`` don't match.
 
-.. _api-view-datatype:
-
-:cpp:class:`View` DataType
---------------------------
+.. _api-view-assignment:
 
 Assignment Rules
 ----------------
@@ -632,10 +638,8 @@ These rules only cover cases where both layouts are one of ``LayoutLeft``, ``Lay
 
   - For each dimension ``k`` it must hold that ``dst_view.extent(k) == src_view.extent(k)``
 
-Assignment Examples
-~~~~~~~~~~~~~~~~~~~
-
 .. code-block:: cpp
+   :caption: Assignment Examples
 
     View<int*>       a1 = View<int*>("A1",N);     // OK
     View<int**>      a2 = View<int*[10]>("A2",N); // OK

--- a/docs/source/API/core/view/view.rst
+++ b/docs/source/API/core/view/view.rst
@@ -67,13 +67,13 @@ Header File: ``<Kokkos_Core.hpp>``
 
       Example usage: ``Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>``
 
-   .. rubric:: Public Constants
+   .. rubric:: Public Constants:
    
    .. cpp:member:: static constexpr bool reference_type_is_lvalue_reference
 
       whether the reference type is a C++ lvalue reference.
 
-   .. rubric:: Data Types
+   .. rubric:: Data Types:
 
    .. cpp:type:: data_type
 
@@ -100,7 +100,7 @@ Header File: ``<Kokkos_Core.hpp>``
       Non-:cpp:`const` version of :cpp:type:`scalar_array_type`, same as :cpp:type:`scalar_array_type` if that is already non-:cpp:`const`.
 
 
-   .. rubric:: Scalar Types
+   .. rubric:: Scalar Types:
 
    .. cpp:type:: value_type
 
@@ -115,7 +115,7 @@ Header File: ``<Kokkos_Core.hpp>``
       non-:cpp:`const` version of :cpp:type:`value_type`.
 
 
-   .. rubric:: Spaces
+   .. rubric:: Spaces:
 
    .. cpp:type:: execution_space
 
@@ -138,7 +138,7 @@ Header File: ``<Kokkos_Core.hpp>``
 
       Host accessible memory space used in :cpp:type:`HostMirror`.
 
-   .. rubric:: ViewTypes
+   .. rubric:: ViewTypes:
 
    .. cpp:type:: non_const_type
 
@@ -153,7 +153,7 @@ Header File: ``<Kokkos_Core.hpp>``
       compatible view type with the same :cpp:type:`data_type` and :cpp:type:`array_layout` stored in host accessible memory space.
 
 
-   .. rubric:: Data Handles
+   .. rubric:: Data Handles:
 
    .. cpp:type:: reference_type
 
@@ -164,7 +164,7 @@ Header File: ``<Kokkos_Core.hpp>``
       pointer to :cpp:type:`value_type`.
 
 
-   .. rubric:: Other Types
+   .. rubric:: Other Types:
 
    .. cpp:type:: array_layout
 
@@ -183,7 +183,7 @@ Header File: ``<Kokkos_Core.hpp>``
       A specialization tag used for partial specialization of the mapping construct underlying a :cpp:class:`View`.
 
 
-   .. rubric:: Constructors
+   .. rubric:: Constructors:
 
    .. cpp:function:: View()
 
@@ -356,7 +356,7 @@ Header File: ``<Kokkos_Core.hpp>``
       .. versionadded:: 4.4.0
 
 
-   .. rubric:: Data Access Functions
+   .. rubric:: Data Access Functions:
 
    .. cpp:function:: reference_type operator() (const IntType& ... indices) const
 
@@ -382,7 +382,7 @@ Header File: ``<Kokkos_Core.hpp>``
       Index arguments beyond :cpp:func:`rank` must be :cpp:`0`, which will be enforced if :cpp:any:`KOKKOS_DEBUG` is defined.
 
 
-   .. rubric:: Data Layout, Dimensions, Strides
+   .. rubric:: Data Layout, Dimensions, Strides:
 
    .. cpp:function:: static constexpr size_t rank()
 
@@ -536,7 +536,7 @@ Header File: ``<Kokkos_Core.hpp>``
       :param layout: the layout to query
       :return: the number of bytes necessary for an unmanaged :cpp:class:`View` of the provided layout.
 
-   .. rubric:: Other Utility Methods
+   .. rubric:: Other Utility Methods:
 
    .. cpp:function:: int use_count() const;
 
@@ -566,7 +566,7 @@ Header File: ``<Kokkos_Core.hpp>``
       This function works for both managed and unmanaged views.
       With the unmanaged view, there is no guarantee that referenced address is valid, only that it is a non-null pointer.
 
-   .. rubric:: Conversion to mdspan
+   .. rubric:: Conversion to mdspan:
 
    .. cpp:function:: template <class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessor> constexpr operator mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>()
 

--- a/docs/source/API/core/view/view.rst
+++ b/docs/source/API/core/view/view.rst
@@ -212,7 +212,7 @@ Header File: ``<Kokkos_Core.hpp>``
 
       :tparam IntType: an integral type
 
-      :param name: a user provided label, which is used for profiling and debugging purposes. Names are not required to be unique,
+      :param name: a user provided label, which is used for profiling and debugging purposes. Names are not required to be unique.
 
       :param extents: Extents of the :cpp:class:`View`.
 
@@ -228,7 +228,7 @@ Header File: ``<Kokkos_Core.hpp>``
       instance of the execution space corresponding to :cpp:type:`memory_space` and fences it.
 
       :param name: a user provided label, which is used for profiling and debugging purposes.
-         Names are not required to be unique,
+         Names are not required to be unique.
 
       :param layout: an instance of a layout class.
          The number of valid extents must either match the :cpp:func:`rank_dynamic` or :cpp:func:`rank`.

--- a/docs/source/API/core/view/view.rst
+++ b/docs/source/API/core/view/view.rst
@@ -32,7 +32,7 @@ Header File: ``<Kokkos_Core.hpp>``
 
    :tparam Properties...: Defines various properties of the :cpp:class:`View`, including layout, memory space, and memory traits.
    
-      :cpp:class:`View`'s template parameters after ``DataType`` are variadic and optional, but must be specified in order. That means for example that ``LayoutType`` can be omitted but if both ``MemorySpace`` and ``MemoryTraits`` are specified, ``MemorySpace`` must come before ``MemoryTraits``.
+      :cpp:class:`View`'s template parameters after ``DataType`` are variadic and optional, but must be specified in order. That means for example that :cpp:any:`LayoutType` can be omitted but if both :cpp:any:`MemorySpace` and :cpp:`MemoryTraits` are specified, :cpp:any:`MemorySpace` must come before :cpp:any:`MemoryTraits`.
 
       .. code-block:: cpp
          :caption: The ordering of View template parameters.
@@ -174,7 +174,7 @@ Header File: ``<Kokkos_Core.hpp>``
 
    .. cpp:type:: array_layout
 
-      The ``Layout`` of the :cpp:class:`View`.
+      The :cpp:any:`LayoutType` of the :cpp:class:`View`.
 
    .. cpp:type:: size_type
 

--- a/docs/source/API/core/view/view.rst
+++ b/docs/source/API/core/view/view.rst
@@ -42,7 +42,7 @@ Header File: ``<Kokkos_Core.hpp>``
 
    :tparam LayoutType: Determines the mapping of indices into the underlying 1D memory storage.
    
-      Custom Layouts can be implemented, but Kokkos comes with some built-in ones:
+      Kokkos comes with some built-in layouts:
 
       - :cpp:struct:`LayoutRight`: strides increase from the right most to the left most dimension.
          The last dimension has a stride of one.
@@ -77,19 +77,19 @@ Header File: ``<Kokkos_Core.hpp>``
 
    .. cpp:type:: data_type
 
-      The ``DataType`` of the :cpp:class:`View`, note :cpp:type:`data_type` contains the array specifiers (e.g. ``int**[3]``)
+      The :cpp:any:`DataType` of the :cpp:class:`View`, note :cpp:type:`data_type` contains the array specifiers (e.g. :cpp:`int**[3]`)
 
    .. cpp:type:: const_data_type
 
-      :cpp:`const` version of ``DataType``, same as :cpp:type:`data_type` if that is already  :cpp:`const`.
+      :cpp:`const` version of :cpp:any:`DataType`, same as :cpp:type:`data_type` if that is already  :cpp:`const`.
 
    .. cpp:type:: non_const_data_type
 
-      Non-:cpp:`const` version of ``DataType``, same as :cpp:type:`data_type` if that is already non-:cpp:`const`.
+      Non-:cpp:`const` version of :cpp:any:`DataType`, same as :cpp:type:`data_type` if that is already non-:cpp:`const`.
 
    .. cpp:type:: scalar_array_type
 
-      If ``DataType`` represents some properly specialised array data type such as Sacado FAD types, :cpp:type:`scalar_array_type` is the underlying fundamental scalar type.
+      If :cpp:any:`DataType` represents some properly specialised array data type such as Sacado FAD types, :cpp:type:`scalar_array_type` is the underlying fundamental scalar type.
 
    .. cpp:type:: const_scalar_array_type
 
@@ -142,11 +142,11 @@ Header File: ``<Kokkos_Core.hpp>``
 
    .. cpp:type:: non_const_type
 
-      this view type with all template parameters explicitly defined.
+      this :cpp:class:`View` type with :cpp:type:`non_const_data_type` passed as the :cpp:any:`DataType` template parameter
 
    .. cpp:type:: const_type
 
-      this view type with all template parameters explicitly defined using a ``const`` data type.
+      this :cpp:class:`View` type with :cpp:type:`const_data_type` passed as the :cpp:any:`DataType` template parameter
 
    .. cpp:type:: HostMirror
 
@@ -158,6 +158,12 @@ Header File: ``<Kokkos_Core.hpp>``
    .. cpp:type:: reference_type
 
       return type of the view access operators.
+
+      .. seealso::
+         :cpp:func:`operator()`
+
+         :cpp:func:`access()`
+
 
    .. cpp:type:: pointer_type
 
@@ -191,7 +197,7 @@ Header File: ``<Kokkos_Core.hpp>``
 
    .. cpp:function:: template<class DT, class... Prop> View( const View<DT, Prop...>& rhs)
 
-      Copy constructor with compatible view. Follows View assignment rules.
+      Copy constructor with a compatible view. Follows :cpp:class:`View` assignment rules.
 
       .. seealso:: :ref:`api-view-assignment`
 
@@ -202,7 +208,7 @@ Header File: ``<Kokkos_Core.hpp>``
    .. cpp:function:: template<class IntType> View( const std::string& name, const IntType& ... extents)
 
       Standard allocating constructor. The initialization is executed on the default
-      instance of the execution space corresponding to ``MemorySpace`` and fences it.
+      instance of the execution space corresponding to :cpp:type:`memory_space` and fences it.
 
       :tparam IntType: an integral type
 
@@ -210,7 +216,7 @@ Header File: ``<Kokkos_Core.hpp>``
 
       :param extents: Extents of the :cpp:class:`View`.
 
-      **Requirements**
+      .. rubric:: Requirements:
 
       - :cpp:expr:`sizeof(IntType...) == rank_dynamic()` or :cpp:expr:`sizeof(IntType...) == rank()`.
          In the latter case, the extents corresponding to compile-time dimensions must match the :cpp:class:`View` type's compile-time extents.
@@ -226,19 +232,21 @@ Header File: ``<Kokkos_Core.hpp>``
 
       :param layout: an instance of a layout class.
          The number of valid extents must either match the :cpp:func:`dynamic_rank` or :cpp:func:`rank`.
-         In the latter case, the extents corresponding to compile-time dimensions must match the View type's compile-time extents.
+         In the latter case, the extents corresponding to compile-time dimensions must match the :cpp:class:`View` type's compile-time extents.
 
-   .. cpp:function:: View( const ALLOC_PROP &prop, const IntType& ... extents)
+   .. cpp:function:: template<class IntType> View( const ALLOC_PROP &prop, const IntType& ... extents)
 
-      Allocating constructor with allocation properties (created by a call to :cpp:expr:`Kokkos::view_alloc`). If an execution space is
-      specified in ``prop``, the initialization uses it and does not fence.
-      Otherwise, the View is initialized using the default execution space instance corresponding to :cpp:type:`memory_space` and fences it.
+      Allocating constructor with allocation properties (created by a call to :cpp:func:`view_alloc`). If an execution space is
+      specified in :cpp:any:`prop`, the initialization uses it and does not fence.
+      Otherwise, the :cpp:class:`View` is initialized using the default execution space instance corresponding to :cpp:type:`memory_space` and fences it.
+
+      :tparam IntType: an integral type
 
       :param prop: An allocation properties object that is returned by :cpp:func:`view_alloc`.
 
       :param extents: Extents of the View.
 
-      **Requirements**
+      .. rubric:: Requirements:
 
       - :cpp:expr:`sizeof(IntType...) == rank_dynamic()` or :cpp:expr:`sizeof(IntType...) == rank()`.
          In the latter case, the extents corresponding to compile-time dimensions must match the :cpp:class:`View` type's compile-time extents.
@@ -246,26 +254,28 @@ Header File: ``<Kokkos_Core.hpp>``
 
    .. cpp:function:: View( const ALLOC_PROP &prop, const array_layout& layout)
 
-      Allocating constructor with allocation properties (created by a call to :cpp:expr:`Kokkos::view_alloc`) and a layout object. If an execution space is
-      specified in ``prop``, the initialization uses it and does not fence. Otherwise, the View is
-      initialized using the default execution space instance corresponding to :cpp:type:`memory_space` and fences it.
+      Allocating constructor with allocation properties (created by a call to :cpp:func:`view_alloc`) and a layout object. If an execution space is
+      specified in :cpp:any:`prop`, the initialization uses it and does not fence.
+      Otherwise, the :cpp:class:`View` is initialized using the default execution space instance corresponding to :cpp:type:`memory_space` and fences it.
 
       :param prop: An allocation properties object that is returned by :cpp:func:`view_alloc`.
 
       :param layout: an instance of a layout class.
          The number of valid extents must either match the :cpp:func:`dynamic_rank` or :cpp:func:`rank`.
-         In the latter case, the extents corresponding to compile-time dimensions must match the View type's compile-time extents.
+         In the latter case, the extents corresponding to compile-time dimensions must match the :cpp:class:`View` type's compile-time extents.
 
-   .. cpp:function:: View( pointer_type ptr, const IntType& ... extents)
+   .. cpp:function:: template<class IntType> View( pointer_type ptr, const IntType& ... extents)
 
       Unmanaged data wrapping constructor.
 
+      :tparam IntType: an integral type
+
       :param ptr: pointer to a user provided memory allocation.
-         Must provide storage of size :cpp:expr:`View::required_allocation_size(extents...)`
+         Must provide storage of size :cpp:expr:`required_allocation_size(extents...)`
 
       :param extents: Extents of the :cpp:class:`View`.
 
-      **Requirements**
+      .. rubric:: Requirements:
 
       - :cpp:expr:`sizeof(IntType...) == rank_dynamic()` or :cpp:expr:`sizeof(IntType...) == rank()`.
          In the latter case, the extents corresponding to compile-time dimensions must match the :cpp:class:`View` type's compile-time extents.
@@ -281,16 +291,18 @@ Header File: ``<Kokkos_Core.hpp>``
       :param layout: an instance of a layout class.
          The number of valid extents must either match the dynamic rank or the total rank. In the latter case, the extents corresponding to compile-time dimensions must match the :cpp:class:`View` type's compile-time extents.
 
-   .. cpp:function:: View( const ScratchSpace& space, const IntType& ... extents)
+   .. cpp:function:: template<class IntType> View( const ScratchSpace& space, const IntType& ... extents)
 
       Constructor which acquires memory from a Scratch Memory handle.
+
+      :tparam IntType: an integral type
 
       :param space: scratch memory handle.
          Typically returned from :cpp:func:`team_shmem`, :cpp:func:`team_scratch`, or :cpp:func:`thread_scratch` in ``TeamPolicy`` kernels.
 
       :param extents: Extents of the :cpp:class:`View`.
 
-      **Requirements**
+      .. rubric:: Requirements:
 
       - :cpp:expr:`sizeof(IntType...) == rank_dynamic()` or :cpp:expr:`sizeof(IntType...) == rank()`.
          In the latter case, the extents corresponding to compile-time dimensions must match the :cpp:class:`View` type's compile-time extents.
@@ -306,7 +318,7 @@ Header File: ``<Kokkos_Core.hpp>``
       :param layout: an instance of a layout class.
          The number of valid extents must either match the dynamic rank or the total rank. In the latter case, the extents corresponding to compile-time dimensions must match the :cpp:class:`View` type's compile-time extents.
 
-   .. cpp:function:: View( const View<DT, Prop...>& rhs, Args ... args)
+   .. cpp:function:: template<class DT, class... Prop> View( const View<DT, Prop...>& rhs, Args ... args)
 
       :param rhs: the :cpp:class:`View` to take a subview of
       :param args...: the subview slices as specified in :cpp:func:`subview`
@@ -358,7 +370,9 @@ Header File: ``<Kokkos_Core.hpp>``
 
    .. rubric:: Data Access Functions:
 
-   .. cpp:function:: reference_type operator() (const IntType& ... indices) const
+   .. cpp:function:: template<class IntType> reference_type operator() (const IntType& ... indices) const
+
+      :tparam IntType: an integral type
 
       :param indices: the indices of the element to get a reference to
       :return: a reference to the element at the given indices
@@ -366,13 +380,15 @@ Header File: ``<Kokkos_Core.hpp>``
       Returns a value of :cpp:type:`reference_type` which may or not be referenceable itself.
       The number of index arguments must match the :cpp:func:`rank` of the view.
 
-      **Requirements**
+      .. rubric:: Requirements:
       
       - :cpp:expr:`sizeof(IntType...) == rank_dynamic()`
 
-   .. cpp:function:: reference_type access(const IntType& i0=0, const IntType& i1=0, \
+   .. cpp:function:: template<class IntType> reference_type access(const IntType& i0=0, const IntType& i1=0, \
             const IntType& i2=0, const IntType& i3=0, const IntType& i4=0, \
             const IntType& i5=0, const IntType& i6=0, const IntType& i7=0) const
+
+      :tparam IntType: an integral type
       
       :param i0, i1, i2, i3, i4, i5, i6, i7: the indices of the element to get a reference to
       :return: a reference to the element at the given indices
@@ -420,7 +436,7 @@ Header File: ``<Kokkos_Core.hpp>``
       :param dim: the dimension to get the extent of
       :return: the extent of dimension :cpp:any:`dim`
 
-      **Preconditions**
+      .. rubric:: Preconditions:
 
       - :cpp:any:`dim` must be smaller than :cpp:func:`rank`.
 
@@ -435,7 +451,7 @@ Header File: ``<Kokkos_Core.hpp>``
       It also may eliminate the need for type casts in applications which
       otherwise perform all index operations with :cpp:`int`.
 
-      **Preconditions**
+      .. rubric:: Preconditions:
 
       - :cpp:any:`dim` must be smaller than :cpp:func:`rank`.
 
@@ -447,7 +463,7 @@ Header File: ``<Kokkos_Core.hpp>``
 
       Example: :cpp:expr:`a.stride(3) == (&a(i0,i1,i2,i3+1,i4)-&a(i0,i1,i2,i3,i4))`
 
-      **Preconditions**
+      .. rubric:: Preconditions:
 
       - :cpp:any:`dim` must be smaller than :cpp:func:`rank`.
 
@@ -491,7 +507,7 @@ Header File: ``<Kokkos_Core.hpp>``
       Sets :cpp:expr:`strides[r]` to :cpp:expr:`stride(r)` for all :math:`r` with :math:`0 \le r \lt \texttt{rank()}`.
       Sets :cpp:expr:`strides[rank()]` to :cpp:func:`span()`.
 
-      **Preconditions**
+      .. rubric:: Preconditions:
 
       - :cpp:any:`strides` must be an array of length :cpp:expr:`rank() + 1`
 
@@ -526,8 +542,8 @@ Header File: ``<Kokkos_Core.hpp>``
       
       :param N0, N1, N2, N3, N4, N5, N6, N7, N8: the dimensions to query
       :return: the number of bytes necessary for an unmanaged :cpp:class:`View` of the provided dimensions.
-      
-      **Requirements**
+
+      .. rubric:: Requirements:
       
       - :cpp:expr:`array_layout::is_regular == true`.
 
@@ -545,12 +561,6 @@ Header File: ``<Kokkos_Core.hpp>``
    .. cpp:function:: const std::string label() const;
 
       :return: the label of the View.
-
-   .. cpp:function:: const bool is_assignable(const View<DT, Prop...>& rhs);
-
-      :return: true if the View can be assigned to rhs.
-
-      .. seealso:: :ref:`api-view-assignment`
 
    .. cpp:function:: void assign_data(pointer_type arg_data);
 
@@ -591,13 +601,19 @@ Header File: ``<Kokkos_Core.hpp>``
 Non-Member Functions
 --------------------
 
-.. cpp:function:: template<class ViewDst, class ViewSrc> bool operator==(ViewDst, ViewSrc);
+.. cpp:function:: template <class... ViewTDst, class... ViewTSrc> bool is_assignable(const View<ViewTDst...>& dst, const View<ViewTSrc...>& src)
+
+   :return: true if src can be assigned to dst.
+
+   .. seealso:: :ref:`api-view-assignment`
+
+.. cpp:function:: template <class LT, class... LP, class RT, class... RP> bool operator==(const View<LT, LP...>& lhs, const View<RT, RP...>& rhs)
 
    :return: :cpp:`true` if :cpp:type:`~View::value_type`, :cpp:type:`~View::array_layout`, :cpp:type:`~View::memory_space`, :cpp:func:`~View::rank()`, :cpp:func:`~View::data()` and :cpp:expr:`extent(r)`, for :math:`0 \le r \lt \texttt{rank()}`, match.
 
-.. cpp:function:: template<class ViewDst, class ViewSrc> bool operator!=(ViewDst, ViewSrc);
+.. cpp:function:: template <class LT, class... LP, class RT, class... RP> bool operator!=(const View<LT, LP...>& lhs, const View<RT, RP...>& rhs)
 
-   Returns true if any of ``value_type``, ``array_layout``, ``memory_space``, ``rank``, ``data()`` and ``extent(r)``, for ``0<=r<rank`` don't match.
+   :return: :cpp:expr:`!(lhs == rhs)`
 
 .. _api-view-assignment:
 

--- a/docs/source/API/core/view/view.rst
+++ b/docs/source/API/core/view/view.rst
@@ -231,7 +231,7 @@ Header File: ``<Kokkos_Core.hpp>``
          Names are not required to be unique,
 
       :param layout: an instance of a layout class.
-         The number of valid extents must either match the :cpp:func:`dynamic_rank` or :cpp:func:`rank`.
+         The number of valid extents must either match the :cpp:func:`rank_dynamic` or :cpp:func:`rank`.
          In the latter case, the extents corresponding to compile-time dimensions must match the :cpp:class:`View` type's compile-time extents.
 
    .. cpp:function:: template<class IntType> View( const ALLOC_PROP &prop, const IntType& ... extents)
@@ -261,7 +261,7 @@ Header File: ``<Kokkos_Core.hpp>``
       :param prop: An allocation properties object that is returned by :cpp:func:`view_alloc`.
 
       :param layout: an instance of a layout class.
-         The number of valid extents must either match the :cpp:func:`dynamic_rank` or :cpp:func:`rank`.
+         The number of valid extents must either match the :cpp:func:`rank_dynamic` or :cpp:func:`rank`.
          In the latter case, the extents corresponding to compile-time dimensions must match the :cpp:class:`View` type's compile-time extents.
 
    .. cpp:function:: template<class IntType> View( pointer_type ptr, const IntType& ... extents)
@@ -620,9 +620,9 @@ Non-Member Functions
 Assignment Rules
 ----------------
 
-Assignment rules cover the assignment operator as well as copy constructors. We aim at making all logically legal assignments possible,
-while intercepting illegal assignments if possible at compile time, otherwise at runtime.
-In the following we use ``DstType`` and ``SrcType`` as the type of the destination view and source view respectively.
+Assignment rules cover the assignment operator as well as copy constructors.
+We aim at making all logically legal assignments possible, while intercepting illegal assignments if possible at compile time, otherwise at runtime.
+In the following we use ``DstType`` and ``SrcType`` as the type of the destination view and source view respectively. 
 ``dst_view`` and ``src_view`` refer to the runtime instances of the destination and source views, i.e.:
 
 .. code-block:: cpp
@@ -633,26 +633,26 @@ In the following we use ``DstType`` and ``SrcType`` as the type of the destinati
 
 The following conditions must be met at and are evaluated at compile time:
 
-* ``DstType::rank == SrcType::rank``
-* ``DstType::non_const_value_type`` is the same as ``SrcType::non_const_value_type``
-* If ``std::is_const<SrcType::value_type>::value == true`` than ``std::is_const<DstType::value_type>::value == true``.
-* ``MemorySpaceAccess<DstType::memory_space,SrcType::memory_space>::assignable == true``
-* If ``DstType::dynamic_rank != DstType::rank`` and ``SrcType::dynamic_rank != SrcType::rank`` then for each dimension ``k`` which is compile time for both it must be true that ``dst_view.extent(k) == src_view.extent(k)``
+* :cpp:`DstType::rank() == SrcType::rank()`
+* :cpp:`DstType::non_const_value_type` is the same as :cpp:`SrcType::non_const_value_type`
+* If :cpp:`std::is_const_v<SrcType::value_type> == true` then :cpp:`std::is_const_v<DstType::value_type>` must also be :cpp:`true`.
+* :cpp:`MemorySpaceAccess<DstType::memory_space,SrcType::memory_space>::assignable == true`
+* If :cpp:`DstType::rank_dynamic() != DstType::rank()` and :cpp:`SrcType::rank_dynamic() != SrcType::rank()` then for each dimension :cpp:`k` that is compile time for both it must be true that :cpp:`dst_view.extent(k) == src_view.extent(k)`
 
 Additionally the following conditions must be met at runtime:
 
-* If ``DstType::dynamic_rank != DstType::rank`` then for each compile time dimension ``k`` it must be true that ``dst_view.extent(k) == src_view.extent(k)``.
+* If :cpp:`DstType::rank_dynamic() != DstType::rank()` then for each compile time dimension :cpp:`k` it must be true that :cpp:`dst_view.extent(k) == src_view.extent(k)`.
 
-Furthermore there are rules which must be met if ``DstType::array_layout`` is not the same as ``SrcType::array_layout``.
-These rules only cover cases where both layouts are one of ``LayoutLeft``, ``LayoutRight`` or ``LayoutStride``
+Furthermore there are rules which must be met if :cpp:`DstType::array_layout` is not the same as :cpp:`SrcType::array_layout`.
+These rules only cover cases where both layouts are one of :cpp:class:`LayoutLeft`, :cpp:class:`LayoutRight` or :cpp:class:`LayoutStride`
 
-* If neither ``DstType::array_layout`` nor ``SrcType::array_layout`` is ``LayoutStride``:
+* If neither :cpp:`DstType::array_layout` nor :cpp:`SrcType::array_layout` is :cpp:class:`LayoutStride`:
 
-  - If ``DstType::rank > 1`` then ``DstType::array_layout`` must be the same as ``SrcType::array_layout``.
+  - If :cpp:`DstType::rank > 1` then :cpp:`DstType::array_layout` must be the same as :cpp:`SrcType::array_layout`.
 
-* If either ``DstType::array_layout`` or ``SrcType::array_layout`` is ``LayoutStride``
+* If either :cpp:`DstType::array_layout` or :cpp:`SrcType::array_layout` is :cpp:class:`LayoutStride`
 
-  - For each dimension ``k`` it must hold that ``dst_view.extent(k) == src_view.extent(k)``
+  - For each dimension :cpp:`k` it must hold that :cpp:`dst_view.extent(k) == src_view.extent(k)`
 
 .. code-block:: cpp
    :caption: Assignment Examples

--- a/docs/source/templates/class_api.rst
+++ b/docs/source/templates/class_api.rst
@@ -141,7 +141,7 @@ Non-Member Functions
 
   :tparam ViewDst: the other
 
-  :return: true if :cpp:type:`View::value_type`, :cpp:type:`View::array_layout`, :cpp:type:`View::memory_space`, :cpp:member:`View::func`, :cpp:func:`View::data()` and :cpp:expr:`View::extent(r)`, for :cpp:expr:`0<=r<rank`, match.
+  :return: true if :cpp:type:`View::value_type`, :cpp:type:`View::array_layout`, :cpp:type:`View::memory_space`, :cpp:func:`View::rank`, :cpp:func:`View::data()` and :cpp:expr:`View::extent(r)`, for :cpp:expr:`0<=r<rank`, match.
 
 .. cpp:function:: void frobrnicator(CoolerView &v) noexcept
 

--- a/docs/source/templates/class_api.rst
+++ b/docs/source/templates/class_api.rst
@@ -49,24 +49,20 @@ Interface
     Template parameters (if applicable)
     Omit template parameters that are just used for specialization/are deduced/ and/or should not be exposed to the user.
 
-  .. rubric:: Template Parameters
-
   :tparam Foo: Description of the Foo template parameter
 
   ..
     Parameters (if applicable)
 
-  .. rubric:: Parameters
-
   :param bar: Description of the bar parameter
 
-  .. rubric:: Public Types
+  .. rubric:: Public Types:
 
   .. cpp:type:: data_type
 
     Some interesting description of the type and how to use it.
 
-  .. rubric:: Static Public Member Variables
+  .. rubric:: Static Public Member Variables:
 
   .. cpp:member:: int some_var = 5;
 
@@ -82,7 +78,7 @@ Interface
 
       The :cpp:func:`frobrnicator` free function.
 
-  .. rubric:: Constructors
+  .. rubric:: Constructors:
 
   .. cpp:function:: CoolerView(CoolerView&& rhs)
 
@@ -92,13 +88,13 @@ Interface
     Only include the destructor if it does something interesting as part of the API, such as RAII classes that release a resource on their destructor. Classes that merely
     clean up or destroy their members don't need this member documented.
 
-  .. rubric:: Destructor
+  .. rubric:: Destructor:
 
   .. cpp:function:: ~CoolerView()
 
     Performs some special operation when destroyed.
 
-  .. rubric:: Public Member Functions
+  .. rubric:: Public Member Functions:
 
   .. cpp:function:: template<class U> foo(U x)
 
@@ -145,7 +141,7 @@ Non-Member Functions
 
   :tparam ViewDst: the other
 
-  :return: true if :cpp:type:`View::value_type`, :cpp:type:`View::array_layout`, :cpp:type:`View::memory_space`, :cpp:member:`View::rank`, :cpp:func:`View::data()` and :cpp:expr:`View::extent(r)`, for :cpp:expr:`0<=r<rank`, match.
+  :return: true if :cpp:type:`View::value_type`, :cpp:type:`View::array_layout`, :cpp:type:`View::memory_space`, :cpp:member:`View::func`, :cpp:func:`View::data()` and :cpp:expr:`View::extent(r)`, for :cpp:expr:`0<=r<rank`, match.
 
 .. cpp:function:: void frobrnicator(CoolerView &v) noexcept
 


### PR DESCRIPTION
This fixes a few issues and makes View a cross-referenceable entity. Also it brings everything in line stylistically with how we want to write documentation (i.e. use of cross-references and sphinx entities)