### PR TITLE
Document deprecations of Experimental HIP and SYCL symbols

### DIFF
--- a/docs/source/API/core/execution_spaces.rst
+++ b/docs/source/API/core/execution_spaces.rst
@@ -55,6 +55,7 @@ Except in rare instances, it should not be used directly, but instead should be 
 ``Kokkos::HIP`` :sup:`promoted from` |Experimental|_ :sup:`since 4.0` is an |ExecutionSpaceConceptType|_ representing
 execution on a device supported by HIP. Except in rare instances, it should not be used directly,
 but instead should be used generically as an execution space. For details, see |DocExecutionSpaceConcept|_.
+``Kokkos::Experimental::HIP`` was deprecated in the 5.2.0 release.
 
 ``Kokkos::SYCL``
 ------------------------------
@@ -63,6 +64,7 @@ but instead should be used generically as an execution space. For details, see |
 
 If the SYCL backend is enabled and no GPU architecture is specified, Kokkos will use Just-In-Time compilation without any restriction to a particular SYCL device type.
 Thus, this is the only option to target a CPU with the SYCL backend (which is experimental, untested, and not optimized for).
+``Kokkos::Experimental::SYCL`` was deprecated in the 5.2.0 release.
 
 ``Kokkos::HPX``
 ---------------

--- a/docs/source/API/core/execution_spaces.rst
+++ b/docs/source/API/core/execution_spaces.rst
@@ -55,7 +55,7 @@ Except in rare instances, it should not be used directly, but instead should be 
 ``Kokkos::HIP`` :sup:`promoted from` |Experimental|_ :sup:`since 4.0` is an |ExecutionSpaceConceptType|_ representing
 execution on a device supported by HIP. Except in rare instances, it should not be used directly,
 but instead should be used generically as an execution space. For details, see |DocExecutionSpaceConcept|_.
-``Kokkos::Experimental::HIP`` was deprecated in the 5.2.0 release.
+``Kokkos::Experimental::HIP`` was deprecated in the 5.2 release.
 
 ``Kokkos::SYCL``
 ------------------------------
@@ -64,7 +64,7 @@ but instead should be used generically as an execution space. For details, see |
 
 If the SYCL backend is enabled and no GPU architecture is specified, Kokkos will use Just-In-Time compilation without any restriction to a particular SYCL device type.
 Thus, this is the only option to target a CPU with the SYCL backend (which is experimental, untested, and not optimized for).
-``Kokkos::Experimental::SYCL`` was deprecated in the 5.2.0 release.
+``Kokkos::Experimental::SYCL`` was deprecated in the 5.2 release.
 
 ``Kokkos::HPX``
 ---------------

--- a/docs/source/API/core/memory_spaces.rst
+++ b/docs/source/API/core/memory_spaces.rst
@@ -45,31 +45,37 @@ Memory Spaces
 --------------------
 
 ``Kokkos::HIPSpace`` :sup:`promoted from` |Experimental|_ :sup:`since 4.0` is a |MemorySpaceType|_ representing device memory on a GPU in the HIP GPU programming environment.  Except in rare instances, it should not be used directly, but instead should be used generically as a memory space.  For details, see |TheDocumentationOnTheMemorySpaceConcept|_.
+``Kokkos::Experimental::HIPSpace``
 
 ``Kokkos::HIPHostPinnedSpace``
 ------------------------------
 
 ``Kokkos::HIPHostPinnedSpace`` :sup:`promoted from` |Experimental|_ :sup:`since 4.0` is a |MemorySpaceType|_ representing host-side pinned memory accessible from a GPU in the HIP GPU programming environment.  This memory is accessible by both host and device execution spaces.  Except in rare instances, it should not be used directly, but instead should be used generically as a memory space.  For details, see |TheDocumentationOnTheMemorySpaceConcept|_.
+``Kokkos::Experimental::HIPHostPinnedSpace``
 
 ``Kokkos::HIPManagedSpace``
 ---------------------------
 
 ``Kokkos::HIPManagedSpace`` :sup:`promoted from` |Experimental|_ :sup:`since 4.0`  is a |MemorySpaceType|_ representing page-migrating memory on a GPU in the HIP GPU programming environment.  Page-migrating memory is accessible from most host execution spaces. Even though available with all combinations of operating system and HIP-supported hardware, it requires both operating system and hardware to support and enable the ``xnack`` feature. Except in rare instances, it should not be used directly, but instead should be used generically as a memory space.  For details, see |TheDocumentationOnTheMemorySpaceConcept|_.
+``Kokkos::Experimental::HIPManagedSpace`` was deprecated in the 5.2.0 release.
 
 ``Kokkos::SYCLDeviceUSMSpace``
 --------------------------------------------
 
 ``Kokkos::SYCLDeviceUSMSpace`` :sup:`promoted from` |Experimental|_ :sup:`since 4.5` is a |MemorySpaceType|_ representing device memory on a GPU in the SYCL GPU programming environment. This memory is only accessible from the SYCL execution space.
+``Kokkos::Experimental::SYCLDeviceUSMSpace`` was deprecated in the 5.2.0 release.
 
 ``Kokkos::SYCLHostUSMSpace``
 ------------------------------------------
 
 ``Kokkos::SYCLHostUSMSpace`` :sup:`promoted from` |Experimental|_ :sup:`since 4.5` is a |MemorySpaceType|_ representing host-side pinned memory accessible from a GPU in the SYCL GPU programming environment. This memory is accessible from both host and SYCL execution spaces.
+``Kokkos::Experimental::SYCLHostUSMSpace`` was deprecated in the 5.2.0 release.
 
 ``Kokkos::SYCLSharedUSMSpace``
 --------------------------------------------
 
 ``Kokkos::SYCLSharedUSMSpace`` :sup:`promoted from` |Experimental|_ :sup:`since 4.5` is a |MemorySpaceType|_ representing page-migrating memory on a GPU in the SYCL GPU programming environment. This memory is accessible from both host and SYCL execution spaces.
+``Kokkos::Experimental::SYCLSharedUSMSpace`` was deprecated in the 5.2.0 release.
 
 ``Kokkos::HostSpace``
 ---------------------

--- a/docs/source/API/core/memory_spaces.rst
+++ b/docs/source/API/core/memory_spaces.rst
@@ -45,37 +45,37 @@ Memory Spaces
 --------------------
 
 ``Kokkos::HIPSpace`` :sup:`promoted from` |Experimental|_ :sup:`since 4.0` is a |MemorySpaceType|_ representing device memory on a GPU in the HIP GPU programming environment.  Except in rare instances, it should not be used directly, but instead should be used generically as a memory space.  For details, see |TheDocumentationOnTheMemorySpaceConcept|_.
-``Kokkos::Experimental::HIPSpace``
+``Kokkos::Experimental::HIPSpace`` was deprecated in the 5.2 release.
 
 ``Kokkos::HIPHostPinnedSpace``
 ------------------------------
 
 ``Kokkos::HIPHostPinnedSpace`` :sup:`promoted from` |Experimental|_ :sup:`since 4.0` is a |MemorySpaceType|_ representing host-side pinned memory accessible from a GPU in the HIP GPU programming environment.  This memory is accessible by both host and device execution spaces.  Except in rare instances, it should not be used directly, but instead should be used generically as a memory space.  For details, see |TheDocumentationOnTheMemorySpaceConcept|_.
-``Kokkos::Experimental::HIPHostPinnedSpace``
+``Kokkos::Experimental::HIPHostPinnedSpace`` was deprecated in the 5.2 release.
 
 ``Kokkos::HIPManagedSpace``
 ---------------------------
 
 ``Kokkos::HIPManagedSpace`` :sup:`promoted from` |Experimental|_ :sup:`since 4.0`  is a |MemorySpaceType|_ representing page-migrating memory on a GPU in the HIP GPU programming environment.  Page-migrating memory is accessible from most host execution spaces. Even though available with all combinations of operating system and HIP-supported hardware, it requires both operating system and hardware to support and enable the ``xnack`` feature. Except in rare instances, it should not be used directly, but instead should be used generically as a memory space.  For details, see |TheDocumentationOnTheMemorySpaceConcept|_.
-``Kokkos::Experimental::HIPManagedSpace`` was deprecated in the 5.2.0 release.
+``Kokkos::Experimental::HIPManagedSpace`` was deprecated in the 5.2 release.
 
 ``Kokkos::SYCLDeviceUSMSpace``
 --------------------------------------------
 
 ``Kokkos::SYCLDeviceUSMSpace`` :sup:`promoted from` |Experimental|_ :sup:`since 4.5` is a |MemorySpaceType|_ representing device memory on a GPU in the SYCL GPU programming environment. This memory is only accessible from the SYCL execution space.
-``Kokkos::Experimental::SYCLDeviceUSMSpace`` was deprecated in the 5.2.0 release.
+``Kokkos::Experimental::SYCLDeviceUSMSpace`` was deprecated in the 5.2 release.
 
 ``Kokkos::SYCLHostUSMSpace``
 ------------------------------------------
 
 ``Kokkos::SYCLHostUSMSpace`` :sup:`promoted from` |Experimental|_ :sup:`since 4.5` is a |MemorySpaceType|_ representing host-side pinned memory accessible from a GPU in the SYCL GPU programming environment. This memory is accessible from both host and SYCL execution spaces.
-``Kokkos::Experimental::SYCLHostUSMSpace`` was deprecated in the 5.2.0 release.
+``Kokkos::Experimental::SYCLHostUSMSpace`` was deprecated in the 5.2 release.
 
 ``Kokkos::SYCLSharedUSMSpace``
 --------------------------------------------
 
 ``Kokkos::SYCLSharedUSMSpace`` :sup:`promoted from` |Experimental|_ :sup:`since 4.5` is a |MemorySpaceType|_ representing page-migrating memory on a GPU in the SYCL GPU programming environment. This memory is accessible from both host and SYCL execution spaces.
-``Kokkos::Experimental::SYCLSharedUSMSpace`` was deprecated in the 5.2.0 release.
+``Kokkos::Experimental::SYCLSharedUSMSpace`` was deprecated in the 5.2 release.
 
 ``Kokkos::HostSpace``
 ---------------------

--- a/docs/source/deprecations.rst
+++ b/docs/source/deprecations.rst
@@ -4,6 +4,17 @@ Deprecations
 Deprecated in Kokkos 5.x
 ===========================
 
+Deprecated in Kokkos 5.2
+---------------------------
+
+* ``Kokkos::Experimental::HIP``, ``Kokkos::Experimental::HIPSpace``, ``Kokkos::Experimental::HIPHostPinnedSpace``, ``Kokkos::Experimental::HIPManagedSpace``
+   * replacement: ``Kokkos::HIP``, ``Kokkos::HIPSpace``, ``Kokkos::HIPHostPinnedSpace``, ``Kokkos::HIPManagedSpace``
+   * maturing of the HIP backend
+
+* ``Kokkos::Experimental::SYCL``, ``Kokkos::Experimental::SYCLDeviceUSMSpace``, ``Kokkos::Experimental::SYCLHostUSMSpace``, ``Kokkos::Experimental::SYCLSharedUSMSpace``
+   * replacement: ``Kokkos::SYCL``, ``Kokkos::SYCLDeviceUSMSpace``, ``Kokkos::SYCLHostUSMSpace``, ``Kokkos::SYCLSharedUSMSpace``
+   * maturing of the SYCL backend
+
 Deprecated in Kokkos 5.0
 ---------------------------
 


### PR DESCRIPTION
Follow-up to https://github.com/kokkos/kokkos/pull/9232.