### PR TITLE
Set clang cuda version to 15.0.0 in the requirements

### DIFF
--- a/docs/source/get-started/requirements.rst
+++ b/docs/source/get-started/requirements.rst
@@ -28,7 +28,7 @@ Kokkos 5.x
       * 14.0.0
 
     * * Clang (CUDA)
-      * 14.0.0
+      * 15.0.0
 
     * * AppleClang 
       * 8.0


### PR DESCRIPTION
The minimum clang cuda version should be 15.0.0 according to what is set in kokkos_compiler_id.cmake (https://github.com/kokkos/kokkos/blob/33aa9d8ca3720873ca1aec19b828035b17db3395/cmake/kokkos_compiler_id.cmake#L158)