### PR TITLE
Improve documentation of abort

### DIFF
--- a/docs/source/API/core/utilities/abort.rst
+++ b/docs/source/API/core/utilities/abort.rst
@@ -45,6 +45,13 @@ Backend-Specific Behavior
    the SYCL backend and ``NDEBUG`` is defined, the function does **not** cause
    abnormal termination. Instead, it prints to the standard output stream and
    continues program execution.
+   See :ref:`Known Issues <known-issues-sycl-abort>`.
+
+.. warning::
+   **NextSilicon Backend:** When calling :cpp:func:`abort` from a parallel
+   region with the NextSilicon backend, the function will cause abnormal
+   program termination but will not print the message if the region has been
+   offloaded to the accelerator.
 
 
 Example

--- a/docs/source/API/core/utilities/abort.rst
+++ b/docs/source/API/core/utilities/abort.rst
@@ -13,7 +13,8 @@ Usage
 
     Kokkos::abort("helpful error message");
 
-Causes abnormal program termination and prints an error message.
+Causes abnormal program termination and prints an error message to the standard
+error stream.
 This function can be called from both host and device code, including within
 parallel kernels.
 
@@ -23,7 +24,8 @@ Interface
 
 .. cpp:function:: KOKKOS_FUNCTION void abort(const char * msg);
 
-   :param msg: Null-terminated string containing the error message to print before termination
+   :param msg: Null-terminated string containing the error message to print
+     before aborting the process.
    :returns: Does not return
 
 

--- a/docs/source/API/core/utilities/abort.rst
+++ b/docs/source/API/core/utilities/abort.rst
@@ -1,22 +1,75 @@
-``Kokkos::abort``
-=================
+``abort``
+=========
 
 .. role:: cpp(code)
     :language: cpp
 
-Defined in header ``<Kokkos_Core.hpp>``
+Defined in header ``<Kokkos_Abort.hpp>``:sup:`since Kokkos 4.2` which is included from ``<Kokkos_Core.hpp>``
+
+Usage 
+-----
 
 .. code-block:: cpp
 
-    KOKKOS_FUNCTION void abort(const char *const msg);
+    Kokkos::abort("helpful error message");
 
-Causes abnormal program termination with error explanatory string being printed.
+Causes abnormal program termination and prints an error message.
+This function can be called from both host and device code, including within
+parallel kernels.
+
+
+Interface
+---------
+
+.. cpp:function:: KOKKOS_FUNCTION void abort(const char * msg);
+
+   :param msg: Null-terminated string containing the error message to print before termination
+   :returns: Does not return
+
 
 Notes
 -----
 
-.. _KokkosAbort: https://github.com/kokkos/kokkos/blob/4.2.00/core/src/Kokkos_Abort.hpp
+Version History
+^^^^^^^^^^^^^^^
+* Available in all Kokkos versions
+* The fine-grained header ``<Kokkos_Abort.hpp>`` was added in version 4.2
 
-.. |KokkosAbort| replace:: ``<Kokkos_Abort.hpp>``
+Backend-Specific Behavior
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* Since version 4.2, one may include |KokkosAbort|_ instead of ``<Kokkos_Core.hpp>``.
+.. warning::
+   **SYCL Backend:** When calling :cpp:func:`abort` from a parallel region with
+   the SYCL backend and ``NDEBUG`` is defined, the function does **not** cause
+   abnormal termination. Instead, it prints to the standard output stream and
+   continues program execution.
+
+
+Example
+-------
+
+.. code-block:: cpp
+
+    KOKKOS_FUNCTION void validate_input(int value) {
+      if (value < 0) {
+        Kokkos::abort("Error: negative value not allowed");
+      }
+    }
+
+    // Can be used in parallel regions
+    Kokkos::parallel_for("check_data", n, KOKKOS_LAMBDA(int i) {
+      if (data(i) > threshold) {
+        Kokkos::abort("Data value exceeds threshold");
+      }
+    });
+
+See also
+--------
+
+.. seealso::
+
+   :doc:`assert`
+      Conditionally aborts if a condition is false; can be disabled in release builds
+   
+   :doc:`printf`
+      Prints formatted output without terminating execution

--- a/docs/source/known-issues.rst
+++ b/docs/source/known-issues.rst
@@ -141,7 +141,7 @@ SYCL
 
 .. _known-issues-sycl-abort:
 
-- Longer explanation here.
+- Longer explanation here explaining limitations with :cpp:func:`abort` in the SYCL backend.
 
 
 Mathematical functions

--- a/docs/source/known-issues.rst
+++ b/docs/source/known-issues.rst
@@ -139,6 +139,10 @@ SYCL
     struct sycl::is_device_copyable<MyComparator>
       : std::true_type {};
 
+.. _known-issues-sycl-abort:
+
+- Longer explanation here.
+
 
 Mathematical functions
 ======================

--- a/docs/source/known-issues.rst
+++ b/docs/source/known-issues.rst
@@ -141,7 +141,11 @@ SYCL
 
 .. _known-issues-sycl-abort:
 
-- Longer explanation here explaining limitations with :cpp:func:`abort` in the SYCL backend.
+- When calling :cpp:func:`abort` from a parallel region with the SYCL backend
+  and ``NDEBUG`` is defined, the function does **not** cause abnormal
+  termination. Instead, it prints to the standard output stream and continues
+  program execution. Note that ``NDEBUG`` is typically defined for ``CMake``'s
+  ``RelWithDebInfo`` and ``Release`` build types, but not for ``Debug``.
 
 
 Mathematical functions


### PR DESCRIPTION
Prompted by a question on Slack

> I think this is implied but not explicitly stated, and I wanted to check: does void Kokkos::abort(const char *const msg) assume that msg is a fixed string, i.e., not a printf-style format string?

I went ahead and modernize the page to use more idiomatic restructured text directives.
I also added an example.