### PR TITLE
About deprecated managed memory trait

### DIFF
--- a/docs/source/API/core/view/memoryTraits.rst
+++ b/docs/source/API/core/view/memoryTraits.rst
@@ -84,7 +84,7 @@ The following type aliases are also available in the ``Kokkos`` namespace.
 .. cpp:type:: MemoryUnmanaged = Kokkos::MemoryTraits<Kokkos::Unmanaged>;
 .. cpp:type:: MemoryRandomAccess = Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>;
 
-Note that managed memory as an explicit memory trait (i.e., ``using MemoryManaged = Kokkos::MemoryTraits<>;``) has been deprecated in Kokkos 4.7. Also, in earlier versions of Kokkos, the alias ``Kokkos::MemoryManaged`` was defined as ``Kokkos::MemoryTraits<0>``. Check the sub-section on |UnmanagedViews|_ for further discussion about this.
+Note that managed memory as an explicit memory trait (i.e., ``using MemoryManaged = Kokkos::MemoryTraits<>;``) has been deprecated in Kokkos 4.7. Also, in earlier versions of Kokkos, the enumeration value of ``0`` had to be explicitly mentioned, i.e., ``Kokkos::MemoryTraits<0>``. Check the sub-section on |UnmanagedViews|_ for further discussion about this.
 
 Note that in order to use a managed View in a random access manner, the memory trait should be specified as ``Kokkos::MemoryTraits<Kokkos::RandomAccess>`` and not ``Kokkos::MemoryRandomAccess``.
 

--- a/docs/source/API/core/view/memoryTraits.rst
+++ b/docs/source/API/core/view/memoryTraits.rst
@@ -84,7 +84,8 @@ The following type aliases are also available in the ``Kokkos`` namespace.
 .. cpp:type:: MemoryUnmanaged = Kokkos::MemoryTraits<Kokkos::Unmanaged>;
 .. cpp:type:: MemoryRandomAccess = Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>;
 
-Note that managed memory as an explicit memory trait (i.e., ``using MemoryManaged = Kokkos::MemoryTraits<>;``) has been deprecated in Kokkos 4.7. Also, in earlier versions of Kokkos, the enumeration value of ``0`` had to be explicitly mentioned, i.e., ``Kokkos::MemoryTraits<0>``. Check the sub-section on |UnmanagedViews|_ for further discussion about this.
+.. deprecated:: 4.7
+  Managed memory as an explicit memory trait (i.e., ``using MemoryManaged = Kokkos::MemoryTraits<>;``) has been deprecated in Kokkos 4.7. Also, in earlier versions of Kokkos, the enumeration value of ``0`` had to be explicitly mentioned, i.e., ``Kokkos::MemoryTraits<0>``. Check the sub-section on |UnmanagedViews|_ for further discussion about this.
 
 Note that in order to use a managed View in a random access manner, the memory trait should be specified as ``Kokkos::MemoryTraits<Kokkos::RandomAccess>`` and not ``Kokkos::MemoryRandomAccess``.
 

--- a/docs/source/API/core/view/memoryTraits.rst
+++ b/docs/source/API/core/view/memoryTraits.rst
@@ -85,7 +85,7 @@ The following type aliases are also available in the ``Kokkos`` namespace.
 .. cpp:type:: MemoryRandomAccess = Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>;
 
 .. deprecated:: 4.7
-  Managed memory as an explicit memory trait (i.e., ``using MemoryManaged = Kokkos::MemoryTraits<>;``) has been deprecated in Kokkos 4.7. Also, in earlier versions of Kokkos, the enumeration value of ``0`` had to be explicitly mentioned, i.e., ``Kokkos::MemoryTraits<0>``. Check the sub-section on |UnmanagedViews|_ for further discussion about this.
+  Managed memory as an explicit memory trait (i.e., ``using MemoryManaged = Kokkos::MemoryTraits<>;``) has been deprecated in Kokkos 4.7. Also, in earlier versions of Kokkos, the enumeration value of ``0`` had to be explicitly mentioned, i.e., ``Kokkos::MemoryTraits<0>``. Check the sub-section on |UnmanagedViews|_ for a discussion about this.
 
 Note that in order to use a managed View in a random access manner, the memory trait should be specified as ``Kokkos::MemoryTraits<Kokkos::RandomAccess>`` and not ``Kokkos::MemoryRandomAccess``.
 

--- a/docs/source/API/core/view/memoryTraits.rst
+++ b/docs/source/API/core/view/memoryTraits.rst
@@ -38,14 +38,18 @@ Struct Interface
 
   A boolean that indicates whether the Aligned trait is enabled.
 
-.. _ProgrammingGuide: ../../../ProgrammingGuide/View.html#memory-access-traits
+.. _MemoryAccessTraits: ../../../ProgrammingGuide/View.html#memory-access-traits
 
-.. |ProgrammingGuide| replace:: Programming Guide
+.. |MemoryAccessTraits| replace:: memory access traits
+
+.. _UnmanagedViews: ../../../ProgrammingGuide/View.html#unmanaged-views
+
+.. |UnmanagedViews| replace:: unmanaged views
 
 Non-Member Enums
 ^^^^^^^^^^^^^^^^
 
-The following enumeration values are used to specify the memory access traits. Check the sub-section on memory access traits in the |ProgrammingGuide|_ for further information about how these traits can be used in practice.
+The following enumeration values are used to specify the memory access traits. Check the sub-section on |MemoryAccessTraits|_ in the Programming Guide for further information about how these traits can be used in practice.
 
 .. cpp:enum:: MemoryTraitsFlags
 
@@ -79,6 +83,8 @@ The following type aliases are also available in the ``Kokkos`` namespace.
 .. cpp:type:: MemoryManaged = Kokkos::MemoryTraits<>;
 .. cpp:type:: MemoryUnmanaged = Kokkos::MemoryTraits<Kokkos::Unmanaged>;
 .. cpp:type:: MemoryRandomAccess = Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>;
+
+Note that managed memory as an explicit memory trait (i.e., ``using MemoryManaged = Kokkos::MemoryTraits<>;``) has been deprecated in Kokkos 4.7. Also, in earlier versions of Kokkos, the alias ``Kokkos::MemoryManaged`` was defined as ``Kokkos::MemoryTraits<0>``. Check the sub-section on |UnmanagedViews|_ for further discussion about this.
 
 Note that in order to use a managed View in a random access manner, the memory trait should be specified as ``Kokkos::MemoryTraits<Kokkos::RandomAccess>`` and not ``Kokkos::MemoryRandomAccess``.
 

--- a/docs/source/ProgrammingGuide/View.rst
+++ b/docs/source/ProgrammingGuide/View.rst
@@ -602,13 +602,13 @@ Another way to get optimized data accesses is to specify memory traits. These tr
 Unmanaged Views
 ~~~~~~~~~~~~~~~
 
-.. _MemoryTraits: ../../../API/core/view/memoryTraits.html
+.. _MemoryTraits: ../API/core/view/memoryTraits.html
 
 .. |MemoryTraits| replace:: memory traits
 
 It's always better to let Kokkos control memory allocation, but sometimes you don't have a choice. You might have to work with an application or an interface that returns a raw pointer, for example. Kokkos lets you wrap raw pointers in an *unmanaged View*. "Unmanaged" means that Kokkos does *neither* reference counting *nor* automatic deallocation for those Views. The following example shows how to create an unmanaged View of host memory. You may do this for CUDA device memory too, or indeed for memory allocated in any memory space, by specifying the View's execution or memory space accordingly. Note that the pointer to the allocation has to be provided to the constructor.
 
-We would like to highlight that in Kokkos, Views are managed by default. Thus, an explicit memory trait that corresponds to managed Views (with an alias called ``Kokkos::Managed``), has been deprecated in Kokkos 4.7. See the API reference on |MemoryTraits|_. 
+We would like to highlight that in Kokkos, Views are managed by default. Thus, an explicit memory trait for managed Views (with an alias called ``Kokkos::MemoryManaged``), has been deprecated in Kokkos 4.7. See the API reference on |MemoryTraits|_. 
 
 .. code-block:: c++
 

--- a/docs/source/ProgrammingGuide/View.rst
+++ b/docs/source/ProgrammingGuide/View.rst
@@ -602,7 +602,13 @@ Another way to get optimized data accesses is to specify memory traits. These tr
 Unmanaged Views
 ~~~~~~~~~~~~~~~
 
-It's always better to let Kokkos control memory allocation, but sometimes you don't have a choice. You might have to work with an application or an interface that returns a raw pointer, for example. Kokkos lets you wrap raw pointers in an *unmanaged View*. "Unmanaged" means that Kokkos does *neither* reference counting *nor* automatic deallocation for those Views. The following example shows how to create an unmanaged View of host memory. You may do this for CUDA device memory too, or indeed for memory allocated in any memory space, by specifying the View's execution or memory space accordingly. Note that the allocation has to be provided to the constructor.
+.. _MemoryTraits: ../../../API/core/view/memoryTraits.html
+
+.. |MemoryTraits| replace:: memory traits
+
+It's always better to let Kokkos control memory allocation, but sometimes you don't have a choice. You might have to work with an application or an interface that returns a raw pointer, for example. Kokkos lets you wrap raw pointers in an *unmanaged View*. "Unmanaged" means that Kokkos does *neither* reference counting *nor* automatic deallocation for those Views. The following example shows how to create an unmanaged View of host memory. You may do this for CUDA device memory too, or indeed for memory allocated in any memory space, by specifying the View's execution or memory space accordingly. Note that the pointer to the allocation has to be provided to the constructor.
+
+We would like to highlight that in Kokkos, Views are managed by default. Thus, an explicit memory trait that corresponds to managed Views (with an alias called ``Kokkos::Managed``), has been deprecated in Kokkos 4.7. See the API reference on |MemoryTraits|_. 
 
 .. code-block:: c++
 

--- a/docs/source/ProgrammingGuide/View.rst
+++ b/docs/source/ProgrammingGuide/View.rst
@@ -608,7 +608,7 @@ Unmanaged Views
 
 It's always better to let Kokkos control memory allocation, but sometimes you don't have a choice. You might have to work with an application or an interface that returns a raw pointer, for example. Kokkos lets you wrap raw pointers in an *unmanaged View*. "Unmanaged" means that Kokkos does *neither* reference counting *nor* automatic deallocation for those Views. The following example shows how to create an unmanaged View of host memory. You may do this for CUDA device memory too, or indeed for memory allocated in any memory space, by specifying the View's execution or memory space accordingly. Note that the pointer to the allocation has to be provided to the constructor.
 
-We would like to highlight that in Kokkos, Views are managed by default. In other words, if a View is not explicitly specified as unmanaged, then it is managed, irrespective of other memory traits. Thus, an explicit memory trait for managed Views (with an alias called ``Kokkos::MemoryManaged``), has been deprecated in Kokkos 4.7. Since, it has no practical value. See the API reference on |MemoryTraits|_. 
+We would like to highlight that in Kokkos, Views are managed by default. In other words, if a View is not created as an unmanaged View, then it is managed, irrespective of other memory traits. Thus, an explicit memory trait for managed Views (with an alias called ``Kokkos::MemoryManaged``), has been deprecated in Kokkos 4.7. Since, it has no practical value. See the API reference on |MemoryTraits|_. 
 
 .. code-block:: c++
 

--- a/docs/source/ProgrammingGuide/View.rst
+++ b/docs/source/ProgrammingGuide/View.rst
@@ -608,7 +608,7 @@ Unmanaged Views
 
 It's always better to let Kokkos control memory allocation, but sometimes you don't have a choice. You might have to work with an application or an interface that returns a raw pointer, for example. Kokkos lets you wrap raw pointers in an *unmanaged View*. "Unmanaged" means that Kokkos does *neither* reference counting *nor* automatic deallocation for those Views. The following example shows how to create an unmanaged View of host memory. You may do this for CUDA device memory too, or indeed for memory allocated in any memory space, by specifying the View's execution or memory space accordingly. Note that the pointer to the allocation has to be provided to the constructor.
 
-We would like to highlight that in Kokkos, Views are managed by default. Thus, an explicit memory trait for managed Views (with an alias called ``Kokkos::MemoryManaged``), has been deprecated in Kokkos 4.7. See the API reference on |MemoryTraits|_. 
+We would like to highlight that in Kokkos, Views are managed by default. In other words, if a View is not explicitly specified as unmanaged, then it is managed, irrespective of other memory traits. Thus, an explicit memory trait for managed Views (with an alias called ``Kokkos::MemoryManaged``), has been deprecated in Kokkos 4.7. Since, it has no practical value. See the API reference on |MemoryTraits|_. 
 
 .. code-block:: c++
 


### PR DESCRIPTION
Fixes issue [682](https://github.com/kokkos/kokkos-core-wiki/issues/682).

The goal is to document the deprecated managed memory trait.