### PR TITLE
Move iterator functions from algorithms to core

### DIFF
--- a/docs/source/API/algorithms/std-algorithms/Iterators.rst
+++ b/docs/source/API/algorithms/std-algorithms/Iterators.rst
@@ -7,95 +7,25 @@ Iterators
 ``Kokkos::Experimental::{begin, cbegin, end, cend}``
 ----------------------------------------------------
 
-Header File: ``<Kokkos_StdAlgorithms.hpp>``
+Header File: ``<Kokkos_StdAlgorithms.hpp>`` (until Kokkos 5.2), ``<Kokkos_Core.hpp>`` (since Kokkos 5.2)
 
-
-.. cpp:function:: template <class DataType, class... Properties> KOKKOS_INLINE_FUNCTION auto begin(const Kokkos::View<DataType, Properties...>& view);
-
-   Returns a Kokkos **random access** iterator to the beginning of ``view``
-
-.. cpp:function:: template <class DataType, class... Properties> KOKKOS_INLINE_FUNCTION auto cbegin(const Kokkos::View<DataType, Properties...>& view);
-
-   Returns a Kokkos const-qualified **random access** iterator to the beginning of ``view``
-
-.. cpp:function:: template <class DataType, class... Properties> KOKKOS_INLINE_FUNCTION auto end(const Kokkos::View<DataType, Properties...>& view);
-
-   Returns a Kokkos **random access** iterator to the element past the end of ``view``
-
-.. cpp:function:: template <class DataType, class... Properties> KOKKOS_INLINE_FUNCTION auto cend(const Kokkos::View<DataType, Properties...>& view);
-
-   Returns a const-qualified Kokkos **random access** iterator to the element past the end of ``view``
-
-Notes
-~~~~~
-
-* the returned iterator is a **random access** for performance reasons
-
-* ``view`` is taken as ``const`` because, within each function, we are not changing the view itself: the returned iterator operates on the view without changing its structure.
-
-* dereferencing an iterator must be done within an execution space where ``view`` is accessible
-
-Parameters and Requirements
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-* ``view``: must be a rank-1 view with ``LayoutLeft``, ``LayoutRight``, or ``LayoutStride``
-
-Example
-~~~~~~~
-
-.. code-block:: cpp
-
-    namespace KE = Kokkos::Experimental;
-    using view_type = Kokkos::View<int*>;
-    view_type a("a", 15);
-
-    auto it = KE::begin(a);
-    // if dereferenced (within a proper execution space), can modify the content of `a`
-
-    auto itc = KE::cbegin(a);
-    // if dereferenced (within a proper execution space), can only read the content of `a`
+See `Iterators (Core) <../../core/view/iterators.html>`__.
 
 ------------------
 
 ``Kokkos::Experimental::distance``
 ----------------------------------
 
-.. cpp:function:: template <class IteratorType> KOKKOS_INLINE_FUNCTION constexpr typename IteratorType::difference_type distance(IteratorType first, IteratorType last);
+Header File: ``<Kokkos_StdAlgorithms.hpp>`` (until Kokkos 5.2), ``<Kokkos_Core.hpp>`` (since Kokkos 5.2)
 
-   Returns the number of steps needed to go from ``first`` to ``last``.
-
-Parameters and Requirements
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-* ``first, last``: range to calculate the distance of
-
-Return
-~~~~~~
-
-The number of steps needed to go from ``first`` to ``last``.
-The value may be negative if random-access iterators are used.
-
-
-Example
-~~~~~~~
-
-.. code-block:: cpp
-
-    namespace KE = Kokkos::Experimental;
-    Kokkos::View<double*> a("a", 13);
-
-    auto it1 = KE::begin(a);
-    auto it2 = it1 + 4;
-    const auto stepsA = KE::distance(it1, it2);
-    // stepsA should be equal to 4
-
-    const auto stepsB = KE::distance(it2, it1);
-    // stepsB should be equal to -4
+See `Iterators (Core) <../../core/view/iterators.html>`__.
 
 ------------------
 
 ``Kokkos::Experimental::iter_swap``
 -----------------------------------
+
+Header File: ``<Kokkos_StdAlgorithms.hpp>``
 
 .. cpp:function:: template <class IteratorType> void iter_swap(IteratorType first, IteratorType last);
 

--- a/docs/source/API/core/View.rst
+++ b/docs/source/API/core/View.rst
@@ -34,6 +34,8 @@ The following facilities are available:
      - Create View allocation parameter bundle from argument list.
    * - `View-like Types <view/view_like.html>`__
      - Loosely defined as the set of class templates that behave like ``Kokkos::View``.
+   * - `Iterators <view/iterators.html>`__
+     - Helper functions to work with iterators on ``Kokkos::View``
 
 .. toctree::
    :hidden:
@@ -52,3 +54,4 @@ The following facilities are available:
    ./view/view
    ./view/view_alloc
    ./view/view_like
+   ./view/iterators

--- a/docs/source/API/core/view/iterators.rst
+++ b/docs/source/API/core/view/iterators.rst
@@ -1,0 +1,95 @@
+Iterators
+=========
+
+.. role:: cpp(code)
+    :language: cpp
+
+``Kokkos::Experimental::{begin, cbegin, end, cend}``
+----------------------------------------------------
+
+Header File: ``<Kokkos_StdAlgorithms.hpp>`` (until Kokkos 5.2), ``<Kokkos_Core.hpp>`` (since Kokkos 5.2)
+
+
+.. cpp:function:: template <class DataType, class... Properties> KOKKOS_INLINE_FUNCTION auto begin(const Kokkos::View<DataType, Properties...>& view);
+
+   Returns a Kokkos **random access** iterator to the beginning of ``view``
+
+.. cpp:function:: template <class DataType, class... Properties> KOKKOS_INLINE_FUNCTION auto cbegin(const Kokkos::View<DataType, Properties...>& view);
+
+   Returns a Kokkos const-qualified **random access** iterator to the beginning of ``view``
+
+.. cpp:function:: template <class DataType, class... Properties> KOKKOS_INLINE_FUNCTION auto end(const Kokkos::View<DataType, Properties...>& view);
+
+   Returns a Kokkos **random access** iterator to the element past the end of ``view``
+
+.. cpp:function:: template <class DataType, class... Properties> KOKKOS_INLINE_FUNCTION auto cend(const Kokkos::View<DataType, Properties...>& view);
+
+   Returns a const-qualified Kokkos **random access** iterator to the element past the end of ``view``
+
+Notes
+~~~~~
+
+* the returned iterator is a **random access** for performance reasons
+
+* ``view`` is taken as ``const`` because, within each function, we are not changing the view itself: the returned iterator operates on the view without changing its structure.
+
+* dereferencing an iterator must be done within an execution space where ``view`` is accessible
+
+Parameters and Requirements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* ``view``: must be a rank-1 view with ``LayoutLeft``, ``LayoutRight``, or ``LayoutStride``
+
+Example
+~~~~~~~
+
+.. code-block:: cpp
+
+    namespace KE = Kokkos::Experimental;
+    using view_type = Kokkos::View<int*>;
+    view_type a("a", 15);
+
+    auto it = KE::begin(a);
+    // if dereferenced (within a proper execution space), can modify the content of `a`
+
+    auto itc = KE::cbegin(a);
+    // if dereferenced (within a proper execution space), can only read the content of `a`
+
+------------------
+
+``Kokkos::Experimental::distance``
+----------------------------------
+
+Header File: ``<Kokkos_StdAlgorithms.hpp>`` (until Kokkos 5.2), ``<Kokkos_Core.hpp>`` (since Kokkos 5.2)
+
+.. cpp:function:: template <class IteratorType> KOKKOS_INLINE_FUNCTION constexpr typename IteratorType::difference_type distance(IteratorType first, IteratorType last);
+
+   Returns the number of steps needed to go from ``first`` to ``last``.
+
+Parameters and Requirements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* ``first, last``: range to calculate the distance of
+
+Return
+~~~~~~
+
+The number of steps needed to go from ``first`` to ``last``.
+The value may be negative if random-access iterators are used.
+
+
+Example
+~~~~~~~
+
+.. code-block:: cpp
+
+    namespace KE = Kokkos::Experimental;
+    Kokkos::View<double*> a("a", 13);
+
+    auto it1 = KE::begin(a);
+    auto it2 = it1 + 4;
+    const auto stepsA = KE::distance(it1, it2);
+    // stepsA should be equal to 4
+
+    const auto stepsB = KE::distance(it2, it1);
+    // stepsB should be equal to -4


### PR DESCRIPTION
Documentation PR for kokkos/kokkos#6684, the documentation for `[c]begin`, `[c]end` and `distance` is moved from `algorithms/std-algorithms/Iterators.rst` to `core/views/Iterators.rst` and a link to the page in `core` is displayed in place of the functions' documentation in the `algorithms` page