### PR TITLE
Fix documentation on kokkos unique

### DIFF
--- a/docs/source/API/algorithms/std-algorithms/all/StdUnique.rst
+++ b/docs/source/API/algorithms/std-algorithms/all/StdUnique.rst
@@ -8,6 +8,8 @@ Description
 
 Eliminates all except the last element from every consecutive group of equivalent elements in a range or in a ``View`` and returns an iterator to the element *after* the new logical end of the range. Equivalence is checked using ``operator==`` and the binary predicate ``pred``.
 
+.. note:: This behavior deviates from that of ``std::unique``. Specifically, ``std::unique`` eliminates all except the **first** element from every consecutive group of equivalent elements.
+
 Interface
 ---------
 


### PR DESCRIPTION
Updated the description on `Kokkos::unique` to match its behavior.

Unlike its current description, `Kokkos::unique` actually eliminates all except the last element from the group of equivalent elements: https://godbolt.org/z/vz5zdY3G8

Based on a comment in its implementation (which shares an implementation with `UniqueCopy`), it's looking like this behavior was intended:
https://github.com/kokkos/kokkos/blob/a58abdda9ab93f33a2474e242936073a61617dcf/algorithms/src/std_algorithms/impl/Kokkos_UniqueCopy.hpp#L76-L85