### PR TITLE
Clarify that we require value types to be assignable in deep_copy

### DIFF
--- a/docs/source/API/core/view/deep_copy.rst
+++ b/docs/source/API/core/view/deep_copy.rst
@@ -52,7 +52,7 @@ Requirements
 
   - For all ``k`` in ``[0, dest.rank)`` ``dest.extent(k) == src.extent(k)`` (or the same as ``dest.rank()``)
 
-  - ``src.span_is_contiguous() && dest.span_is_contiguous() && std::is_same<ViewDest::array_layout,ViewSrc::array_layout>::value``, *or* there exists an `ExecutionSpace <../execution_spaces.html>`_ ``copy_space`` (either given or defaulted) such that both ``SpaceAccessibility<copy_space, ViewDest::memory_space>::accessible == true`` and ``SpaceAccessibility<copy_space,ViewSrc::memory_space>::accessible == true``.
+  - ``src.span_is_contiguous() && dest.span_is_contiguous() && std::is_same<ViewDest::array_layout,ViewSrc::array_layout>::value && std::is_same<ViewDest::non_const_value_type, ViewSrc::non_const_value_type>::value == true``, *or* there exists an `ExecutionSpace <../execution_spaces.html>`_ ``copy_space`` (either given or defaulted) such that both ``SpaceAccessibility<copy_space, ViewDest::memory_space>::accessible == true`` and ``SpaceAccessibility<copy_space,ViewSrc::memory_space>::accessible == true``.
 
 * If ``src`` is a `Kokkos::View <view.html>`_ and ``dest`` is a scalar, then ``src.rank == 0`` is true.
 

--- a/docs/source/API/core/view/deep_copy.rst
+++ b/docs/source/API/core/view/deep_copy.rst
@@ -46,7 +46,7 @@ Requirements
 
 * If ``src`` and ``dest`` are `Kokkos::View <view.html>`_ s, then all the following are true:
 
-  - ``std::is_same<ViewDest::non_const_value_type, ViewSrc::non_const_value_type>::value == true``
+  - ``ViewDst::non_const_value_type`` is assignable from ``ViewSrc::non_const_value_type``
 
   - ``src.rank == dest.rank`` (or, for ``Kokkos::DynRankView`` , ``src.rank() == dest.rank()`` )
 


### PR DESCRIPTION
As discussed in https://github.com/kokkos/kokkos/pull/8322#issuecomment-3188977990 and https://kokkosteam.slack.com/archives/C5BGU5NDQ/p1773963510956809, `deep_copy` allows different value types as long as the destination value type is assignable from the source value type.