### PR TITLE
old_value -> new_value in atomic_op_fetch

### DIFF
--- a/docs/source/API/core/atomics/atomic_op_fetch.rst
+++ b/docs/source/API/core/atomics/atomic_op_fetch.rst
@@ -11,7 +11,7 @@ Usage
 
 .. code-block:: cpp
 
-    old_value =  atomic_[op]_fetch(ptr_to_value,update_value);
+    new_value =  atomic_[op]_fetch(ptr_to_value,update_value);
 
 Atomically updates the variable at the address given by ``ptr_to_value`` with ``update_value`` according to the relevant operation, and returns the updated value found at that address.
 


### PR DESCRIPTION
Compared to `atomic_fetch_op` where we use `old_value`. 
