### PR TITLE
Add a note on the deprecated code option in spack

### DIFF
--- a/docs/source/get-started/package-managers.rst
+++ b/docs/source/get-started/package-managers.rst
@@ -90,8 +90,9 @@ To use the installed Kokkos, you can simply load the Kokkos module:
 This will inject the Kokkos environment into your shell session.
 
 .. note::
-   When enabling the `deprecated_code` option in spack, Kokkos will only enable code deprecated in the current major version.
-   E.g. for for 5.2.0 it will enable `Kokkos_ENABLE_DEPRECATED_CODE_5`.
+   Spack's `deprecated_code` variant automatically enables deprecated code for the 
+   installed major version (e.g., `Kokkos_ENABLE_DEPRECATED_CODE_5` for version 5.2.0). 
+   Separate variants for different major versions are not provided.
 
 Packaging your own Kokkos dependent project with Spack
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/docs/source/get-started/package-managers.rst
+++ b/docs/source/get-started/package-managers.rst
@@ -89,6 +89,10 @@ To use the installed Kokkos, you can simply load the Kokkos module:
 
 This will inject the Kokkos environment into your shell session.
 
+.. note::
+   When enabling the `deprecated_code` option in spack, Kokkos will only enable code deprecated in the current major version.
+   E.g. for for 5.2.0 it will enable `Kokkos_ENABLE_DEPRECATED_CODE_5`.
+
 Packaging your own Kokkos dependent project with Spack
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++
 


### PR DESCRIPTION
We discussed in the build and packaging WG that we think this option for now should only enable the code deprecated in the current major version.

This will be a problem when switching to the next major, but we opted for crossing that bridge when we get to Kokkos 6

https://github.com/spack/spack-packages/pull/5035 will need to be updated (@tpadioleau)