### PR TITLE
Refactor BAnd/Bor reducers

### DIFF
--- a/docs/source/API/core/builtinreducers/BAnd.rst
+++ b/docs/source/API/core/builtinreducers/BAnd.rst
@@ -14,7 +14,7 @@ Usage
 .. code-block:: cpp
 
     T result;
-    parallel_reduce(N,Functor,BAnd<T,S>(result));
+    parallel_reduce(N, Functor, BAnd<T, S>(result));
 
 Synopsis
 --------
@@ -22,33 +22,26 @@ Synopsis
 .. code-block:: cpp
 
     template<class Scalar, class Space>
-    class BAnd{
-        public:
-            typedef BAnd reducer;
-            typedef typename std::remove_cv<Scalar>::type value_type;
-            typedef Kokkos::View<value_type, Space> result_view_type;
+    class BAnd {
+      public:
+        using reducer = BAnd<Scalar, Space>;
+        using value_type = typename std::remove_cv<Scalar>::type;
 
-            KOKKOS_INLINE_FUNCTION
-            void join(value_type& dest, const value_type& src) const;
+        KOKKOS_INLINE_FUNCTION
+        void join(value_type& dest, const value_type& src) const {
+          dest = dest & src;
+        }
 
-            KOKKOS_INLINE_FUNCTION
-            void init(value_type& val) const;
-
-            KOKKOS_INLINE_FUNCTION
-            value_type& reference() const;
-
-            KOKKOS_INLINE_FUNCTION
-            result_view_type view() const;
-
-            KOKKOS_INLINE_FUNCTION
-            BAnd(value_type& value_);
-
-            KOKKOS_INLINE_FUNCTION
-            BAnd(const result_view_type& value_);
+        KOKKOS_INLINE_FUNCTION
+        void init(value_type& val) const {
+          val = Kokkos::reduction_identity<value_type>::band();
+        }
     };
 
 Interface
 ---------
+
+All the public types, constructors and methods from `ReducerConcept <ReducerConcept.html>`_ are available. The following types and methods are overridden by this reducer:
 
 .. cpp:class:: template<class Scalar, class Space> BAnd
 
@@ -56,52 +49,26 @@ Interface
 
    .. cpp:type:: reducer
 
-      The self type
+      The self type.
 
    .. cpp:type:: value_type
 
-      The reduction scalar type.
-
-   .. cpp:type:: result_view_type
-
-      A ``Kokkos::View`` referencing the reduction result
-
-   .. rubric:: Constructors
-
-   .. cpp:function:: KOKKOS_INLINE_FUNCTION BAnd(value_type& value_);
-
-      Constructs a reducer which references a local variable as its result location.
-
-   .. cpp:function:: KOKKOS_INLINE_FUNCTION BAnd(const result_view_type& value_);
-
-      Constructs a reducer which references a specific view as its result location.
+      The non-const version of the ``Scalar`` template parameter.      
 
    .. rubric:: Public Member Functions
 
    .. cpp:function:: KOKKOS_INLINE_FUNCTION void join(value_type& dest, const value_type& src) const;
 
-      Store bitwise ``and`` of ``src`` and ``dest`` into ``dest``:  ``dest = src & dest;``.
+      Store bitwise ``and`` of ``src`` and ``dest`` into ``dest``:  ``dest = src & dest``.
 
    .. cpp:function:: KOKKOS_INLINE_FUNCTION void init(value_type& val) const;
 
-      Initialize ``val`` using the ``Kokkos::reduction_identity<Scalar>::land()`` method. The default implementation sets ``val=~(0)``.
-
-   .. cpp:function:: KOKKOS_INLINE_FUNCTION value_type& reference() const;
-
-      Returns a reference to the result provided in class constructor.
-
-   .. cpp:function:: KOKKOS_INLINE_FUNCTION result_view_type view() const;
-
-      Returns a view of the result place provided in class constructor.
+      Initialize ``val`` using the ``Kokkos::reduction_identity<value_type>::band()`` method. The default implementation sets ``val=~(0x0)``.
 
 
 Additional Information
 ~~~~~~~~~~~~~~~~~~~~~~
 
-* ``BAnd<T,S>::value_type`` is non-const ``T``
+* Requires: ``Scalar`` has ``operator =`` and ``operator &`` defined. ``Kokkos::reduction_identity<value_type>::band()`` is a valid expression.
 
-* ``BAnd<T,S>::result_view_type`` is ``Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>``. Note that the S (memory space) must be the same as the space where the result resides.
-
-* Requires: ``Scalar`` has ``operator =`` and ``operator &`` defined. ``Kokkos::reduction_identity<Scalar>::band()`` is a valid expression.
-
-* In order to use BAnd with a custom type, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined. See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details
+* In order to use ``BAnd`` with a custom type, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined. See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details

--- a/docs/source/API/core/builtinreducers/BAnd.rst
+++ b/docs/source/API/core/builtinreducers/BAnd.rst
@@ -53,7 +53,7 @@ All the public types, constructors and methods from `ReducerConcept <ReducerConc
 
    .. cpp:type:: value_type
 
-      The non-const version of the ``Scalar`` template parameter.      
+      The ``Scalar`` template parameter stripped of its potential const qualifier.
 
    .. rubric:: Public Member Functions
 

--- a/docs/source/API/core/builtinreducers/BAnd.rst
+++ b/docs/source/API/core/builtinreducers/BAnd.rst
@@ -36,6 +36,8 @@ Synopsis
         void init(value_type& val) const {
           val = Kokkos::reduction_identity<value_type>::band();
         }
+
+        // other members to fulfill the ReducerConcept
     };
 
 Interface
@@ -53,7 +55,7 @@ All the public types, constructors and methods from `ReducerConcept <ReducerConc
 
    .. cpp:type:: value_type
 
-      The ``Scalar`` template parameter stripped of its potential const qualifier.
+      The ``Scalar`` template parameter stripped of its potential ``const`` and/or ``volatile`` qualifier.
 
    .. rubric:: Public Member Functions
 
@@ -69,6 +71,6 @@ All the public types, constructors and methods from `ReducerConcept <ReducerConc
 Additional Information
 ~~~~~~~~~~~~~~~~~~~~~~
 
-* Requires: ``Scalar`` has ``operator =`` and ``operator &`` defined. ``Kokkos::reduction_identity<value_type>::band()`` is a valid expression.
+* Requires: ``value_type`` has ``operator =`` and ``operator &`` defined. ``Kokkos::reduction_identity<value_type>::band()`` is a valid expression.
 
 * In order to use ``BAnd`` with a custom type, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined. See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details

--- a/docs/source/API/core/builtinreducers/BOr.rst
+++ b/docs/source/API/core/builtinreducers/BOr.rst
@@ -53,7 +53,7 @@ All the public types, constructors and methods from `ReducerConcept <ReducerConc
 
    .. cpp:type:: value_type
 
-      The non-const version of the ``Scalar`` template parameter.      
+      The ``Scalar`` template parameter stripped of its potential const qualifier.
 
    .. rubric:: Public Member Functions
 

--- a/docs/source/API/core/builtinreducers/BOr.rst
+++ b/docs/source/API/core/builtinreducers/BOr.rst
@@ -36,6 +36,8 @@ Synopsis
        void init(value_type& val) const {
          val = Kokkos::reduction_identity<value_type>::bor();
        }
+
+       // other members to fulfill the ReducerConcept
    };
 
 Interface
@@ -53,7 +55,7 @@ All the public types, constructors and methods from `ReducerConcept <ReducerConc
 
    .. cpp:type:: value_type
 
-      The ``Scalar`` template parameter stripped of its potential const qualifier.
+      The ``Scalar`` template parameter stripped of its potential ``const`` and/or ``volatile`` qualifier.
 
    .. rubric:: Public Member Functions
 
@@ -68,6 +70,6 @@ All the public types, constructors and methods from `ReducerConcept <ReducerConc
 Additional Information
 ^^^^^^^^^^^^^^^^^^^^^^
 
-* Requires: ``Scalar`` has ``operator =`` and ``operator |`` defined. ``Kokkos::reduction_identity<value_type>::bor()`` is a valid expression.
+* Requires: ``value_type`` has ``operator =`` and ``operator |`` defined. ``Kokkos::reduction_identity<value_type>::bor()`` is a valid expression.
 
 * In order to use ``BOr`` with a custom type, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined. See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details

--- a/docs/source/API/core/builtinreducers/BOr.rst
+++ b/docs/source/API/core/builtinreducers/BOr.rst
@@ -14,7 +14,7 @@ Usage
 .. code-block:: cpp
 
    T result;
-   parallel_reduce(N,Functor,BOr<T,S>(result));
+   parallel_reduce(N, Functor, BOr<T, S>(result));
 
 Synopsis
 --------
@@ -22,33 +22,26 @@ Synopsis
 .. code-block:: cpp
 
    template<class Scalar, class Space>
-   class BOr{
+   class BOr {
      public:
-       typedef BOr reducer;
-       typedef typename std::remove_cv<Scalar>::type value_type;
-       typedef Kokkos::View<value_type, Space> result_view_type;
+       using reducer = BOr<Scalar, Space>;
+       using value_type = typename std::remove_cv<Scalar>::type;
 
        KOKKOS_INLINE_FUNCTION
-       void join(value_type& dest, const value_type& src) const;
+       void join(value_type& dest, const value_type& src) const {
+         dest = dest | src;
+       }
 
        KOKKOS_INLINE_FUNCTION
-       void init(value_type& val) const;
-
-       KOKKOS_INLINE_FUNCTION
-       value_type& reference() const;
-
-       KOKKOS_INLINE_FUNCTION
-       result_view_type view() const;
-
-       KOKKOS_INLINE_FUNCTION
-       BOr(value_type& value_);
-
-       KOKKOS_INLINE_FUNCTION
-       BOr(const result_view_type& value_);
+       void init(value_type& val) const {
+         val = Kokkos::reduction_identity<value_type>::bor();
+       }
    };
 
 Interface
 ---------
+
+All the public types, constructors and methods from `ReducerConcept <ReducerConcept.html>`_ are available. The following types and methods are overridden by this reducer:
 
 .. cpp:class:: template<class Scalar, class Space> BOr
 
@@ -56,51 +49,25 @@ Interface
 
    .. cpp:type:: reducer
 
-      The self type
+      The self type.
 
    .. cpp:type:: value_type
 
-      The reduction scalar type.
-
-   .. cpp:type:: result_view_type
-
-      A ``Kokkos::View`` referencing the reduction result
-
-   .. rubric:: Constructors
-
-   .. cpp:function:: KOKKOS_INLINE_FUNCTION BOr(value_type& value_);
-
-      Constructs a reducer which references a local variable as its result location.
-
-   .. cpp:function:: KOKKOS_INLINE_FUNCTION BOr(const result_view_type& value_);
-
-      Constructs a reducer which references a specific view as its result location.
+      The non-const version of the ``Scalar`` template parameter.      
 
    .. rubric:: Public Member Functions
 
    .. cpp:function:: KOKKOS_INLINE_FUNCTION void join(value_type& dest, const value_type& src) const;
 
-      Store logical ``or`` of ``src`` and ``dest`` into ``dest``:  ``dest = src | dest;``.
+      Store logical ``or`` of ``src`` and ``dest`` into ``dest``:  ``dest = src | dest``.
 
    .. cpp:function:: KOKKOS_INLINE_FUNCTION void init(value_type& val) const;
 
-      Initialize ``val`` using the ``Kokkos::reduction_identity<Scalar>::land()`` method. The default implementation sets ``val=0``.
-
-   .. cpp:function:: KOKKOS_INLINE_FUNCTION value_type& reference() const;
-
-      Returns a reference to the result provided in class constructor.
-
-   .. cpp:function:: KOKKOS_INLINE_FUNCTION result_view_type view() const;
-
-      Returns a view of the result place provided in class constructor.
+      Initialize ``val`` using the ``Kokkos::reduction_identity<value_type>::bor()`` method. The default implementation sets ``val=0x0``.
 
 Additional Information
 ^^^^^^^^^^^^^^^^^^^^^^
 
-* ``BOr<T,S>::value_type`` is non-const ``T``
+* Requires: ``Scalar`` has ``operator =`` and ``operator |`` defined. ``Kokkos::reduction_identity<value_type>::bor()`` is a valid expression.
 
-* ``BOr<T,S>::result_view_type`` is ``Kokkos::View<T,S,Kokkos::MemoryTraits<Kokkos::Unmanaged>>``. Note that the S (memory space) must be the same as the space where the result resides.
-
-* Requires: ``Scalar`` has ``operator =`` and ``operator |`` defined. ``Kokkos::reduction_identity<Scalar>::bor()`` is a valid expression.
-
-* In order to use BOr with a custom type, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined. See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details
+* In order to use ``BOr`` with a custom type, a template specialization of ``Kokkos::reduction_identity<CustomType>`` must be defined. See `Built-In Reducers with Custom Scalar Types <../../../ProgrammingGuide/Custom-Reductions-Built-In-Reducers-with-Custom-Scalar-Types.html>`_ for details

--- a/docs/source/API/core/builtinreducers/ReductionScalarTypes.rst
+++ b/docs/source/API/core/builtinreducers/ReductionScalarTypes.rst
@@ -1,6 +1,8 @@
 Reduction Scalar Types
 ######################
 
+Types designed to hold the result of ``parallel_reduce()``, while using the corresponding builtin reducers.
+
 .. list-table::
    :widths: 20 65 15
    :header-rows: 1


### PR DESCRIPTION
As discussed in #871, we refactor reducer docs starting from BAnd/Bor.

- [x] Fix reduction_identity
- [x] Suppress type def
- [x] Only describe the types and methods overwritten by each reducer 
- [x] Summarize `Reduction Scalar Types` at the top