### PR TITLE
Add a section on the advanced configuration an build options with Kokkos

### DIFF
--- a/docs/source/get-started.rst
+++ b/docs/source/get-started.rst
@@ -52,4 +52,4 @@ providing a convenient alternative to building from source.
 
 :doc:`Advanced Configuration and Build <get-started/advanced-configuration-and-build>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-This page lists advaced topics regarding the configuration and build that are available in Kokkos.
+This page lists advanced topics regarding the configuration and build that are available in Kokkos.

--- a/docs/source/get-started.rst
+++ b/docs/source/get-started.rst
@@ -11,7 +11,7 @@ Get Started
    get-started/building-from-source
    get-started/configuration-guide
    get-started/package-managers
-
+   get-started/advanced-configuration-and-build
 
 Want to try Kokkos right away?  Check it out on `Compiler Explorer
 <https://godbolt.org/z/svrE563Kn>`_.
@@ -49,3 +49,7 @@ usage, and a complete list of supported CPU and GPU architectures.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 This page lists package managers that offer pre-built Kokkos packages,
 providing a convenient alternative to building from source.
+
+:doc:`Advanced Configuration and Build <get-started/advanced-configuration-and-build>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This page lists advaced topics regarding the configuration and build that are available in Kokkos.

--- a/docs/source/get-started/advanced-configuration-and-build.rst
+++ b/docs/source/get-started/advanced-configuration-and-build.rst
@@ -23,7 +23,7 @@ To work around these situations, Kokkos introduced another ``bash`` script calle
 This script **only** redirects compiler and linker commands that compile a ``C++`` file that uses Kokkos to a compiler that can compile Kokkos code (e.g. ``nvcc_wrapper`` for the ``CUDA`` backend). Compiler and linker commands of ``C++`` files that don't use Kokkos, or files in different languages will not be redirected.
 
 This script, located in the ``bin`` subdirectory, is meant to be used like a compiler launcher in ``CMake``.
-But (except when being configured with ``Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON``) Kokkos will try to detect if the ``CXX`` compiler that ``CMake`` uses can compile the code for the enabled backend. If the ``CXX`` compiler can **not** compile the backend code, Kokkos automatically uses ``kokkos_launch_compiler``. The idea of this to help users to create performance-portable libraries that seamlessly integrate into complex software projects.
+But (except when being configured with ``Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON``) Kokkos will try to detect if the ``CXX`` compiler that ``CMake`` uses can compile the code for the enabled backend. If the ``CXX`` compiler can **not** compile the backend code, Kokkos automatically uses ``kokkos_launch_compiler``. The idea is to help users create performance-portable libraries that seamlessly integrate into complex software projects.
 
 Although, this covers most usecases, Kokkos provides ways for users to request ``kokkos_launch_compiler`` to be used **always** or **never**.
 To always use ``kokkos_launch_compiler``, users can ask for the ``launch_compiler`` component when calling ``find_packlage``:

--- a/docs/source/get-started/advanced-configuration-and-build.rst
+++ b/docs/source/get-started/advanced-configuration-and-build.rst
@@ -41,7 +41,7 @@ In contrast, when users want that ``kokkos_launch_compiler`` to never be used:
 Compile in the CMake language of the backend
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For the backends ``CUDA`` and ``HIP``, that have dedicated ``CMake`` languages corresponding to them, Kokkos can be configured to only set compiler and linker flags in the respective ``CMake`` language. This effectively causes Kokkos to identify as a ``CUDA`` or ``HIP`` library to ``CMake`` (**instead** of identifying as a ``CXX`` library). This does allow additional host backends to be enabled (e.g. ``CUDA`` and ``OPENMP`` and ``Serial`` can be compiled in ``CUDA`` language mode).
+For the backends ``CUDA`` and ``HIP``, that have dedicated ``CMake`` languages corresponding to them, Kokkos can be configured to only set compiler and linker flags in the respective ``CMake`` language. This effectively causes Kokkos to identify as a ``CUDA`` or ``HIP`` library to ``CMake`` (**instead** of identifying as a ``CXX`` library). This does allow additional host backends to be enabled (e.g. ``CUDA``, ``OPENMP`` and ``SERIAL`` can be compiled in ``CUDA`` language mode).
 This implies, that files that link to Kokkos also have to identify as the respective ``CMake`` language, and need to be compiled for the architecture that is enabled in Kokkos.
 To enable this behavior, enable the option `Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE <configuration-guide.html#backend-specific-options>`_. For a detailed example and explanation check the notes on the option.
 

--- a/docs/source/get-started/advanced-configuration-and-build.rst
+++ b/docs/source/get-started/advanced-configuration-and-build.rst
@@ -4,8 +4,8 @@ Advanced Configuration and Build
 nvcc_wrapper: Why do we have it and what does it do
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In general (except when being configured with ``Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON``) performance-portable code depending on Kokkos identifies itself as ``CXX`` code in ``CMake``.
-This implies, that the compiler used by ``CMake`` to compile ``CXX`` code must be able to compile the code for the backend and architecture enabled in Kokkos.
+In general (except when being configured with ``Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON``), performance-portable code depending on Kokkos identifies itself as ``CXX`` code in ``CMake``.
+This implies that the compiler used by ``CMake`` to compile ``CXX`` code must be able to compile the code for the backend and architecture enabled in Kokkos.
 
 For the ``CUDA`` backend this implies setting ``CMAKE_CXX_COMPILER=nvcc`` during configuration. But ``nvcc`` needed separate flags for the host and the device compilation (newer ``nvcc`` versions have improved support for unknown flags).
 This requirement of ``nvcc`` for separate flags implies that other libraries that are linked to the same target also need to adhere to do this.

--- a/docs/source/get-started/advanced-configuration-and-build.rst
+++ b/docs/source/get-started/advanced-configuration-and-build.rst
@@ -1,0 +1,52 @@
+Advanced Configuration and Build
+================================
+
+nvcc_wrapper: Why do we have it and what does it do
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In general (except when being configured with ``Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON``) performance-portable code depending on Kokkos identifies itself as ``CXX`` code in ``CMake``.
+This implies, that the compiler used by ``CMake`` to compile ``CXX`` code must be able to compile the code for the backend and architecture enabled in Kokkos.
+
+For the ``CUDA`` backend this implies setting ``CMAKE_CXX_COMPILER=nvcc`` during configuration. But ``nvcc`` needed separate flags for the host and the device compilation (newer ``nvcc`` versions have improved support for unknown flags).
+This requirement of ``nvcc`` for separate flags implies that other libraries that are linked to the same target also need to adhere to do this.
+
+To help users with this problem, Kokkos comes with a small ``bash`` script called ``nvcc_wrapper`` located in the ``bin`` subdirectory (At the current state there is no way to use this script in ``MSVC`` builds. Please see the section on compiling Kokkos in CMake language mode below).
+This script has two functions. It redirects compile and link commands to ``nvcc``, and it sorts the given compiler and linker flags into the ones for the host and the device compiler.
+
+To use it, set ``CMAKE_CXX_COMPILER=<path_to_kokkos>/bin/nvcc_wrapper``, replacing ``<path_to_kokkos>`` with the path of the Kokkos you are using. If you don't do that, Kokkos will use ``kokkos_launch_compiler`` (see next section) to redirect calls to ``nvcc_wrapper`` automatically.
+
+kokkos_launch_compiler: What does it do and how to control it
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In complex software projects that rely on multiple libraries it can occur, that the compiler Kokkos requires for the enabled backend can not compile one of the other libraries the project depends on.
+To work around these situations, Kokkos introduced another ``bash`` script called ``kokkos_launch_compiler``.
+This script **only** redirects compiler and linker commands that compile a ``C++`` file that uses Kokkos to a compiler that can compile Kokkos code (e.g. ``nvcc_wrapper`` for the ``CUDA`` backend). Compiler and linker commands of ``C++`` files that don't use Kokkos, or files in differnt languages will not be redirected.
+
+This script, located in the ``bin`` subdirectory, is meant to be used like a compiler launcher in ``CMake``.
+But (except when being configured with ``Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON``) Kokkos will try to detect if the ``CXX`` compiler that ``CMake`` uses can compile the code for the enabled backend. If the ``CXX`` compiler can **not** compile the backend code, Kokkos automatically uses ``kokkos_launch_compiler``. The idea of this to help users to create performance-portable libraries that seemlessly integrate into complex software projects.
+
+Although, this covers most usecases, Kokkos provides ways for users to request ``kokkos_launch_compiler`` to be used **always** or **never**.
+To always use ``kokkos_launch_compiler``, users can ask for the ``launch_compiler`` component when calling ``find_packlage``:
+
+.. code-block:: sh
+
+   find_package(Kokkos REQUIRED COMPONENTS launch_compiler)
+
+In contrast, when users want that ``kokkos_launch_compiler`` to never be used:
+
+.. code-block:: sh
+
+   find_package(Kokkos REQUIRED COMPONENTS separable_compilation)
+
+Compile in the CMake language of the backend
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For the backends ``CUDA`` and ``HIP``, that have dedicated ``CMake`` languages corresponding to them, Kokkos can be configured to only set compiler and linker flags in the respective ``CMake`` language. This effectively causes Kokkos to identify as a ``Cuda`` or ``HIP`` library to ``CMake`` (**instead** of identifying as a ``CXX`` library). This does allow additional host backends to be enabled (e.g. ``CUDA`` and ``OPENMP`` and ``Serial`` can be compiled in ``Cuda`` language mode).
+This implies, that files that link to Kokkos also have to identify as the respective ``CMake`` language, and need to be compiled for the architecture that is enabled in Kokkos.
+To enable this behavior, enable the option `Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE <configuration-guide.html#backend-specific-options>`_. For a detailed example and explanation check the notes on the option.
+
+Compile in multiple languages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Complex software projects might use multiple libraries that use Kokkos. If one of these uses Kokkos in the ``CMake`` language of the backend (e.g. ``Cuda`` or ``HIP``), while other libraries use Kokkos as a ``CXX`` library, they need a Kokkos that can be compiled in both modes.
+To allow this, Kokkos provides the option `Kokkos_ENABLE_MULTIPLE_CMAKE_LANGUAGES <configuration-guide.html#backend-specific-options>`_. For details and requirements check the notes on the option.

--- a/docs/source/get-started/advanced-configuration-and-build.rst
+++ b/docs/source/get-started/advanced-configuration-and-build.rst
@@ -20,10 +20,10 @@ kokkos_launch_compiler: What does it do and how to control it
 
 In complex software projects that rely on multiple libraries it can occur, that the compiler Kokkos requires for the enabled backend can not compile one of the other libraries the project depends on.
 To work around these situations, Kokkos introduced another ``bash`` script called ``kokkos_launch_compiler``.
-This script **only** redirects compiler and linker commands that compile a ``C++`` file that uses Kokkos to a compiler that can compile Kokkos code (e.g. ``nvcc_wrapper`` for the ``CUDA`` backend). Compiler and linker commands of ``C++`` files that don't use Kokkos, or files in differnt languages will not be redirected.
+This script **only** redirects compiler and linker commands that compile a ``C++`` file that uses Kokkos to a compiler that can compile Kokkos code (e.g. ``nvcc_wrapper`` for the ``CUDA`` backend). Compiler and linker commands of ``C++`` files that don't use Kokkos, or files in different languages will not be redirected.
 
 This script, located in the ``bin`` subdirectory, is meant to be used like a compiler launcher in ``CMake``.
-But (except when being configured with ``Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON``) Kokkos will try to detect if the ``CXX`` compiler that ``CMake`` uses can compile the code for the enabled backend. If the ``CXX`` compiler can **not** compile the backend code, Kokkos automatically uses ``kokkos_launch_compiler``. The idea of this to help users to create performance-portable libraries that seemlessly integrate into complex software projects.
+But (except when being configured with ``Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON``) Kokkos will try to detect if the ``CXX`` compiler that ``CMake`` uses can compile the code for the enabled backend. If the ``CXX`` compiler can **not** compile the backend code, Kokkos automatically uses ``kokkos_launch_compiler``. The idea of this to help users to create performance-portable libraries that seamlessly integrate into complex software projects.
 
 Although, this covers most usecases, Kokkos provides ways for users to request ``kokkos_launch_compiler`` to be used **always** or **never**.
 To always use ``kokkos_launch_compiler``, users can ask for the ``launch_compiler`` component when calling ``find_packlage``:

--- a/docs/source/get-started/advanced-configuration-and-build.rst
+++ b/docs/source/get-started/advanced-configuration-and-build.rst
@@ -5,9 +5,9 @@ nvcc_wrapper: Why do we have it and what does it do
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In general (except when being configured with ``Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON``), performance-portable code depending on Kokkos identifies itself as ``CXX`` code in ``CMake``.
-This implies that the compiler used by ``CMake`` to compile ``CXX`` code must be able to compile the code for the backend and architecture enabled in Kokkos.
+This implies that the compiler used by ``CMake`` to compile ``CXX`` code must be able to compile the code for the backends and architectures enabled in Kokkos.
 
-For the ``CUDA`` backend using ``nvcc`` this implies setting ``CMAKE_CXX_COMPILER=nvcc`` during configuration. But ``nvcc`` requires needed separate flags for the host and the device compilation (newer ``nvcc`` versions have improved support for unknown flags).
+For the ``CUDA`` backend using ``nvcc`` this implies setting ``CMAKE_CXX_COMPILER=nvcc`` during configuration. But ``nvcc`` requires separate flags for host and device compilation.
 This requirement of ``nvcc`` for separate flags implies that other libraries that are linked to the same target also need to adhere to do this.
 Other compilers like ``clang`` do not need to differentiate between host and device flags and thus do not need a wrapper script but can be directly used via ``CMAKE_CXX_COMPILER``.
 
@@ -24,10 +24,10 @@ To work around these situations, Kokkos introduced another ``bash`` script calle
 This script **only** redirects compiler and linker commands that compile a ``C++`` file that uses Kokkos to a compiler that can compile Kokkos code (e.g. ``nvcc_wrapper`` for the ``CUDA`` backend). Compiler and linker commands of ``C++`` files that don't use Kokkos, or files in different languages will not be redirected.
 
 This script, located in the ``bin`` subdirectory, is meant to be used like a compiler launcher in ``CMake``.
-But (except when being configured with ``Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON``) Kokkos will try to detect if the ``CXX`` compiler that ``CMake`` uses can compile the code for the enabled backend. If the ``CXX`` compiler can **not** compile the backend code, Kokkos automatically uses ``kokkos_launch_compiler``. If it redirects to ``nvcc_wrapper``, it will set ``nvcc``'s host compiler to the ``CXX`` compiler. The idea of this is to simplify the usage of Kokkos performance-portable build system.
+But (except when being configured with ``Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON``) Kokkos will try to detect if the ``CXX`` compiler that ``CMake`` uses can compile the code for the enabled backend. If the ``CXX`` compiler can **not** compile the backend code, Kokkos automatically uses ``kokkos_launch_compiler``. If it redirects to ``nvcc_wrapper``, it will set ``nvcc``'s host compiler to the ``CXX`` compiler. The idea of this is to simplify the usage of Kokkos' performance-portable build system.
 
 Although this covers most usecases, Kokkos provides ways for users to request ``kokkos_launch_compiler`` to be used **always** or **never**.
-To always use ``kokkos_launch_compiler``, users can ask for the ``launch_compiler`` component when calling ``find_packlage``:
+To always use ``kokkos_launch_compiler``, users can ask for the ``launch_compiler`` component when calling ``find_package``:
 
 .. code-block:: sh
 
@@ -42,12 +42,12 @@ In contrast, when users want that ``kokkos_launch_compiler`` to never be used:
 Compile in the CMake language of the backend
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For the backends ``CUDA`` and ``HIP``, that have dedicated ``CMake`` languages corresponding to them, Kokkos can be configured to only set compiler and linker flags in the respective ``CMake`` language. This effectively causes Kokkos to identify as a ``CUDA`` or ``HIP`` library to ``CMake`` (**instead** of identifying as a ``CXX`` library). This does allow additional host backends to be enabled (e.g. ``CUDA``, ``OPENMP`` and ``SERIAL`` can be compiled in ``CUDA`` language mode).
+For the ``CUDA`` and ``HIP`` backends, that have dedicated ``CMake`` languages corresponding to them, Kokkos can be configured to only set compiler and linker flags in the respective ``CMake`` language. This effectively causes Kokkos to identify as a ``CUDA`` or ``HIP`` library to ``CMake`` (**instead** of identifying as a ``CXX`` library). This does allow additional host backends to be enabled (e.g. ``CUDA``, ``OPENMP`` and ``SERIAL`` can be compiled in ``CUDA`` language mode).
 This implies, that files that link to Kokkos also have to identify as the respective ``CMake`` language, and need to be compiled for the architecture that is enabled in Kokkos.
 To enable this behavior, enable the option `Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE <configuration-guide.html#backend-specific-options>`_. For a detailed example and explanation check the notes on the option.
 
 Compile in multiple languages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Complex software projects might use multiple libraries that use Kokkos. If one of these uses Kokkos in the ``CMake`` language of the backend (e.g. ``Cuda`` or ``HIP``), while other libraries use Kokkos as a ``CXX`` library, they need a Kokkos that can be compiled in both modes.
+Complex software projects might use multiple libraries that use Kokkos. If one of these uses Kokkos in the ``CMake`` language of the backend (e.g. ``Cuda`` or ``HIP``), while other libraries use Kokkos as a ``CXX`` library, they need a Kokkos installation that can be compiled in both modes.
 To allow this, Kokkos provides the option `Kokkos_ENABLE_MULTIPLE_CMAKE_LANGUAGES <configuration-guide.html#backend-specific-options>`_. For details and requirements check the notes on the option.

--- a/docs/source/get-started/advanced-configuration-and-build.rst
+++ b/docs/source/get-started/advanced-configuration-and-build.rst
@@ -41,7 +41,7 @@ In contrast, when users want that ``kokkos_launch_compiler`` to never be used:
 Compile in the CMake language of the backend
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For the backends ``CUDA`` and ``HIP``, that have dedicated ``CMake`` languages corresponding to them, Kokkos can be configured to only set compiler and linker flags in the respective ``CMake`` language. This effectively causes Kokkos to identify as a ``Cuda`` or ``HIP`` library to ``CMake`` (**instead** of identifying as a ``CXX`` library). This does allow additional host backends to be enabled (e.g. ``CUDA`` and ``OPENMP`` and ``Serial`` can be compiled in ``Cuda`` language mode).
+For the backends ``CUDA`` and ``HIP``, that have dedicated ``CMake`` languages corresponding to them, Kokkos can be configured to only set compiler and linker flags in the respective ``CMake`` language. This effectively causes Kokkos to identify as a ``CUDA`` or ``HIP`` library to ``CMake`` (**instead** of identifying as a ``CXX`` library). This does allow additional host backends to be enabled (e.g. ``CUDA`` and ``OPENMP`` and ``Serial`` can be compiled in ``CUDA`` language mode).
 This implies, that files that link to Kokkos also have to identify as the respective ``CMake`` language, and need to be compiled for the architecture that is enabled in Kokkos.
 To enable this behavior, enable the option `Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE <configuration-guide.html#backend-specific-options>`_. For a detailed example and explanation check the notes on the option.
 

--- a/docs/source/get-started/advanced-configuration-and-build.rst
+++ b/docs/source/get-started/advanced-configuration-and-build.rst
@@ -25,7 +25,7 @@ This script **only** redirects compiler and linker commands that compile a ``C++
 This script, located in the ``bin`` subdirectory, is meant to be used like a compiler launcher in ``CMake``.
 But (except when being configured with ``Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON``) Kokkos will try to detect if the ``CXX`` compiler that ``CMake`` uses can compile the code for the enabled backend. If the ``CXX`` compiler can **not** compile the backend code, Kokkos automatically uses ``kokkos_launch_compiler``. The idea is to help users create performance-portable libraries that seamlessly integrate into complex software projects.
 
-Although, this covers most usecases, Kokkos provides ways for users to request ``kokkos_launch_compiler`` to be used **always** or **never**.
+Although this covers most usecases, Kokkos provides ways for users to request ``kokkos_launch_compiler`` to be used **always** or **never**.
 To always use ``kokkos_launch_compiler``, users can ask for the ``launch_compiler`` component when calling ``find_packlage``:
 
 .. code-block:: sh

--- a/docs/source/get-started/advanced-configuration-and-build.rst
+++ b/docs/source/get-started/advanced-configuration-and-build.rst
@@ -7,8 +7,9 @@ nvcc_wrapper: Why do we have it and what does it do
 In general (except when being configured with ``Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON``), performance-portable code depending on Kokkos identifies itself as ``CXX`` code in ``CMake``.
 This implies that the compiler used by ``CMake`` to compile ``CXX`` code must be able to compile the code for the backend and architecture enabled in Kokkos.
 
-For the ``CUDA`` backend this implies setting ``CMAKE_CXX_COMPILER=nvcc`` during configuration. But ``nvcc`` needed separate flags for the host and the device compilation (newer ``nvcc`` versions have improved support for unknown flags).
+For the ``CUDA`` backend using ``nvcc`` this implies setting ``CMAKE_CXX_COMPILER=nvcc`` during configuration. But ``nvcc`` requires needed separate flags for the host and the device compilation (newer ``nvcc`` versions have improved support for unknown flags).
 This requirement of ``nvcc`` for separate flags implies that other libraries that are linked to the same target also need to adhere to do this.
+Other compilers like ``clang`` do not need to differentiate between host and device flags and thus do not need a wrapper script but can be directly used via ``CMAKE_CXX_COMPILER``.
 
 To help users with this problem, Kokkos comes with a small ``bash`` script called ``nvcc_wrapper`` located in the ``bin`` subdirectory.
 This script has two functions. It redirects compile and link commands to ``nvcc``, and it sorts the given compiler and linker flags into the ones for the host and the device compiler.

--- a/docs/source/get-started/advanced-configuration-and-build.rst
+++ b/docs/source/get-started/advanced-configuration-and-build.rst
@@ -10,10 +10,10 @@ This implies that the compiler used by ``CMake`` to compile ``CXX`` code must be
 For the ``CUDA`` backend this implies setting ``CMAKE_CXX_COMPILER=nvcc`` during configuration. But ``nvcc`` needed separate flags for the host and the device compilation (newer ``nvcc`` versions have improved support for unknown flags).
 This requirement of ``nvcc`` for separate flags implies that other libraries that are linked to the same target also need to adhere to do this.
 
-To help users with this problem, Kokkos comes with a small ``bash`` script called ``nvcc_wrapper`` located in the ``bin`` subdirectory (At the current state there is no way to use this script in ``MSVC`` builds. Please see the section on compiling Kokkos in CMake language mode below).
+To help users with this problem, Kokkos comes with a small ``bash`` script called ``nvcc_wrapper`` located in the ``bin`` subdirectory.
 This script has two functions. It redirects compile and link commands to ``nvcc``, and it sorts the given compiler and linker flags into the ones for the host and the device compiler.
 
-To use it, set ``CMAKE_CXX_COMPILER=<path_to_kokkos>/bin/nvcc_wrapper``, replacing ``<path_to_kokkos>`` with the path of the Kokkos you are using. If you do not do that, Kokkos will use ``kokkos_launch_compiler`` (see next section) to redirect calls to ``nvcc_wrapper`` automatically.
+To use it explicitly, set ``CMAKE_CXX_COMPILER`` accordingly. If the compiler can't compile device code, Kokkos will use ``kokkos_launch_compiler`` (see next section) to redirect calls to ``nvcc_wrapper`` automatically.
 
 kokkos_launch_compiler: What does it do and how to control it
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ To work around these situations, Kokkos introduced another ``bash`` script calle
 This script **only** redirects compiler and linker commands that compile a ``C++`` file that uses Kokkos to a compiler that can compile Kokkos code (e.g. ``nvcc_wrapper`` for the ``CUDA`` backend). Compiler and linker commands of ``C++`` files that don't use Kokkos, or files in different languages will not be redirected.
 
 This script, located in the ``bin`` subdirectory, is meant to be used like a compiler launcher in ``CMake``.
-But (except when being configured with ``Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON``) Kokkos will try to detect if the ``CXX`` compiler that ``CMake`` uses can compile the code for the enabled backend. If the ``CXX`` compiler can **not** compile the backend code, Kokkos automatically uses ``kokkos_launch_compiler``. The idea is to help users create performance-portable libraries that seamlessly integrate into complex software projects.
+But (except when being configured with ``Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON``) Kokkos will try to detect if the ``CXX`` compiler that ``CMake`` uses can compile the code for the enabled backend. If the ``CXX`` compiler can **not** compile the backend code, Kokkos automatically uses ``kokkos_launch_compiler``. If it redirects to ``nvcc_wrapper``, it will set ``nvcc``'s host compiler to the ``CXX`` compiler. The idea of this is to simplify the usage of Kokkos performance-portable build system.
 
 Although this covers most usecases, Kokkos provides ways for users to request ``kokkos_launch_compiler`` to be used **always** or **never**.
 To always use ``kokkos_launch_compiler``, users can ask for the ``launch_compiler`` component when calling ``find_packlage``:

--- a/docs/source/get-started/advanced-configuration-and-build.rst
+++ b/docs/source/get-started/advanced-configuration-and-build.rst
@@ -18,7 +18,7 @@ To use it, set ``CMAKE_CXX_COMPILER=<path_to_kokkos>/bin/nvcc_wrapper``, replaci
 kokkos_launch_compiler: What does it do and how to control it
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In complex software projects that rely on multiple libraries it can occur, that the compiler Kokkos requires for the enabled backend can not compile one of the other libraries the project depends on.
+In complex software projects that rely on multiple libraries, it can occur that the compiler Kokkos requires for the enabled backend can not compile one of the other libraries the project depends on.
 To work around these situations, Kokkos introduced another ``bash`` script called ``kokkos_launch_compiler``.
 This script **only** redirects compiler and linker commands that compile a ``C++`` file that uses Kokkos to a compiler that can compile Kokkos code (e.g. ``nvcc_wrapper`` for the ``CUDA`` backend). Compiler and linker commands of ``C++`` files that don't use Kokkos, or files in different languages will not be redirected.
 

--- a/docs/source/get-started/advanced-configuration-and-build.rst
+++ b/docs/source/get-started/advanced-configuration-and-build.rst
@@ -13,7 +13,7 @@ This requirement of ``nvcc`` for separate flags implies that other libraries tha
 To help users with this problem, Kokkos comes with a small ``bash`` script called ``nvcc_wrapper`` located in the ``bin`` subdirectory (At the current state there is no way to use this script in ``MSVC`` builds. Please see the section on compiling Kokkos in CMake language mode below).
 This script has two functions. It redirects compile and link commands to ``nvcc``, and it sorts the given compiler and linker flags into the ones for the host and the device compiler.
 
-To use it, set ``CMAKE_CXX_COMPILER=<path_to_kokkos>/bin/nvcc_wrapper``, replacing ``<path_to_kokkos>`` with the path of the Kokkos you are using. If you don't do that, Kokkos will use ``kokkos_launch_compiler`` (see next section) to redirect calls to ``nvcc_wrapper`` automatically.
+To use it, set ``CMAKE_CXX_COMPILER=<path_to_kokkos>/bin/nvcc_wrapper``, replacing ``<path_to_kokkos>`` with the path of the Kokkos you are using. If you do not do that, Kokkos will use ``kokkos_launch_compiler`` (see next section) to redirect calls to ``nvcc_wrapper`` automatically.
 
 kokkos_launch_compiler: What does it do and how to control it
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
So we can point users to a page describing these things as seen e.g. in https://kokkosteam.slack.com/archives/C08HHLY3490/p1777251459276539