### PR TITLE
Document removal of DEPRECATED_CODE_4 option and more

### DIFF
--- a/docs/source/API/containers/DynRankView.rst
+++ b/docs/source/API/containers/DynRankView.rst
@@ -193,6 +193,8 @@ Description
 
       A specialization tag used for partial specialization of the mapping construct underlying a Kokkos ``DynRankView``.
 
+      .. versionremoved:: 5.3
+
    .. rubric:: Constructors
 
    .. cpp:function:: DynRankView()

--- a/docs/source/API/containers/DynRankView.rst
+++ b/docs/source/API/containers/DynRankView.rst
@@ -154,16 +154,16 @@ Description
 
       Compatible view type with the same ``DataType`` and ``LayoutType`` stored in host accessible memory space.
 
-       .. versionadded:: 5.0
+      .. versionadded:: 5.0
 
    .. cpp:type:: HostMirror
 
       Compatible view type with the same ``DataType`` and ``LayoutType`` stored in host accessible memory space.
 
-       .. deprecated:: 5.0
-          Use :cpp:type:`host_mirror_type` instead
+      .. deprecated:: 5.0
+         Use :cpp:type:`host_mirror_type` instead
 
-       .. versionremoved:: 5.3
+      .. versionremoved:: 5.3
 
    .. rubric:: Public Data Handles Typedefs
 

--- a/docs/source/API/containers/DynRankView.rst
+++ b/docs/source/API/containers/DynRankView.rst
@@ -138,7 +138,7 @@ Description
 
    .. cpp:type:: host_mirror_space
 
-      Host accessible memory space used in ``HostMirror``.
+      Host accessible memory space used in ``host_mirror_type``.
 
    .. rubric:: Public View Typedefs
 
@@ -150,9 +150,20 @@ Description
 
       This view type with all template parameters explicitly defined using a ``const`` data type.
 
+   .. cpp:type:: host_mirror_type
+
+      Compatible view type with the same ``DataType`` and ``LayoutType`` stored in host accessible memory space.
+
+       .. versionadded:: 5.0
+
    .. cpp:type:: HostMirror
 
       Compatible view type with the same ``DataType`` and ``LayoutType`` stored in host accessible memory space.
+
+       .. deprecated:: 5.0
+          Use :cpp:type:`host_mirror_type` instead
+
+       .. versionremoved:: 5.3
 
    .. rubric:: Public Data Handles Typedefs
 

--- a/docs/source/API/containers/DynamicView.rst
+++ b/docs/source/API/containers/DynamicView.rst
@@ -50,6 +50,9 @@ Description
         The compatible view type with the same ``DataType`` and ``LayoutType`` stored in host accessible memory space.
 
         .. deprecated:: 5.0
+           Use :cpp:type:`host_mirror_type` instead.
+
+        .. versionremoved:: 5.3
 
     .. rubric:: Public Data Handle Types
 

--- a/docs/source/API/core/view/memoryTraits.rst
+++ b/docs/source/API/core/view/memoryTraits.rst
@@ -107,6 +107,7 @@ The following type aliases are also available in the ``Kokkos`` namespace.
     Note that prior Kokkos versions require an explicit ``0`` template
     argument.
 
+  .. versionremoved:: 5.3
      
 .. cpp:type:: MemoryUnmanaged = MemoryTraits<Unmanaged>;
 .. cpp:type:: MemoryRandomAccess = MemoryTraits<Unmanaged | RandomAccess>;

--- a/docs/source/API/core/view/memoryTraits.rst
+++ b/docs/source/API/core/view/memoryTraits.rst
@@ -108,6 +108,7 @@ The following type aliases are also available in the ``Kokkos`` namespace.
     argument.
 
   .. versionremoved:: 5.3
+
      
 .. cpp:type:: MemoryUnmanaged = MemoryTraits<Unmanaged>;
 .. cpp:type:: MemoryRandomAccess = MemoryTraits<Unmanaged | RandomAccess>;

--- a/docs/source/API/core/view/view.rst
+++ b/docs/source/API/core/view/view.rst
@@ -169,6 +169,9 @@ View Types
    compatible view type with the same :cpp:type:`data_type` and :cpp:type:`array_layout` stored in host accessible memory space.
 
    .. deprecated:: 5.0
+      Use :cpp:type:`host_mirror_type` instead.
+
+   .. versionremoved:: 5.3
 
 Data Handles
 ^^^^^^^^^^^^

--- a/docs/source/API/core/view/view.rst
+++ b/docs/source/API/core/view/view.rst
@@ -210,6 +210,9 @@ Other Types
 
    A specialization tag used for partial specialization of the mapping construct underlying a :cpp:class:`View`.
 
+   .. versionremoved:: 5.3
+
+
 
 Constructors
 ^^^^^^^^^^^^

--- a/docs/source/get-started/configuration-guide.rst
+++ b/docs/source/get-started/configuration-guide.rst
@@ -139,7 +139,7 @@ General options
       * ``OFF``
 
     * * ``Kokkos_ENABLE_DEPRECATED_CODE_4``
-      * Enable deprecated code in the Kokkos 4.x series
+      * Enable deprecated code in the Kokkos 4.x series :red:`[Removed in 5.3]`
       * ``OFF``
 
     * * ``Kokkos_ENABLE_DEPRECATED_CODE_5``


### PR DESCRIPTION
Corresponds to kokkos/kokkos#9386

Note that I did not attempt to document aliases when they were missing.  I am not planning to do it but feel free to push if you want to do it.