### PR TITLE
Remove unnecessary overload in custom reducer

### DIFF
--- a/docs/source/ProgrammingGuide/Custom-Reductions-Custom-Reducers.md
+++ b/docs/source/ProgrammingGuide/Custom-Reductions-Custom-Reducers.md
@@ -54,13 +54,6 @@ struct array_type {
     }
     return *this;
   }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator+=(const array_type& src) {
-    for (int i = 0; i < N; i++) {
-      myArray[i] += src.myArray[i];
-    }
-  }
 };
 
 template <class T, class Space, int N>


### PR DESCRIPTION
This fixes a minor typo kind of error, where two `operator+=` overloads have been defined in the example code for the custom reducer.

The overload returning a reference to the object has been retained. Even though chaining `operator+=` is a less likely scenario, [other use cases](https://stackoverflow.com/questions/36232136/return-type-of-operator-while-overloading) like implementing `operator+` using `operator+=` and writing to an output stream are worth addressing.