### PR TITLE
Add Kokkos_ARCH_AMD_GFX1101

### DIFF
--- a/docs/source/get-started/configuration-guide.rst
+++ b/docs/source/get-started/configuration-guide.rst
@@ -798,9 +798,14 @@ Kokkos will attempt to autodetect the architecture flag at configuration time.
       * Ryzen 8000G Phoenix series APU
       * (since Kokkos 4.5)
 
+    * * ``Kokkos_ARCH_AMD_GFX1101``
+      * GFX1101
+      * Radeon RX 7800 XT, RX 7700 XT, RX 7700
+      * (since Kokkos 5.2)
+
     * * ``Kokkos_ARCH_AMD_GFX1100``
       * GFX1100
-      * 7900xt
+      * Radeon RX 7900 XT
       * (since Kokkos 4.2)
 
     * * ``Kokkos_ARCH_AMD_GFX1030``


### PR DESCRIPTION
Documentation PR for https://github.com/kokkos/kokkos/pull/9230, this adds an entry in the amd gpu arch table for gfx1101.

Drive-by change: replace "7900xt" by "Radeon RX 7900 XT" in the gfx1100 row to align with the naming used in the gfx1201 and gfx1101 rows