### PR TITLE
Update built in reducers

### DIFF
--- a/docs/source/API/core/builtin_reducers.rst
+++ b/docs/source/API/core/builtin_reducers.rst
@@ -15,20 +15,30 @@ Reducer objects used in conjunction with `parallel_reduce <parallel-dispatch/par
      - Binary 'And' reduction
    * - `BOr <builtinreducers/BOr.html>`__
      - Binary 'Or' reduction
+   * - `FirstLoc <builtinreducers/FirstLoc.html>`__
+     - Providing the first index satisfying a condition
    * - `LAnd <builtinreducers/LAnd.html>`__
      - Logical 'And' reduction
+   * - `LastLoc <builtinreducers/LastLoc.html>`__
+     - Providing the last index satisfying a condition
    * - `LOr <builtinreducers/LOr.html>`__
      - Logical 'Or' reduction
    * - `Max <builtinreducers/Max.html>`__
      - Maximum reduction
+   * - `MaxFirstLoc <builtinreducers/MaxFirstLoc.html>`__
+     - Reduction providing maximum and an associated first index
    * - `MaxLoc <builtinreducers/MaxLoc.html>`__
      - Reduction providing maximum and an associated index
    * - `Min <builtinreducers/Min.html>`__
      - Minimum reduction
+   * - `MinFirstLoc <builtinreducers/MinFirstLoc.html>`__
+     - Reduction providing minimum and an associated first index
    * - `MinLoc <builtinreducers/MinLoc.html>`__
      - Reduction providing minimum and an associated index
    * - `MinMax <builtinreducers/MinMax.html>`__
      - Reduction providing both minimum and maximum
+   * - `MinMaxFirstLastLoc <builtinreducers/MinMaxFirstLastLoc.html>`__
+     - Reduction providing both minimum and maximum and associated first indices
    * - `MinMaxLoc <builtinreducers/MinMaxLoc.html>`__
      - Reduction providing both minimum and maximum and associated indices
    * - `Prod <builtinreducers/Prod.html>`__
@@ -50,13 +60,18 @@ built-in reducers to work with user-defined types.
    ./builtinreducers/ReducerConcept
    ./builtinreducers/BAnd
    ./builtinreducers/BOr
+   ./builtinreducers/FirstLoc
    ./builtinreducers/LAnd
+   ./builtinreducers/LastLoc
    ./builtinreducers/LOr
    ./builtinreducers/Max
+   ./builtinreducers/MaxFirstLoc
    ./builtinreducers/MaxLoc
    ./builtinreducers/Min
+   ./builtinreducers/MinFirstLoc
    ./builtinreducers/MinLoc
    ./builtinreducers/MinMax
+   ./builtinreducers/MinMaxFirstLastLoc
    ./builtinreducers/MinMaxLoc
    ./builtinreducers/Prod
    ./builtinreducers/Sum

--- a/docs/source/API/core/builtin_reducers.rst
+++ b/docs/source/API/core/builtin_reducers.rst
@@ -38,7 +38,7 @@ Reducer objects used in conjunction with `parallel_reduce <parallel-dispatch/par
    * - `MinMax <builtinreducers/MinMax.html>`__
      - Reduction providing both minimum and maximum
    * - `MinMaxFirstLastLoc <builtinreducers/MinMaxFirstLastLoc.html>`__
-     - Reduction providing both minimum and maximum and associated first indices
+     - Reduction providing both minimum and maximum and associated first and last indices
    * - `MinMaxLoc <builtinreducers/MinMaxLoc.html>`__
      - Reduction providing both minimum and maximum and associated indices
    * - `Prod <builtinreducers/Prod.html>`__

--- a/docs/source/API/core/builtinreducers/FirstLoc.rst
+++ b/docs/source/API/core/builtinreducers/FirstLoc.rst
@@ -25,7 +25,7 @@ Synopsis
    class FirstLoc{
      public:
        using reducer = FirstLoc;
-       using value_type = FirstLocScalar<typename std::remove_cv<Index>::type >;
+       using value_type = FirstLocScalar<typename std::remove_cv<Index>::type>;
        using result_view_type = Kokkos::View<value_type, Space>;
 
        KOKKOS_INLINE_FUNCTION
@@ -88,16 +88,14 @@ Interface
 
    .. cpp:function:: KOKKOS_INLINE_FUNCTION value_type& reference() const;
 
-      Returns a reference to the result provided in class constructor.
+      Returns a reference to the result provided in the class constructor.
 
    .. cpp:function:: KOKKOS_INLINE_FUNCTION result_view_type view() const;
 
-      Returns a view of the result place provided in class constructor.
+      Returns a view of the result provided in the class constructor.
 
 Additional Information
 ^^^^^^^^^^^^^^^^^^^^^^
-
-* ``FirstLoc<I,S>::value_type`` is Specialization of ``FirstLocScalar`` on non-const ``I``
 
 * ``FirstLoc<I,S>::result_view_type`` is ``Kokkos::View<I,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>``. Note that the S (memory space) must be the same as the space where the result resides.
 

--- a/docs/source/API/core/builtinreducers/FirstLoc.rst
+++ b/docs/source/API/core/builtinreducers/FirstLoc.rst
@@ -97,10 +97,10 @@ Interface
 Additional Information
 ^^^^^^^^^^^^^^^^^^^^^^
 
-* ``FirstLoc<I,S>::value_type`` is Specialization of FirstLocScalar on non-const ``I``
+* ``FirstLoc<I,S>::value_type`` is Specialization of ``FirstLocScalar`` on non-const ``I``
 
 * ``FirstLoc<I,S>::result_view_type`` is ``Kokkos::View<I,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>``. Note that the S (memory space) must be the same as the space where the result resides.
 
 * Requires: ``Index`` has ``operator =`` defined. ``Kokkos::reduction_identity<Index>::min()`` is a valid expression.
 
-* In order to use FirstLoc with a custom type of ``Index``, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined. See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details
+* In order to use ``FirstLoc`` with a custom type of ``Index``, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined. See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details

--- a/docs/source/API/core/builtinreducers/FirstLoc.rst
+++ b/docs/source/API/core/builtinreducers/FirstLoc.rst
@@ -1,0 +1,106 @@
+``FirstLoc``
+============
+
+.. role:: cpp(code)
+    :language: cpp
+
+Specific implementation of `ReducerConcept <ReducerConcept.html>`_ storing the first index satisfying a condition.
+
+Header File: ``<Kokkos_Core.hpp>``
+
+Usage
+-----
+
+.. code-block:: cpp
+
+   FirstLoc<I,S>::value_type result;
+   parallel_reduce(N,Functor,FirstLoc<I,S>(result));
+
+Synopsis
+--------
+
+.. code-block:: cpp
+
+   template<class Index, class Space>
+   class FirstLoc{
+     public:
+       using reducer = FirstLoc;
+       using value_type = FirstLocScalar<typename std::remove_cv<Index>::type >;
+       using result_view_type = Kokkos::View<value_type, Space>;
+
+       KOKKOS_INLINE_FUNCTION
+       void join(value_type& dest, const value_type& src) const;
+
+       KOKKOS_INLINE_FUNCTION
+       void init(value_type& val) const;
+
+       KOKKOS_INLINE_FUNCTION
+       value_type& reference() const;
+
+       KOKKOS_INLINE_FUNCTION
+       result_view_type view() const;
+
+       KOKKOS_INLINE_FUNCTION
+       FirstLoc(value_type& value_);
+
+       KOKKOS_INLINE_FUNCTION
+       FirstLoc(const result_view_type& value_);
+   };
+
+Interface
+---------
+
+.. cpp:class:: template<class Index, class Space> FirstLoc
+
+   .. rubric:: Public Types
+
+   .. cpp:type:: reducer
+
+      The self type.
+
+   .. cpp:type:: value_type
+
+      The reduction scalar type (specialization of `FirstLocScalar <FirstLocScalar.html>`_)
+
+   .. cpp:type:: result_view_type
+
+      A ``Kokkos::View`` referencing the reduction result
+
+   .. rubric:: Constructors
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION FirstLoc(value_type& value_);
+
+      Constructs a reducer which references a local variable as its result location.
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION FirstLoc(const result_view_type& value_);
+
+      Constructs a reducer which references a specific view as its result location.
+
+   .. rubric:: Public Member Functions
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION void join(value_type& dest, const value_type& src) const;
+
+      Store maximum with the first index of ``src`` and ``dest`` into ``dest``: ``dest = (src.min_loc_true < dest.min_loc_true) ? src :dest;``.
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION void init(value_type& val) const;
+
+      Initialize ``val.min_loc_true`` using the ``Kokkos::reduction_identity<Index>::min()`` method. The default implementation sets ``val=<TYPE>_MAX``.
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION value_type& reference() const;
+
+      Returns a reference to the result provided in class constructor.
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION result_view_type view() const;
+
+      Returns a view of the result place provided in class constructor.
+
+Additional Information
+^^^^^^^^^^^^^^^^^^^^^^
+
+* ``FirstLoc<I,S>::value_type`` is Specialization of FirstLocScalar on non-const ``I``
+
+* ``FirstLoc<I,S>::result_view_type`` is ``Kokkos::View<I,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>``. Note that the S (memory space) must be the same as the space where the result resides.
+
+* Requires: ``Index`` has ``operator =`` defined. ``Kokkos::reduction_identity<Index>::min()`` is a valid expression.
+
+* In order to use FirstLoc with a custom type of ``Index``, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined. See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details

--- a/docs/source/API/core/builtinreducers/FirstLocScalar.rst
+++ b/docs/source/API/core/builtinreducers/FirstLocScalar.rst
@@ -1,0 +1,36 @@
+``FirstLocScalar``
+==================
+
+.. role::cpp(code)
+    :language: cpp
+
+The :cpp:struct:`FirstLocScalar` is a class template that stores a **location** (index) of the first occurrence satisfying a condition as a single, convenient unit.
+It's designed to hold the result of :cpp:func:`parallel_reduce` operations using a :cpp:class:`FirstLoc` builtin reducer.
+
+It is generally recommended to get this type by using the reducer's
+``::value_type`` member (e.g., ``FirstLoc<Index,Space>::value_type``)
+to ensure the correct template parameters are used.
+
+Header File: ``<Kokkos_Core.hpp>``
+
+Usage
+-----
+
+.. code-block:: cpp
+
+   FirstLocScalar<Index>::value_type result;
+   parallel_reduce(N,Functor,FirstLocScalar<Index>(result));
+   I firstLoc = result.min_loc_true;
+
+Interface
+---------
+
+.. cpp:struct::  template<class Index> FirstLocScalar
+
+   :tparam Index: The data type of the locations (indices) of the values.
+
+   .. rubric:: Data members
+
+   .. cpp:var:: Index min_loc_true
+
+      The location (iteration index) of the minimum value

--- a/docs/source/API/core/builtinreducers/LastLoc.rst
+++ b/docs/source/API/core/builtinreducers/LastLoc.rst
@@ -97,10 +97,10 @@ Interface
 Additional Information
 ^^^^^^^^^^^^^^^^^^^^^^
 
-* ``LastLoc<I,S>::value_type`` is Specialization of LastLocScalar on non-const ``I``
+* ``LastLoc<I,S>::value_type`` is Specialization of ``LastLocScalar`` on non-const ``I``
 
 * ``LastLoc<I,S>::result_view_type`` is ``Kokkos::View<I,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>``. Note that the S (memory space) must be the same as the space where the result resides.
 
 * Requires: ``Index`` has ``operator =`` defined. ``Kokkos::reduction_identity<Index>::max()`` is a valid expression.
 
-* In order to use LastLoc with a custom type of ``Index``, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined. See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details
+* In order to use ``LastLoc`` with a custom type of ``Index``, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined. See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details

--- a/docs/source/API/core/builtinreducers/LastLoc.rst
+++ b/docs/source/API/core/builtinreducers/LastLoc.rst
@@ -1,0 +1,106 @@
+``LastLoc``
+===========
+
+.. role:: cpp(code)
+    :language: cpp
+
+Specific implementation of `ReducerConcept <ReducerConcept.html>`_ storing the last index satisfying a condition.
+
+Header File: ``<Kokkos_Core.hpp>``
+
+Usage
+-----
+
+.. code-block:: cpp
+
+   LastLoc<I,S>::value_type result;
+   parallel_reduce(N,Functor,LastLoc<I,S>(result));
+
+Synopsis
+--------
+
+.. code-block:: cpp
+
+   template<class Index, class Space>
+   class LastLoc{
+     public:
+       using reducer = LastLoc;
+       using value_type = LastLocScalar<typename std::remove_cv<Index>::type >;
+       using result_view_type = Kokkos::View<value_type, Space>;
+
+       KOKKOS_INLINE_FUNCTION
+       void join(value_type& dest, const value_type& src) const;
+
+       KOKKOS_INLINE_FUNCTION
+       void init(value_type& val) const;
+
+       KOKKOS_INLINE_FUNCTION
+       value_type& reference() const;
+
+       KOKKOS_INLINE_FUNCTION
+       result_view_type view() const;
+
+       KOKKOS_INLINE_FUNCTION
+       LastLoc(value_type& value_);
+
+       KOKKOS_INLINE_FUNCTION
+       LastLoc(const result_view_type& value_);
+   };
+
+Interface
+---------
+
+.. cpp:class:: template<class Index, class Space> LastLoc
+
+   .. rubric:: Public Types
+
+   .. cpp:type:: reducer
+
+      The self type.
+
+   .. cpp:type:: value_type
+
+      The reduction scalar type (specialization of `LastLocScalar <LastLocScalar.html>`_)
+
+   .. cpp:type:: result_view_type
+
+      A ``Kokkos::View`` referencing the reduction result
+
+   .. rubric:: Constructors
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION LastLoc(value_type& value_);
+
+      Constructs a reducer which references a local variable as its result location.
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION LastLoc(const result_view_type& value_);
+
+      Constructs a reducer which references a specific view as its result location.
+
+   .. rubric:: Public Member Functions
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION void join(value_type& dest, const value_type& src) const;
+
+      Store maximum with the last index of ``src`` and ``dest`` into ``dest``: ``dest = (src.max_loc_true > dest.max_loc_true) ? src :dest;``.
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION void init(value_type& val) const;
+
+      Initialize ``val.max_loc_true`` using the ``Kokkos::reduction_identity<Index>::max()`` method. The default implementation sets ``val=<TYPE>_MIN``.
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION value_type& reference() const;
+
+      Returns a reference to the result provided in class constructor.
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION result_view_type view() const;
+
+      Returns a view of the result place provided in class constructor.
+
+Additional Information
+^^^^^^^^^^^^^^^^^^^^^^
+
+* ``LastLoc<I,S>::value_type`` is Specialization of LastLocScalar on non-const ``I``
+
+* ``LastLoc<I,S>::result_view_type`` is ``Kokkos::View<I,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>``. Note that the S (memory space) must be the same as the space where the result resides.
+
+* Requires: ``Index`` has ``operator =`` defined. ``Kokkos::reduction_identity<Index>::max()`` is a valid expression.
+
+* In order to use LastLoc with a custom type of ``Index``, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined. See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details

--- a/docs/source/API/core/builtinreducers/LastLoc.rst
+++ b/docs/source/API/core/builtinreducers/LastLoc.rst
@@ -25,7 +25,7 @@ Synopsis
    class LastLoc{
      public:
        using reducer = LastLoc;
-       using value_type = LastLocScalar<typename std::remove_cv<Index>::type >;
+       using value_type = LastLocScalar<typename std::remove_cv<Index>::type>;
        using result_view_type = Kokkos::View<value_type, Space>;
 
        KOKKOS_INLINE_FUNCTION
@@ -88,16 +88,14 @@ Interface
 
    .. cpp:function:: KOKKOS_INLINE_FUNCTION value_type& reference() const;
 
-      Returns a reference to the result provided in class constructor.
+      Returns a reference to the result provided in the class constructor.
 
    .. cpp:function:: KOKKOS_INLINE_FUNCTION result_view_type view() const;
 
-      Returns a view of the result place provided in class constructor.
+      Returns a view of the result provided in the class constructor.
 
 Additional Information
 ^^^^^^^^^^^^^^^^^^^^^^
-
-* ``LastLoc<I,S>::value_type`` is Specialization of ``LastLocScalar`` on non-const ``I``
 
 * ``LastLoc<I,S>::result_view_type`` is ``Kokkos::View<I,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>``. Note that the S (memory space) must be the same as the space where the result resides.
 

--- a/docs/source/API/core/builtinreducers/LastLocScalar.rst
+++ b/docs/source/API/core/builtinreducers/LastLocScalar.rst
@@ -1,0 +1,36 @@
+``LastLocScalar``
+=================
+
+.. role::cpp(code)
+    :language: cpp
+
+The :cpp:struct:`LastLocScalar` is a class template that stores a **location** (index) of the last occurrence satisfying a condition as a single, convenient unit.
+It's designed to hold the result of :cpp:func:`parallel_reduce` operations using a :cpp:class:`LastLoc` builtin reducer.
+
+It is generally recommended to get this type by using the reducer's
+``::value_type`` member (e.g., ``LastLoc<Index,Space>::value_type``)
+to ensure the correct template parameters are used.
+
+Header File: ``<Kokkos_Core.hpp>``
+
+Usage
+-----
+
+.. code-block:: cpp
+
+   LastLocScalar<Index>::value_type result;
+   parallel_reduce(N,Functor,LastLocScalar<Index>(result));
+   I lastLoc = result.max_loc_true;
+
+Interface
+---------
+
+.. cpp:struct::  template<class Index> LastLocScalar
+
+   :tparam Index: The data type of the locations (indices) of the values.
+
+   .. rubric:: Data members
+
+   .. cpp:var:: Index max_loc_true
+
+      The location (iteration index) of the maximum value

--- a/docs/source/API/core/builtinreducers/MaxFirstLoc.rst
+++ b/docs/source/API/core/builtinreducers/MaxFirstLoc.rst
@@ -1,0 +1,110 @@
+``MaxFirstLoc``
+===============
+
+.. role:: cpp(code)
+    :language: cpp
+
+Specific implementation of `ReducerConcept <ReducerConcept.html>`_ storing the maximum value and the first index satisfying a condition.
+
+Header File: ``<Kokkos_Core.hpp>``
+
+Usage
+-----
+
+.. code-block:: cpp
+
+   MaxFirstLoc<T,I,S>::value_type result;
+   parallel_reduce(N,Functor,MaxFirstLoc<T,I,S>(result));
+
+Synopsis
+--------
+
+.. code-block:: cpp
+
+   template<class Scalar, class Index, class Space>
+   class MaxFirstLoc{
+     public:
+       using reducer = MaxFirstLoc;
+       using value_type = ValLocScalar<typename std::remove_cv<Scalar>::type,
+                               typename std::remove_cv<Index>::type >;
+       using result_view_type = Kokkos::View<value_type, Space>;
+
+       KOKKOS_INLINE_FUNCTION
+       void join(value_type& dest, const value_type& src) const;
+
+       KOKKOS_INLINE_FUNCTION
+       void init(value_type& val) const;
+
+       KOKKOS_INLINE_FUNCTION
+       value_type& reference() const;
+
+       KOKKOS_INLINE_FUNCTION
+       result_view_type view() const;
+
+       KOKKOS_INLINE_FUNCTION
+       MaxFirstLoc(value_type& value_);
+
+       KOKKOS_INLINE_FUNCTION
+       MaxFirstLoc(const result_view_type& value_);
+   };
+
+Interface
+---------
+
+.. cpp:class:: template<class Scalar, class Index, class Space> MaxFirstLoc
+
+   .. rubric:: Public Types
+
+   .. cpp:type:: reducer
+
+      The self type.
+
+   .. cpp:type:: value_type
+
+      The reduction scalar type (specialization of `ValLocScalar <ValLocScalar.html>`_)
+
+   .. cpp:type:: result_view_type
+
+      A ``Kokkos::View`` referencing the reduction result
+
+   .. rubric:: Constructors
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION MaxFirstLoc(value_type& value_);
+
+      Constructs a reducer which references a local variable as its result location.
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION MaxFirstLoc(const result_view_type& value_);
+
+      Constructs a reducer which references a specific view as its result location.
+
+   .. rubric:: Public Member Functions
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION void join(value_type& dest, const value_type& src) const;
+
+      Store maximum with the first index of ``src`` and ``dest`` into ``dest``: ``dest = (src.val > dest.val) ? src :dest;``.
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION void init(value_type& val) const;
+
+      Initialize ``val.val`` using the ``Kokkos::reduction_identity<Scalar>::max()`` method. The default implementation sets ``val=<TYPE>_MIN``.
+      Initialize ``val.loc`` using the ``Kokkos::reduction_identity<Index>::min()`` method. The default implementation sets ``val=<TYPE>_MAX``.
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION value_type& reference() const;
+
+      Returns a reference to the result provided in class constructor.
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION result_view_type view() const;
+
+      Returns a view of the result place provided in class constructor.
+
+Additional Information
+^^^^^^^^^^^^^^^^^^^^^^
+
+* ``MaxFirstLoc<T,I,S>::value_type`` is Specialization of ValLocScalar on non-const ``T`` and non-const ``I``
+
+* ``MaxFirstLoc<T,I,S>::result_view_type`` is ``Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>``. Note that the S (memory space) must be the same as the space where the result resides.
+
+* Requires: ``Scalar`` has ``operator =`` and ``operator >`` defined. ``Kokkos::reduction_identity<Scalar>::max()`` is a valid expression.
+
+* Requires: ``Index`` has ``operator =`` defined. ``Kokkos::reduction_identity<Index>::min()`` is a valid expression.
+
+* In order to use MaxFirstLoc with a custom type of either ``Scalar`` or ``Index``, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined. See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details

--- a/docs/source/API/core/builtinreducers/MaxFirstLoc.rst
+++ b/docs/source/API/core/builtinreducers/MaxFirstLoc.rst
@@ -99,7 +99,7 @@ Interface
 Additional Information
 ^^^^^^^^^^^^^^^^^^^^^^
 
-* ``MaxFirstLoc<T,I,S>::value_type`` is Specialization of ValLocScalar on non-const ``T`` and non-const ``I``
+* ``MaxFirstLoc<T,I,S>::value_type`` is Specialization of ``ValLocScalar`` on non-const ``T`` and non-const ``I``
 
 * ``MaxFirstLoc<T,I,S>::result_view_type`` is ``Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>``. Note that the S (memory space) must be the same as the space where the result resides.
 
@@ -107,4 +107,4 @@ Additional Information
 
 * Requires: ``Index`` has ``operator =`` defined. ``Kokkos::reduction_identity<Index>::min()`` is a valid expression.
 
-* In order to use MaxFirstLoc with a custom type of either ``Scalar`` or ``Index``, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined. See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details
+* In order to use ``MaxFirstLoc`` with a custom type of either ``Scalar`` or ``Index``, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined. See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details

--- a/docs/source/API/core/builtinreducers/MaxFirstLoc.rst
+++ b/docs/source/API/core/builtinreducers/MaxFirstLoc.rst
@@ -26,7 +26,7 @@ Synopsis
      public:
        using reducer = MaxFirstLoc;
        using value_type = ValLocScalar<typename std::remove_cv<Scalar>::type,
-                               typename std::remove_cv<Index>::type >;
+                               typename std::remove_cv<Index>::type>;
        using result_view_type = Kokkos::View<value_type, Space>;
 
        KOKKOS_INLINE_FUNCTION
@@ -90,16 +90,14 @@ Interface
 
    .. cpp:function:: KOKKOS_INLINE_FUNCTION value_type& reference() const;
 
-      Returns a reference to the result provided in class constructor.
+      Returns a reference to the result provided in the class constructor.
 
    .. cpp:function:: KOKKOS_INLINE_FUNCTION result_view_type view() const;
 
-      Returns a view of the result place provided in class constructor.
+      Returns a view of the result provided in the class constructor.
 
 Additional Information
 ^^^^^^^^^^^^^^^^^^^^^^
-
-* ``MaxFirstLoc<T,I,S>::value_type`` is Specialization of ``ValLocScalar`` on non-const ``T`` and non-const ``I``
 
 * ``MaxFirstLoc<T,I,S>::result_view_type`` is ``Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>``. Note that the S (memory space) must be the same as the space where the result resides.
 

--- a/docs/source/API/core/builtinreducers/MinFirstLoc.rst
+++ b/docs/source/API/core/builtinreducers/MinFirstLoc.rst
@@ -107,7 +107,7 @@ Additional Information
 
 * Requires: ``Index`` has ``operator =`` defined. ``Kokkos::reduction_identity<Index>::min()`` is a valid expression.
 
-* In order to use MinFirstLoc with a custom type of either ``Scalar`` or ``Index``, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined. See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details
+* In order to use ``MinFirstLoc`` with a custom type of either ``Scalar`` or ``Index``, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined. See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details
 
 Example
 -------

--- a/docs/source/API/core/builtinreducers/MinFirstLoc.rst
+++ b/docs/source/API/core/builtinreducers/MinFirstLoc.rst
@@ -1,0 +1,151 @@
+``MinFirstLoc``
+===============
+
+.. role:: cpp(code)
+    :language: cpp
+
+Specific implementation of `ReducerConcept <ReducerConcept.html>`_ storing the minimum value with an index
+
+Header File: ``<Kokkos_Core.hpp>``
+
+Usage
+-----
+
+.. code-block:: cpp
+
+   MinFirstLoc<T,I,S>::value_type result;
+   parallel_reduce(N,Functor,MinFirstLoc<T,I,S>(result));
+
+Synopsis
+--------
+
+.. code-block:: cpp
+
+   template<class Scalar, class Index, class Space>
+   class MinFirstLoc{
+     public:
+       using reducer = MinFirstLoc;
+       using value_type = ValLocScalar<typename std::remove_cv<Scalar>::type,
+                               typename std::remove_cv<Index>::type >;
+       using result_view_type = Kokkos::View<value_type, Space>;
+
+       KOKKOS_INLINE_FUNCTION
+       void join(value_type& dest, const value_type& src) const;
+
+       KOKKOS_INLINE_FUNCTION
+       void init(value_type& val) const;
+
+       KOKKOS_INLINE_FUNCTION
+       value_type& reference() const;
+
+       KOKKOS_INLINE_FUNCTION
+       result_view_type view() const;
+
+       KOKKOS_INLINE_FUNCTION
+       MinFirstLoc(value_type& value_);
+
+       KOKKOS_INLINE_FUNCTION
+       MinFirstLoc(const result_view_type& value_);
+   };
+
+Interface
+---------
+
+.. cpp:class:: template<class Scalar, class Index, class Space> MinFirstLoc
+
+   .. rubric:: Public Types
+
+   .. cpp:type:: reducer
+
+      The self type.
+
+   .. cpp:type:: value_type
+
+      The reduction scalar type (specialization of `ValLocScalar <ValLocScalar.html>`_)
+
+   .. cpp:type:: result_view_type
+
+      A ``Kokkos::View`` referencing the reduction result
+
+   .. rubric:: Constructors
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION MinFirstLoc(value_type& value_);
+
+      Constructs a reducer which references a local variable as its result location.
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION MinFirstLoc(const result_view_type& value_);
+
+      Constructs a reducer which references a specific view as its result location.
+
+   .. rubric:: Public Member Functions
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION void join(value_type& dest, const value_type& src) const;
+
+      Store minimum with the first index of ``src`` and ``dest`` into ``dest``:  ``dest = (src.val < dest.val) ? src :dest;``.
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION void init(value_type& val) const;
+
+      Initialize ``val.val`` using the ``Kokkos::reduction_identity<Scalar>::min()`` method. The default implementation sets ``val=<TYPE>_MAX``.
+      Initialize ``val.loc`` using the ``Kokkos::reduction_identity<Index>::min()`` method. The default implementation sets ``val=<TYPE>_MAX``.
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION value_type& reference() const;
+
+      Returns a reference to the result provided in class constructor.
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION result_view_type view() const;
+
+      Returns a view of the result place provided in class constructor.
+
+Additional Information
+^^^^^^^^^^^^^^^^^^^^^^
+
+* ``MinFirstLoc<T,I,S>::value_type`` is Specialization of ValLocScalar on non-const ``T`` and non-const ``I``
+
+* ``MinFirstLoc<T,I,S>::result_view_type`` is ``Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>``. Note that the S (memory space) must be the same as the space where the result resides.
+
+* Requires: ``Scalar`` has ``operator =`` and ``operator <`` defined. ``Kokkos::reduction_identity<Scalar>::min()`` is a valid expression.
+
+* Requires: ``Index`` has ``operator =`` defined. ``Kokkos::reduction_identity<Index>::min()`` is a valid expression.
+
+* In order to use MinFirstLoc with a custom type of either ``Scalar`` or ``Index``, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined. See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details
+
+Example
+-------
+
+.. code-block:: cpp
+
+  #include <Kokkos_Core.hpp>
+  struct Idx3D_t {
+    int value[3];
+    int& operator[](int i) { return value[i]; }
+    const int& operator[](int i) const { return value[i]; }
+  };
+  template <>
+  struct Kokkos::reduction_identity<Idx3D_t> {
+    static constexpr Idx3D_t min() { return {0, 0, 0}; }
+  };
+  int main(int argc, char* argv[]) {
+    Kokkos::initialize(argc, argv);
+    {
+      Kokkos::View<double***> a("A", 5, 5, 5);
+      Kokkos::deep_copy(a, 10);
+      a(2, 3, 1)        = 5;
+      using MinFirstLoc_t    = Kokkos::MinFirstLoc<double, Idx3D_t>;
+      using MinFirstLocVal_t = typename MinFirstLoc_t::value_type;
+      MinFirstLocVal_t result;
+      Kokkos::parallel_reduce(
+          Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {5, 5, 5}),
+          KOKKOS_LAMBDA(int i, int j, int k, MinFirstLocVal_t& val) {
+            if (a(i, j, k) < val.val) {
+              val.val    = a(i, j, k);
+              val.loc[0] = i;
+              val.loc[1] = j;
+              val.loc[2] = k;
+            }
+          },
+          MinFirstLoc_t(result));
+      printf("%lf %i %i %i\n", result.val, result.loc[0], result.loc[1],
+             result.loc[2]);
+    }
+    Kokkos::finalize();
+  }

--- a/docs/source/API/core/builtinreducers/MinFirstLoc.rst
+++ b/docs/source/API/core/builtinreducers/MinFirstLoc.rst
@@ -4,7 +4,7 @@
 .. role:: cpp(code)
     :language: cpp
 
-Specific implementation of `ReducerConcept <ReducerConcept.html>`_ storing the minimum value with an index
+Specific implementation of `ReducerConcept <ReducerConcept.html>`_ storing the minimum value and the first index satisfying a condition.
 
 Header File: ``<Kokkos_Core.hpp>``
 
@@ -26,7 +26,7 @@ Synopsis
      public:
        using reducer = MinFirstLoc;
        using value_type = ValLocScalar<typename std::remove_cv<Scalar>::type,
-                               typename std::remove_cv<Index>::type >;
+                               typename std::remove_cv<Index>::type>;
        using result_view_type = Kokkos::View<value_type, Space>;
 
        KOKKOS_INLINE_FUNCTION
@@ -90,16 +90,14 @@ Interface
 
    .. cpp:function:: KOKKOS_INLINE_FUNCTION value_type& reference() const;
 
-      Returns a reference to the result provided in class constructor.
+      Returns a reference to the result provided in the class constructor.
 
    .. cpp:function:: KOKKOS_INLINE_FUNCTION result_view_type view() const;
 
-      Returns a view of the result place provided in class constructor.
+      Returns a view of the result provided in the class constructor.
 
 Additional Information
 ^^^^^^^^^^^^^^^^^^^^^^
-
-* ``MinFirstLoc<T,I,S>::value_type`` is Specialization of ValLocScalar on non-const ``T`` and non-const ``I``
 
 * ``MinFirstLoc<T,I,S>::result_view_type`` is ``Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>``. Note that the S (memory space) must be the same as the space where the result resides.
 

--- a/docs/source/API/core/builtinreducers/MinMaxFirstLastLoc.rst
+++ b/docs/source/API/core/builtinreducers/MinMaxFirstLastLoc.rst
@@ -4,7 +4,7 @@
 .. role:: cpp(code)
     :language: cpp
 
-Specific implementation of `ReducerConcept <ReducerConcept.html>`_ storing both the minimum and maximum values with corresponding indices
+Specific implementation of `ReducerConcept <ReducerConcept.html>`_ storing both the minimum and maximum values with corresponding first and last indices
 
 Header File: ``<Kokkos_Core.hpp>``
 
@@ -114,4 +114,4 @@ Additional Information
 
 * Requires: ``Index`` has ``operator =`` defined. ``Kokkos::reduction_identity<Index>::min()`` is a valid expressions.
 
-* In order to use MinMaxFirstLastLoc with a custom type of either ``Scalar`` or ``Index``, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined. See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details.
+* In order to use ``MinMaxFirstLastLoc`` with a custom type of either ``Scalar`` or ``Index``, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined. See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details.

--- a/docs/source/API/core/builtinreducers/MinMaxFirstLastLoc.rst
+++ b/docs/source/API/core/builtinreducers/MinMaxFirstLastLoc.rst
@@ -1,0 +1,117 @@
+``MinMaxFirstLastLoc``
+======================
+
+.. role:: cpp(code)
+    :language: cpp
+
+Specific implementation of `ReducerConcept <ReducerConcept.html>`_ storing both the minimum and maximum values with corresponding indices
+
+Header File: ``<Kokkos_Core.hpp>``
+
+Usage
+-----
+
+.. code-block:: cpp
+
+   MinMaxFirstLastLoc<T,I,S>::value_type result;
+   parallel_reduce(N,Functor,MinMaxFirstLastLoc<T,I,S>(result));
+
+Synopsis
+--------
+
+.. code-block:: cpp
+
+   template<class Scalar, class Index, class Space>
+   class MinMaxFirstLastLoc {
+     public:
+       using reducer = MinMaxFirstLastLoc;
+       using value_type = MinMaxFirstLastLocScalar<typename std::remove_cv<Scalar>::type,
+                                        typename std::remove_cv<Index>::type>;
+
+       using result_view_type = Kokkos::View<value_type, Space>;
+
+       KOKKOS_INLINE_FUNCTION
+       void join(value_type& dest, const value_type& src) const;
+
+       KOKKOS_INLINE_FUNCTION
+       void init(value_type& val) const;
+
+       KOKKOS_INLINE_FUNCTION
+       value_type& reference() const;
+
+       KOKKOS_INLINE_FUNCTION
+       result_view_type view() const;
+
+       KOKKOS_INLINE_FUNCTION
+       MinMaxFirstLastLoc(value_type& value_);
+
+       KOKKOS_INLINE_FUNCTION
+       MinMaxFirstLastLoc(const result_view_type& value_);
+   };
+
+Interface
+---------
+
+.. cpp:class:: template<class Scalar, class Index, class Space> MinMaxFirstLastLoc
+
+   .. rubric:: Public Types
+
+   .. cpp:type:: reducer
+
+      The self type
+
+   .. cpp:type:: value_type
+
+      The reduction scalar type (specialization of `MinMaxLocScalar <MinMaxLocScalar.html>`_)
+
+   .. cpp:type:: result_view_type
+
+      A ``Kokkos::View`` referencing the reduction result
+
+   .. rubric:: Constructors
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION MinMaxFirstLastLoc(value_type& value_);
+
+      Constructs a reducer which references a local variable as its result location.
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION MinMaxFirstLastLoc(const result_view_type& value_);
+
+      Constructs a reducer which references a specific view as its result location.
+
+   .. rubric:: Public Member Functions
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION void join(value_type& dest, const value_type& src) const;
+
+      Store minimum with the first location of ``src`` and ``dest`` into ``dest``.
+      Store maximum with the last location of ``src`` and ``dest`` into ``dest``.
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION void init( value_type& val) const;
+
+      Initialize ``val.min_val`` using the ``Kokkos::reduction_identity<Scalar>::min()`` method. The default implementation sets ``val=<TYPE>_MAX``.
+
+      Initialize ``val.max_val`` using the ``Kokkos::reduction_identity<Index>::max()`` method. The default implementation sets ``val=<TYPE>_MIN``.
+
+      Initialize ``val.min_loc`` using the ``Kokkos::reduction_identity<Scalar>::min()`` method. The default implementation sets ``val=<TYPE>_MAX``.
+
+      Initialize ``val.max_loc`` using the ``Kokkos::reduction_identity<Index>::max()`` method. The default implementation sets ``val=<TYPE>_MAX``.
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION value_type& reference() const;
+
+      Returns a reference to the result provided in class constructor.
+
+   .. cpp:function:: KOKKOS_INLINE_FUNCTION result_view_type view() const;
+
+      Returns a view of the result place provided in class constructor.
+
+Additional Information
+^^^^^^^^^^^^^^^^^^^^^^
+
+* ``MinMaxFirstLastLoc<T,I,S>::value_type`` is Specialization of MinMaxFirstLastLocScalar on non-const ``T`` and non-const ``I``
+
+* ``MinMaxFirstLastLoc<T,I,S>::result_view_type`` is ``Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>``. Note that the S (memory space) must be the same as the space where the result resides.
+
+* Requires: ``Scalar`` has ``operator =``, ``operator <`` and ``operator >`` defined. ``Kokkos::reduction_identity<Scalar>::min()`` and ``Kokkos::reduction_identity<Scalar>::max()`` are a valid expressions.
+
+* Requires: ``Index`` has ``operator =`` defined. ``Kokkos::reduction_identity<Index>::min()`` is a valid expressions.
+
+* In order to use MinMaxFirstLastLoc with a custom type of either ``Scalar`` or ``Index``, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined. See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details.

--- a/docs/source/API/core/builtinreducers/MinMaxFirstLastLoc.rst
+++ b/docs/source/API/core/builtinreducers/MinMaxFirstLastLoc.rst
@@ -97,16 +97,14 @@ Interface
 
    .. cpp:function:: KOKKOS_INLINE_FUNCTION value_type& reference() const;
 
-      Returns a reference to the result provided in class constructor.
+      Returns a reference to the result provided in the class constructor.
 
    .. cpp:function:: KOKKOS_INLINE_FUNCTION result_view_type view() const;
 
-      Returns a view of the result place provided in class constructor.
+      Returns a view of the result provided in the class constructor.
 
 Additional Information
 ^^^^^^^^^^^^^^^^^^^^^^
-
-* ``MinMaxFirstLastLoc<T,I,S>::value_type`` is Specialization of MinMaxFirstLastLocScalar on non-const ``T`` and non-const ``I``
 
 * ``MinMaxFirstLastLoc<T,I,S>::result_view_type`` is ``Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>``. Note that the S (memory space) must be the same as the space where the result resides.
 

--- a/docs/source/API/core/builtinreducers/ReductionScalarTypes.rst
+++ b/docs/source/API/core/builtinreducers/ReductionScalarTypes.rst
@@ -8,6 +8,12 @@ Reduction Scalar Types
    * - Class template
      - Description
      - Builtin Reducer
+   * - :doc:`FirstLocScalar`
+     - stores the first location that satisfies a condition
+     - :cpp:class:`FirstLoc`
+   * - :doc:`LastLocScalar`
+     - stores the last location that satisfies a condition
+     - :cpp:class:`LastLoc`
    * - :doc:`MinMaxLocScalar`
      - stores a minimum, a maximum, and their respective locations
      - :cpp:class:`MinMaxLoc`
@@ -22,6 +28,8 @@ Reduction Scalar Types
    :hidden:
    :maxdepth: 1
 
+   FirstLocScalar
+   LastLocScalar
    MinMaxLocScalar
    MinMaxScalar
    ValLocScalar

--- a/docs/source/ProgrammingGuide/HierarchicalParallelism.md
+++ b/docs/source/ProgrammingGuide/HierarchicalParallelism.md
@@ -265,7 +265,7 @@ parallel_for (TeamPolicy<> (league_size, team_size),
       }, Kokkos::Experimental::Prod<Scalar>(product);
   });
 ```
-Note that custom reductions must employ one of the functor join patterns recognized by Kokkos; these include `Sum, Prod, Min, Max, LAnd, LOr, BAnd, BOr, ValLocScalar, MinLoc, MaxLoc, MinMaxScalar, MinMax, MinMaxLocScalar` and `MinMaxLoc`.
+Note that custom reductions must employ one of the functor join patterns recognized by Kokkos; these include `Sum, Prod, Min, Max, LAnd, LOr, BAnd, BOr, ValLocScalar, MinLoc, MaxLoc, MinMaxScalar, MinMax, MinMaxLocScalar, MinMaxLoc, FirstLoc, FirstLocScalar, LastLoc, LastLocScalar, MinFirstLoc, MaxFirstLoc` and `MinMaxFirstLastLoc`.
 
 The third pattern is [`parallel_scan()`](../API/core/parallel-dispatch/parallel_scan) which can be used to perform prefix scans.
 


### PR DESCRIPTION
- [x] Adding `FirstLoc`, `LastLoc`, `MaxFirstLoc`, `MinFirstLoc`, `MinMaxFirstLastLoc`
- [x] Updating reducer table

There are still more undocumented reducers `MaxFirstLocCustomComparator `, `MinFirstLocCustomComparator `, `MinMaxFirstLastLocCustomComparator `, `StdIsPartitioned`, and `StdPartitionPoint`.