### PR TITLE
Add some missing archs

### DIFF
--- a/docs/source/get-started/configuration-guide.rst
+++ b/docs/source/get-started/configuration-guide.rst
@@ -537,6 +537,10 @@ If cross-compiling, or if you want to be specific, the CPU architecture can be p
       - Xeon 9470C @ ANL Aurora
         Xeon @ LANL Crossroads
 
+    * - ``Kokkos_ARCH_ICX``
+      - Icelake
+      -
+
     * - ``Kokkos_ARCH_SKX``
       - Skylake/x86-64
       - 6130 @ OSU Pete

--- a/docs/source/get-started/configuration-guide.rst
+++ b/docs/source/get-started/configuration-guide.rst
@@ -538,7 +538,7 @@ If cross-compiling, or if you want to be specific, the CPU architecture can be p
         Xeon @ LANL Crossroads
 
     * - ``Kokkos_ARCH_ICX``
-      - Icelake
+      - Icelake/x86-64
       -
 
     * - ``Kokkos_ARCH_SKX``


### PR DESCRIPTION
Discovered in spack, see https://github.com/spack/spack-packages/pull/4161#discussion_r3052658941

I opted to not include BGQ since Power7 already is super old and BGQ is very specific to supercomputers (unlikely that someone has such a machine still)