### PR TITLE
Don't specify a minimum compiler version for AppleClang for Kokkos 5

### DIFF
--- a/docs/source/get-started/requirements.rst
+++ b/docs/source/get-started/requirements.rst
@@ -30,9 +30,6 @@ Kokkos 5.x
     * * Clang (CUDA)
       * 15.0.0 and CUDA 11.8.0 (newer versions depending on LLVM support)
 
-    * * AppleClang 
-      * 8.0
-
     * * IntelLLVM (CPU)
       * 2022.0.0
 


### PR DESCRIPTION
As discussed in https://kokkosteam.slack.com/archives/G5CBLMFLP/p1775829992691849, we didn't update the minimum requirement from 4. This pull request suggests to just drop the compiler name from the list since it should largely behave like the respective `Clang` version (using `libc++`).