### PR TITLE
Fix deprecated atomic increment use in documentation

### DIFF
--- a/docs/source/API/core/atomics/atomic_assign.rst
+++ b/docs/source/API/core/atomics/atomic_assign.rst
@@ -3,7 +3,7 @@
 
 .. warning::
    Deprecated since Kokkos 4.5,
-   use `atomic_store <atomic_store.html>`_ instead.
+   use :cpp:func:`atomic_store` instead.
 
 .. role:: cpp(code)
     :language: cpp
@@ -16,9 +16,6 @@ Usage
 .. code-block:: cpp
 
     atomic_assign(&obj, desired);
-    //     ^^^^^^
-    // deprecated since Kokkos 4.5,
-    // use atomic_store(&obj, desired) instead
 
 Atomically replaces the current value of ``obj`` with ``desired``.
 
@@ -34,3 +31,6 @@ Description
    :param ptr: address of the object whose value is to be replaced
    :param val: the value to store in the referenced object
    :returns: (nothing)
+
+   .. deprecated:: 4.5
+      Use :cpp:func:`atomic_store` instead.

--- a/docs/source/API/core/atomics/atomic_compare_exchange_strong.rst
+++ b/docs/source/API/core/atomics/atomic_compare_exchange_strong.rst
@@ -16,10 +16,6 @@ Usage
 .. code-block:: cpp
 
    bool was_exchanged = atomic_compare_exchange_strong(&obj, expected, desired);
-   //                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   //                   deprecated since Kokkos 4.5
-   //                   instead prefer
-   //                   expected == atomic_compare_exchange(&obj, expected, desired)
 
 Atomically compares the current value of ``obj`` with ``expected``
 and replaces its value with ``desired`` if equal.
@@ -39,3 +35,6 @@ Description
    :param expected: value expected to be found in the object
    :param desired: the value to store in the object if as expected
    :returns: the result of the comparison, ``true`` if ``*ptr`` was equal to ``expected``, ``false`` otherwise
+
+   .. deprecated:: 4.5
+      Prefer :cpp:expr:`expected == atomic_compare_exchange(&obj, expected, desired)`

--- a/docs/source/API/core/atomics/atomic_op.rst
+++ b/docs/source/API/core/atomics/atomic_op.rst
@@ -34,9 +34,24 @@ Description
 
    * ``value``: value with which to combine the original value.
 
+.. cpp:function:: template<class T> void atomic_dec(T* ptr_to_value);
+
+   Atomically executes ``(*ptr_to_value)--`` or calls ``atomic_fetch_sub(ptr_to_value, T(-1))``.
+
+   * ``ptr_to_value``: address of the to be updated value.
+
 .. cpp:function:: template<class T> void atomic_decrement(T* const ptr_to_value);
 
    Atomically executes ``(*ptr_to_value)--`` or calls ``atomic_fetch_sub(ptr_to_value, T(-1))``.
+
+   * ``ptr_to_value``: address of the to be updated value.
+
+   .. deprecated:: 4.5
+      Use :cpp:func:`atomic_dec` instead.
+
+.. cpp:function:: template<class T> void atomic_inc(T* ptr_to_value);
+
+   Atomically executes ``(*ptr_to_value)++`` or calls ``atomic_fetch_add(ptr_to_value, T(1))``.
 
    * ``ptr_to_value``: address of the to be updated value.
 
@@ -45,6 +60,9 @@ Description
    Atomically executes ``(*ptr_to_value)++`` or calls ``atomic_fetch_add(ptr_to_value, T(1))``.
 
    * ``ptr_to_value``: address of the to be updated value.
+
+   .. deprecated:: 4.5
+      Use :cpp:func:`atomic_inc` instead.
 
 .. cpp:function:: template<class T> void atomic_max(T* const ptr_to_value, const T value);
 

--- a/docs/source/ProgrammingGuide/Atomic-Operations.md
+++ b/docs/source/ProgrammingGuide/Atomic-Operations.md
@@ -9,7 +9,7 @@ After reading this chapter, you should understand the following:
 
 ## Write Conflicts and Their Resolution With Atomic Operations
 
-Consider the simple task of creating a histogram of a number set. 
+Consider the simple task of creating a histogram of a number set.
 
 ```c++
 void create_histogram(View<int*> histogram, int min, int max, View<int*> values) {
@@ -21,22 +21,22 @@ void create_histogram(View<int*> histogram, int min, int max, View<int*> values)
 }
 ```
 
-When parallelizing this loop with a simple [`parallel_for()`](../API/core/parallel-dispatch/parallel_for) multiple threads may try to 
+When parallelizing this loop with a simple [`parallel_for()`](../API/core/parallel-dispatch/parallel_for) multiple threads may try to
 increment the same `index` at the same time. The increment on the other hand is actually
-three operations: 
+three operations:
   1. load `histogram(index)` into a register,
   2. increment the registers,
   3. store the register back to `&histogram(index)`
 
-When two threads try to do this to the same index at the same time, it can happen that both 
-threads load the value, then increment and then store. Since both loaded the same original 
+When two threads try to do this to the same index at the same time, it can happen that both
+threads load the value, then increment and then store. Since both loaded the same original
 value only one of the updates makes it through, while the second increment gets lost. This
-is called a *race condition*. 
+is called a *race condition*.
 
-Another typical situation for this situation are so called *scatter-add* algorithms. 
+Another typical situation for this situation are so called *scatter-add* algorithms.
 For example in particle codes one often loops over all particles, and then for each particle
 contribute something to each of its neighbours (such as a partial force). If two threads simultaneously
-work on two particles with shared neighbours, they may race on contributing to the same neighbour particle. 
+work on two particles with shared neighbours, they may race on contributing to the same neighbour particle.
 
 ```c++
 void compute_force(View<int**> neighbours, View<double*> values) {
@@ -52,11 +52,11 @@ void compute_force(View<int**> neighbours, View<double*> values) {
 
 There are a number of approaches to resolve such situations: One can (i) apply colouring and run the algorithm multiple times in a way that no conflicts appear with the subset of each colour, (ii) replicate the output array for every thread, or (iii) use atomic operations. All of these come with disadvantages.
 
-Colouring has the disadvantages that one has to create the sets. For the histogram example, the cost of creating the set is likely larger than the operation itself. Furthermore, since one has to run each colour separately, the total amount of memory transfer can be significantly larger, since you tend to loop through all the allocations multiple times while using only parts of each cache line. 
+Colouring has the disadvantages that one has to create the sets. For the histogram example, the cost of creating the set is likely larger than the operation itself. Furthermore, since one has to run each colour separately, the total amount of memory transfer can be significantly larger, since you tend to loop through all the allocations multiple times while using only parts of each cache line.
 
-Replicating the output array is a good strategy for low thread counts (2-8) but often tends to fall apart above that. 
+Replicating the output array is a good strategy for low thread counts (2-8) but often tends to fall apart above that.
 
-Atomic operations execute a whole logical operation uninterrupted. For example the load-modify-store cycle of the above examples will be executed with no other threads being able to access the modified library (via another atomic operation) until the atomic operation is finished. Note that non-atomic operations may still race with atomic operations. The disadvantage of atomic operation is that they hinder certain compiler optimizations, and the throughput of atomics may not be good depending on the architecture and the scalar type. 
+Atomic operations execute a whole logical operation uninterrupted. For example the load-modify-store cycle of the above examples will be executed with no other threads being able to access the modified library (via another atomic operation) until the atomic operation is finished. Note that non-atomic operations may still race with atomic operations. The disadvantage of atomic operation is that they hinder certain compiler optimizations, and the throughput of atomics may not be good depending on the architecture and the scalar type.
 
 ## Atomic Free Functions
 
@@ -67,7 +67,7 @@ void create_histogram(View<int*> histogram, int min, int max, View<int*> values)
   deep_copy(histogram,0);
   parallel_for("CreateHistogram", values.extent(0), KOKKOS_LAMBDA(const int i) {
     int index = (1.0*(values(i)-min)/(max-min)) * histogram.extent(0);
-    atomic_increment(&histogram(index));
+    atomic_inc(&histogram(index));
   });
 }
 ```
@@ -100,18 +100,17 @@ The full list of atomic operations can be found here:
 | Name                                                                                  | Library                   | Category | Description                  |
 |:--------------------------------------------------------------------------------------|:--------------------------|:-----------|:----------------------------|
 | [atomic_compare_exchange](../API/core/atomics/atomic_compare_exchange)                | [Core](../API/core-index) | [Atomic-Operations](Atomic-Operations) | Atomic operation which exchanges a value only if the old value matches a comparison value and returns the old value. |
-| [atomic_compare_exchange_strong](../API/core/atomics/atomic_compare_exchange_strong)  | [Core](../API/core-index) | [Atomic-Operations](Atomic-Operations) | Atomic operation which exchanges a value only if the old value matches a comparison value and returns true if the exchange is executed. |
 | [atomic_exchange](../API/core/atomics/atomic_exchange)                                | [Core](../API/core-index) | [Atomic-Operations](Atomic-Operations) | Atomic operation which exchanges a value and returns the old. |
 | [atomic_fetch_\[op\]](../API/core/atomics/atomic_fetch_op)                            | [Core](../API/core-index) | [Atomic-Operations](Atomic-Operations) | Various atomic operations which return the old value. [op] might be `add`, `and`, `div`, `lshift`, `max`, `min`, `mod`, `mul`, `or`, `rshift`, `sub` or `xor` |
 | [atomic_load](../API/core/atomics/atomic_load)                                        | [Core](../API/core-index) | [Atomic-Operations](Atomic-Operations) | Atomic operation which loads a value. |
-| [atomic_\[op\]](../API/core/atomics/atomic_op)                                        | [Core](../API/core-index) | [Atomic-Operations](Atomic-Operations) | Atomic operation which don't return anything. [op] might be `and`, `add`, `assign`, `decrement`, `max`, `min`, `increment`, `or` or `sub` |
+| [atomic_\[op\]](../API/core/atomics/atomic_op)                                        | [Core](../API/core-index) | [Atomic-Operations](Atomic-Operations) | Atomic operation which don't return anything. [op] might be `and`, `add`, `dec`, `max`, `min`, `inc`, `or` or `sub` |
 | [atomic_\[op\]_fetch](../API/core/atomics/atomic_op_fetch)                            | [Core](../API/core-index) | [Atomic-Operations](Atomic-Operations) | Various atomic operations which return the updated value. [op] might be `add`, `and`, `div`, `lshift`, `max`, `min`, `mod`, `mul`, `or`, `rshift`, `sub` or `xor` |
 | [atomic_store](../API/core/atomics/atomic_store)                                      | [Core](../API/core-index) | [Atomic-Operations](Atomic-Operations) | Atomic operation which stores a value. |
 
 ## Atomic Memory Trait
 
 If all operations on a specific `View` during a Kernel are atomic one can also use the atomic memory trait.
-Generally one creates an *atomic* `View` from a *non-atomic* `View` just for the one kernel, and then uses normal 
+Generally one creates an *atomic* `View` from a *non-atomic* `View` just for the one kernel, and then uses normal
 operations on it.
 
 ```c++
@@ -127,9 +126,9 @@ void create_histogram(View<int*> histogram, int min, int max, View<int*> values)
 
 ## ScatterView
 
-On CPUs one often uses low thread counts, in particular if Kokkos is used in conjunction with MPI. 
-In such situations data replication often performs better than using atomic operations. 
+On CPUs one often uses low thread counts, in particular if Kokkos is used in conjunction with MPI.
+In such situations data replication often performs better than using atomic operations.
 In order to still have portable code, one can use the [`ScatterView`](../API/containers/ScatterView). It allows the transparent switch at
-compile time from using atomic operations to using data replication depending on the underlying hardware. 
+compile time from using atomic operations to using data replication depending on the underlying hardware.
 
 A full description can be found here: [ScatterView](../API/containers/ScatterView)

--- a/docs/source/deprecations.rst
+++ b/docs/source/deprecations.rst
@@ -18,7 +18,7 @@ Deprecated in Kokkos 4.6
 
 * Makefile support
    * replacement: CMake
-   * reducing maintenance burden for a little-used build system 
+   * reducing maintenance burden for a little-used build system
 
 * Direct access to ``d_view`` and ``h_view`` members in ``DualView``
    * replacement: ``view_host()`` and ``view_device()``
@@ -43,20 +43,20 @@ Deprecated in Kokkos 4.5
    * replacement: none
    * no known use case
 
-* ``atomic_assign``
-   * replacement: ``atomic_store``
+* :cpp:func:`atomic_assign`
+   * replacement: :cpp:func:`atomic_store`
    * duplicated functionality
 
-* ``atomic_increment``
-   * replacement: ``atomic_inc``
+* :cpp:func:`atomic_increment`
+   * replacement: :cpp:func:`atomic_inc`
    * duplicated functionality
 
-* ``atomic_decremnent``
-   * replacement: ``atomic_dec``
+* :cpp:func:`atomic_decrement`
+   * replacement: :cpp:func:`atomic_dec`
    * duplicated functionality
 
-* ``atomic_compare_exchange_strong``
-   * replacement: ``atomic_compare_exchange``
+* :cpp:func:`atomic_compare_exchange_strong`
+   * replacement: :cpp:func:`atomic_compare_exchange`
    * duplicated functionality
 
 Deprecated in Kokkos 4.4
@@ -128,7 +128,7 @@ Deprecated in Kokkos 4.3
 
 * ``RangePolicy::set(ChunkSize chunksize)``
    * replacement: ``RangePolicy::set_chunk_size(int chunk_size)``
-   * ``ChunkSize`` was the only extra parameter usable with ``RangePolicy::set()`` 
+   * ``ChunkSize`` was the only extra parameter usable with ``RangePolicy::set()``
 
 * ``InitializationSettings::set_num_devices``, ``InitializationSettings::has_num_devices``, ``InitializationSettings::get_num_devices``
    * replacement: ``num_devices``
@@ -145,14 +145,14 @@ Deprecated in Kokkos 4.2
 * ``Cuda::Cuda(cudaStream_t stream, bool manage_stream)``
    * replacement: ``Cuda::Cuda(cudaStream_t stream)``
    * constructing a Cuda execution space instance should always use an externally managed ``cudaStream`` object
-   
+
 * ``HIP::HIP(hipStream_t stream, bool manage_stream)``
     * replacement ``HIP::HIP(hipStream_t stream)``
     * constructing a HIP execution space instance should always use an externally managed ``hipStream`` object
-    
+
 * ``vector``
     * replacement: none
-    * non-standard behavior, doesn't work well with Kokkos concepts 
+    * non-standard behavior, doesn't work well with Kokkos concepts
 
 * ``HostSpace::HostSpace(AllocationMechanism)``
     * replacement: ``HostSpace::HostSpace()``
@@ -160,7 +160,7 @@ Deprecated in Kokkos 4.2
 
 * SIMD math functions in the ``Kokkos::Experimental`` namespace
     * replacement: SIMD math function in the ``Kokkos`` namespace
-    * issues with ADL, consistency with other math function overloads 
+    * issues with ADL, consistency with other math function overloads
 
 
 Deprecated in Kokkos 4.1
@@ -218,14 +218,14 @@ Macros deprecated in Kokkos-3.7
 Free-functions deprecated in Kokkos-3.7
 ---------------------------------------
 
-.. list-table::  
+.. list-table::
    :widths: 30 70
    :header-rows: 1
 
-   * - Name 
+   * - Name
      - Where
 
-   * - .. code-block:: cpp 
+   * - .. code-block:: cpp
 
           std::vector<OpenMP> OpenMP::partition(...)
 
@@ -267,7 +267,7 @@ Free-functions deprecated in Kokkos-3.7
 Member functions deprecated in Kokkos-3.7
 ------------------------------------------
 
-.. list-table::  
+.. list-table::
    :widths: 70 30
    :header-rows: 1
 
@@ -301,18 +301,18 @@ Member functions deprecated in Kokkos-3.7
    * - ``static int CudaUVMSpace::number_of_allocations();``
      - ``class CudaUVMSpace`` (Kokkos_CudaSpace.hpp)
 
-   * - ``HPX::partition(...), HPX::partition_master()`` 
+   * - ``HPX::partition(...), HPX::partition_master()``
      - ``class HPX`` (Kokkos_HPX.hpp)
 
 
 Classes deprecated in Kokkos-3.7
 --------------------------------
 
-.. list-table::  
+.. list-table::
    :widths: auto
    :header-rows: 1
 
-   * - 
+   * -
 
    * - ``class MasterLock<OpenMP>``
 
@@ -322,13 +322,13 @@ Classes deprecated in Kokkos-3.7
 Namespace updates
 ----------------------
 
-.. list-table::  
+.. list-table::
    :widths: 40 60
    :header-rows: 1
 
    * - Previous
      - You should now use
- 
+
    * - ``Kokkos::Experimental::aMathFunction``
      - ``Kokkos::aMathFunction``
 
@@ -348,7 +348,7 @@ Namespace updates
 Other deprecations
 ------------------
 
-.. list-table::  
+.. list-table::
    :widths: auto
    :header-rows: 1
 
@@ -399,7 +399,7 @@ Other deprecations
      - ``Kokkos::parallel_*("KokkosViewLabel", policy, f);``
 
 
-Public Headers in Kokkos-3.7 
+Public Headers in Kokkos-3.7
 ----------------------------
 
 From Kokkos-3.7, the following are *public* headers:
@@ -414,4 +414,4 @@ Algorithms
 
 Containers
 ~~~~~~~~~~~~~~~~~~
-``Kokkos_Bit.hpp``, ``Kokkos_DualView.hpp``, ``Kokkos_DynRankView.hpp``, ``Kokkos_ErrorReporter.hpp``, ``Kokkos_Functional.hpp``, ``Kokkos_OffsetView.hpp``, ``Kokkos_ScatterView.hpp``, ``Kokkos_StaticCrsGraph.hpp``, ``Kokkos_UnorderedMap.hpp``, ``Kokkos_Vector.hpp``   
+``Kokkos_Bit.hpp``, ``Kokkos_DualView.hpp``, ``Kokkos_DynRankView.hpp``, ``Kokkos_ErrorReporter.hpp``, ``Kokkos_Functional.hpp``, ``Kokkos_OffsetView.hpp``, ``Kokkos_ScatterView.hpp``, ``Kokkos_StaticCrsGraph.hpp``, ``Kokkos_UnorderedMap.hpp``, ``Kokkos_Vector.hpp``

--- a/docs/source/deprecations.rst
+++ b/docs/source/deprecations.rst
@@ -48,7 +48,7 @@ Deprecated in Kokkos 4.5
    * duplicated functionality
 
 * ``atomic_increment``
-   * replacement: ``atoimc_inc``
+   * replacement: ``atomic_inc``
    * duplicated functionality
 
 * ``atomic_decremnent``


### PR DESCRIPTION
This also adds various other annotation fixups to the atomic operations that were deprecated in 4.5