### PR TITLE
Add hyper refs to is_initialized and is_finalized

### DIFF
--- a/docs/source/API/core/initialize_finalize/ScopeGuard.rst
+++ b/docs/source/API/core/initialize_finalize/ScopeGuard.rst
@@ -23,7 +23,7 @@ constructor and `Kokkos::finalize <finalize.html#kokkosfinalize>`_ in the destru
 For correct usage, it is mandatory to create a named instance of a ``ScopeGuard`` before any calls to Kokkos are issued.
 
 
-.. warning:: Change of behavior in version 3.7 (see below). ``ScopeGuard`` will abort if either ``is_initialized()`` or ``is_finalized()`` return ``true``.
+.. warning:: Change of behavior in version 3.7 (see below). ``ScopeGuard`` will abort if either :cpp:func:`is_initialized()` or :cpp:func:`is_finalized()` return ``true``.
 
 Description
 -----------

--- a/docs/source/API/core/initialize_finalize/finalize.rst
+++ b/docs/source/API/core/initialize_finalize/finalize.rst
@@ -19,7 +19,8 @@ This functions cleans up all Kokkos states and released the associated
 resources.
 Once this function is called, no Kokkos API functions (not even
 `Kokkos::initialize <initialize.html>`_) may be called, except for
-``Kokkos::is_initialized`` or ``Kokkos::is_finalized``.
+:cpp:func:`Kokkos::is_initialized() <is_initialized()>` or
+:cpp:func:`Kokkos::is_finalized() <is_finalized()>`.
 The user must ensure that all Kokkos objects (e.g. ``Kokkos::View``) are destroyed
 before ``Kokkos::finalize`` gets called.
 
@@ -40,7 +41,7 @@ Requirements
 Semantics
 ~~~~~~~~~
 
-* ``Kokkos::is_initialized()`` should return false after calling ``Kokkos::finalize``
+* :cpp:func:`Kokkos::is_initialized() <is_initialized()>` should return false after calling ``Kokkos::finalize``
 
 Example
 ~~~~~~~

--- a/docs/source/API/core/initialize_finalize/initialize.rst
+++ b/docs/source/API/core/initialize_finalize/initialize.rst
@@ -19,7 +19,8 @@ Usage:
 Initializes the Kokkos execution environment.
 This function must be called before any other Kokkos API functions or
 constructors.  There are a small number of exceptions, such as
-``Kokkos::is_initialized`` and ``Kokkos::is_finalized``.
+:cpp:func:`Kokkos::is_initialized() <is_initialized()>` or
+:cpp:func:`Kokkos::is_finalized() <is_finalized()>`.
 Kokkos can be initialized at most once; subsequent calls are erroneous.
 
 The function has two overloads.
@@ -67,7 +68,7 @@ Requirements
 Semantics
 ~~~~~~~~~
 
-* After calling ``Kokkos::initialize``, ``Kokkos::is_initialized()`` should return true.
+* After calling ``Kokkos::initialize``, :cpp:func:`Kokkos::is_initialized() <is_initialized()>` should return true.
 
 Example
 ~~~~~~~


### PR DESCRIPTION
Improve existing doc by inserting hyper references pointing to the documentation for is_initialized and is_finalized when the functions are mentioned