### PR TITLE
Update copyright mention and sync license from core repo

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ sys.path.insert(0, os.path.abspath('.'))
 master_doc = "index"
 
 project = 'Kokkos'
-copyright = f'{datetime.datetime.now().year}, National Technology & Engineering Solutions of Sandia, LLC (NTESS)'
+copyright = f'{datetime.datetime.now().year}, Contributors to the Kokkos project'
 author = 'lots of people'
 
 # The full version, including alpha/beta/rc tags

--- a/docs/source/license.rst
+++ b/docs/source/license.rst
@@ -5,16 +5,6 @@ License
 
 ::
 
-   ************************************************************************
-   
-                          Kokkos v. 4.0
-         Copyright (2022) National Technology & Engineering
-                 Solutions of Sandia, LLC (NTESS).
-   
-   Under the terms of Contract DE-NA0003525 with NTESS,
-   the U.S. Government retains certain rights in this software.
-  
-  
    ==============================================================================
    Kokkos is under the Apache License v2.0 with LLVM Exceptions:
    ==============================================================================


### PR DESCRIPTION
I copied the license file from the core library.  Note that it still has 2x NTESS mentions.