### PR TITLE
Correct a typo in the description of the worktag of an ExecutionPolicy

### DIFF
--- a/docs/source/API/core/Execution-Policies.rst
+++ b/docs/source/API/core/Execution-Policies.rst
@@ -90,7 +90,7 @@ Execution Policies generally accept compile time arguments via template paramete
 
     * * WorkTag
       * ``SomeClass``
-      * Specify the work tag type used to call the functor operator. Can be any arbitrary tag type (.i.e. [empty](https://en.cppreference.com/w/cpp/types/is_empty) struct or class). Defaults to ``void``.
+      * Specify the work tag type used to call the functor operator. Can be any arbitrary tag type (i.e. an [empty](https://en.cppreference.com/w/cpp/types/is_empty) struct or class). Defaults to ``void``.
 
 
 .. toctree::

--- a/docs/source/API/core/Execution-Policies.rst
+++ b/docs/source/API/core/Execution-Policies.rst
@@ -90,7 +90,7 @@ Execution Policies generally accept compile time arguments via template paramete
 
     * * WorkTag
       * ``SomeClass``
-      * Specify the work tag type used to call the functor operator. Any arbitrary type defaults to ``void``.
+      * Specify the work tag type used to call the functor operator. Can be any arbitrary type. Defaults to ``void``.
 
 
 .. toctree::

--- a/docs/source/API/core/Execution-Policies.rst
+++ b/docs/source/API/core/Execution-Policies.rst
@@ -90,7 +90,7 @@ Execution Policies generally accept compile time arguments via template paramete
 
     * * WorkTag
       * ``SomeClass``
-      * Specify the work tag type used to call the functor operator. Can be any arbitrary type. Defaults to ``void``.
+      * Specify the work tag type used to call the functor operator. Can be any arbitrary tag type (.i.e. [empty](https://en.cppreference.com/w/cpp/types/is_empty) struct or class). Defaults to ``void``.
 
 
 .. toctree::


### PR DESCRIPTION
Description of the WorkTag contained a typo that made parsing a sentence ambiguous.