### PR TITLE
Remove parenthesis to `has_shared_sapce` in the UVM transition page

### DIFF
--- a/docs/source/usecases/Moving_from_EnableUVM_to_SharedSpace.rst
+++ b/docs/source/usecases/Moving_from_EnableUVM_to_SharedSpace.rst
@@ -62,7 +62,7 @@ Below is an example of a transition:
    int main (){
      Kokkos::initialize();
      {
-       static_assert(Kokkos::has_shared_space(),"code only works on backends with SharedSpace");
+       static_assert(Kokkos::has_shared_space,"code only works on backends with SharedSpace");
 
        unsigned int N = 100;
        Kokkos::View<int*,Kokkos::SharedSpace> myView("myView",N);


### PR DESCRIPTION
There is no need for the parentheses as `has_shared_space` is a variable, not a function.