### PR TITLE
Document minimum Cuda SDK version with LLVM

### DIFF
--- a/docs/source/get-started/requirements.rst
+++ b/docs/source/get-started/requirements.rst
@@ -28,7 +28,7 @@ Kokkos 5.x
       * 14.0.0
 
     * * Clang (CUDA)
-      * 15.0.0
+      * 15.0.0 and CUDA 11.8.0 (newer versions depending on LLVM support)
 
     * * AppleClang 
       * 8.0


### PR DESCRIPTION
As discussed in https://kokkosteam.slack.com/archives/C5BGU5NDQ/p1773854862786789.