### PR TITLE
Add `Unmanaged` to scratch `View` in TeamPolicy example

### DIFF
--- a/docs/source/API/core/execution_spaces.rst
+++ b/docs/source/API/core/execution_spaces.rst
@@ -238,7 +238,7 @@ Additionally, the following type aliases (a.k.a. ``typedef`` s) will be defined 
 
 * ``Ex::array_layout``: the default ``ArrayLayout`` recommended for use with ``View`` types accessed from ``Ex``.
 
-* ``Ex::scratch_memory_space``: the ``ScratchMemorySpace`` that parallel patterns will use for allocation of scratch memory (for instance, as requested by a |KokkosTeamPolicy|_).
+* ``Ex::scratch_memory_space``: the ``ScratchMemorySpace`` that parallel patterns will use for allocation of scratch memory (for instance, as requested by a |KokkosTeamPolicy|_). Only works with unmanaged Views.
 
 Default Constructibility, Copy Constructibility
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -307,7 +307,7 @@ Typedefs
 
 * ``array_layout``: The default ``ArrayLayout`` recommended for use with ``View`` types accessed from |ExecutionSpaceConcept|_.
 
-* ``scratch_memory_space``: The ``ScratchMemorySpace`` that parallel patterns will use for allocation of scratch memory (for instance, as requested by a |KokkosTeamPolicy|_)
+* ``scratch_memory_space``: The ``ScratchMemorySpace`` that parallel patterns will use for allocation of scratch memory (for instance, as requested by a |KokkosTeamPolicy|_). Only works with unmanaged Views.
 
 * ``size_type``: The default integer type associated with this space. Signed or unsigned, 32 or 64 bit integer type, used as preferred type for indexing.
 

--- a/docs/source/API/core/policies/TeamHandleConcept.rst
+++ b/docs/source/API/core/policies/TeamHandleConcept.rst
@@ -168,7 +168,7 @@ Examples
         int scan = team_handle.team_scan(tid+1, &global);
         // scan == tid*(tid+1)/2 on every thread
         // global == ts*(ts-1)/2 on every thread
-        Kokkos::View<int*, policy_type::execution_space::scratch_memory_type>
+        Kokkos::View<int*, policy_type::execution_space::scratch_memory_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>
         a(team_handle.team_scratch(0), 1024);
 
     });


### PR DESCRIPTION
From a discussion with @dalg24 and @dholladay00 on slack.
The `Unmanaged` trait seems to be missing in the view allocation in the example. This PR also adds a hint on the `ScratchMemorySpace` requiring `Unmanaged`