### PR TITLE
DualView: Be more explicit about synchronization behavior for resize

### DIFF
--- a/docs/source/API/containers/DualView.rst
+++ b/docs/source/API/containers/DualView.rst
@@ -251,7 +251,7 @@ Description
     .. cppkokkos:function:: void resize(const size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG, const size_t n1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG, const size_t n2 = KOKKOS_IMPL_CTOR_DEFAULT_ARG, const size_t n3 = KOKKOS_IMPL_CTOR_DEFAULT_ARG, const size_t n4 = KOKKOS_IMPL_CTOR_DEFAULT_ARG, const size_t n5 = KOKKOS_IMPL_CTOR_DEFAULT_ARG, const size_t n6 = KOKKOS_IMPL_CTOR_DEFAULT_ARG, const size_t n7 = KOKKOS_IMPL_CTOR_DEFAULT_ARG);
 
        Resize both views, copying old contents into new if necessary. This method only copies the old
-       contents into the new View objects for the device which was last marked as modified. Thus, users are advised to call ``sync()`` before using the resized object.
+       contents into the new View objects for the device which was last marked as modified. Thus, users are required to call ``sync()`` before using the resized object.
 
     |
 

--- a/docs/source/API/containers/DualView.rst
+++ b/docs/source/API/containers/DualView.rst
@@ -251,7 +251,7 @@ Description
     .. cppkokkos:function:: void resize(const size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG, const size_t n1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG, const size_t n2 = KOKKOS_IMPL_CTOR_DEFAULT_ARG, const size_t n3 = KOKKOS_IMPL_CTOR_DEFAULT_ARG, const size_t n4 = KOKKOS_IMPL_CTOR_DEFAULT_ARG, const size_t n5 = KOKKOS_IMPL_CTOR_DEFAULT_ARG, const size_t n6 = KOKKOS_IMPL_CTOR_DEFAULT_ARG, const size_t n7 = KOKKOS_IMPL_CTOR_DEFAULT_ARG);
 
        Resize both views, copying old contents into new if necessary. This method only copies the old
-       contents into the new View objects for the device which was last marked as modified.
+       contents into the new View objects for the device which was last marked as modified. Thus, users are adviced to call ``sync()`` before using the resized object.
 
     |
 

--- a/docs/source/API/containers/DualView.rst
+++ b/docs/source/API/containers/DualView.rst
@@ -251,7 +251,7 @@ Description
     .. cppkokkos:function:: void resize(const size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG, const size_t n1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG, const size_t n2 = KOKKOS_IMPL_CTOR_DEFAULT_ARG, const size_t n3 = KOKKOS_IMPL_CTOR_DEFAULT_ARG, const size_t n4 = KOKKOS_IMPL_CTOR_DEFAULT_ARG, const size_t n5 = KOKKOS_IMPL_CTOR_DEFAULT_ARG, const size_t n6 = KOKKOS_IMPL_CTOR_DEFAULT_ARG, const size_t n7 = KOKKOS_IMPL_CTOR_DEFAULT_ARG);
 
        Resize both views, copying old contents into new if necessary. This method only copies the old
-       contents into the new View objects for the device which was last marked as modified. Thus, users are adviced to call ``sync()`` before using the resized object.
+       contents into the new View objects for the device which was last marked as modified. Thus, users are advised to call ``sync()`` before using the resized object.
 
     |
 


### PR DESCRIPTION
@JBludau found the current documentation for `DualView::resize` not clear enough in https://github.com/kokkos/kokkos/pull/8011#discussion_r2056021224. Thus, this pull request adds another advice for calling `sync` after `resize`.