### PR TITLE
update sphinx and foro versions

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       docs-directory: /home/runner/work/kokkos-core-wiki/kokkos-core-wiki/docs
     container:
-      image: python:3.10
+      image: python:3.12
     steps:
       - uses: actions/checkout@v4.2.2
       - run: pip install -r build_requirements.txt

--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -1,7 +1,7 @@
-Sphinx==5.0.1
-furo==2022.6.4.1
-myst-parser==0.18.0
-sphinx-copybutton==0.5.0
-sphinx-design==0.5.0
+Sphinx==8.2.3
+furo==2024.8.6
+myst-parser==4.0.1
+sphinx-copybutton==0.5.2
+sphinx-design==0.6.1
 sphinxcontrib-googleanalytics==0.4
 m2r2==0.3.2


### PR DESCRIPTION
This cleans up a few things, and we can do this now that we are not maintaining our own domain :)

* The newer sphinx version fixes a cross referencing bug that I ran into while refactoring the View documentation
* The newer Foro version makes `versionadded` and `versionchanged` directives look nicer
* The newer Foro version makes expressions render not weirdly (i.e. `:cpp:expr:`)